### PR TITLE
prevent namespace conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,9 @@
             "role": "Previous Maintainer"
         }
     ],
+    "replace": {
+        "mdanter/ecc": "*"
+    },
     "require": {
         "php": "^7.1||^8.0",
         "paragonie/sodium_compat": "^1|^2",


### PR DESCRIPTION
With this change paragonie/easy-ecc will not be installed at the same time as mdanter/ecc to prevent conflicts with two packages providing the same namespaces.