### PR TITLE
Avoid branch-based timing leak in point addition

### DIFF
--- a/src/Math/ConstantTimeMath.php
+++ b/src/Math/ConstantTimeMath.php
@@ -84,6 +84,21 @@ class ConstantTimeMath extends GmpMath
     }
 
     /**
+     * Returns 1 if two numbers are equal. Returns 0 otherwise.
+     *
+     * @param GMP $first
+     * @param GMP $other
+     * @return int
+     */
+    public function equalsReturnInt(GMP $first, GMP $other): int
+    {
+        $compared = $this->cmp($first, $other);
+        $gt = $compared & 1;
+        $lt = ($compared >> 1) & 1;
+        return (~$compared & ~$gt & ~$lt) & 1;
+    }
+
+    /**
      * {@inheritDoc}
      * @see GmpMathInterface::inverseMod()
      */

--- a/tests/unit/Math/ConstantTimeMathTest.php
+++ b/tests/unit/Math/ConstantTimeMathTest.php
@@ -60,6 +60,21 @@ class ConstantTimeMathTest extends MathTestBase
         $this->assertEquals(-1, $math->cmp($f, $g), "{$f} < {$g}");
     }
 
+    public function testEqualsReturnint()
+    {
+        $math = new ConstantTimeMath();
+        $big    = '01' . bin2hex(random_bytes(16)) . '01';
+        $bigger = '7f' . bin2hex(random_bytes(16)) . '7f';
+        $a = gmp_init($big, 16);
+        $b = gmp_init($bigger, 16);
+
+
+        $this->assertEquals(0, $math->equalsReturnInt($a, $b), "{$a} < {$b} should return 0");
+        $this->assertEquals(1, $math->equalsReturnInt($a, $a), "{$a} == {$a} should return 1");
+        $this->assertEquals(1, $math->equalsReturnInt($b, $b), "{$b} == {$b} should return 1");
+        $this->assertEquals(0, $math->equalsReturnInt($b, $a), "{$b} > {$a} should return 0");
+    }
+
     public function testOrdChr()
     {
         $math = new ConstantTimeMath();


### PR DESCRIPTION
The "point doubling" vs "point at infinity" condition is replaced by a constant-time swap.