### PR TITLE
Fork PHPECC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Pure PHP Elliptic Curve DSA and DH
+# Pure PHP Elliptic Curve DSA and DH
 
 [![Build Status](https://travis-ci.org/phpecc/phpecc.svg?branch=master)](https://travis-ci.org/phpecc/phpecc)
 
@@ -9,6 +9,19 @@
 [![Total Downloads](https://poser.pugx.org/mdanter/ecc/downloads.png)](https://packagist.org/packages/mdanter/ecc)
 [![Latest Unstable Version](https://poser.pugx.org/mdanter/ecc/v/unstable.png)](https://packagist.org/packages/mdanter/ecc)
 [![License](https://poser.pugx.org/mdanter/ecc/license.png)](https://packagist.org/packages/mdanter/ecc)
+
+## Notice
+
+This library is a fork from `phpecc/phpecc`, which is itself a fork of `mdanter/ecc`. 
+It should serve as a drop-in replacement for any applications that previously depended
+on either method. 
+
+However, Paragon Initiative Enterprises **CANNOT** guarantee the security of this library
+until we have fully audited its code. This notice will be removed when we believe it to
+be secure.
+
+In the meantime, **DO NOT** submit bug bounty reports to us for this code. They will be
+closed as out of scope. File an Issue here instead!
 
 ### Information
 
@@ -53,7 +66,7 @@ Support for older PHP versions:
 
 You can install this library via Composer :
 
-`composer require mdanter/ecc:^1.0`
+`composer require paragonie/ecc:^1.0`
 
 ### Contribute
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^7.0||^8.0",
         "ext-gmp": "*",
-        "fgrosse/phpasn1": "^2.0"
+        "genkgo/php-asn1": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0||^8.0||^9.0",


### PR DESCRIPTION
Nobody can get ahold of the phpecc maintainers, so we will fork this library in order to shore up the security of the PHP ecosystem.