### PR TITLE
Cryptographic Hardening (NIST P-256, P-384)

### DIFF
--- a/src/Crypto/Key/PrivateKey.php
+++ b/src/Crypto/Key/PrivateKey.php
@@ -32,6 +32,7 @@ use Mdanter\Ecc\Crypto\EcDH\EcDHInterface;
 use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Primitives\CurveFpInterface;
 use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Primitives\OptimizedCurveInterface;
 use Mdanter\Ecc\Primitives\PointInterface;
 
 /**
@@ -72,6 +73,11 @@ class PrivateKey implements PrivateKeyInterface
      */
     public function getPublicKey(): PublicKeyInterface
     {
+        $curve = $this->generator->getCurve();
+        if ($curve instanceof OptimizedCurveInterface) {
+            $optimized = $curve->getOptimizedCurveOps();
+            return new PublicKey($this->adapter, $this->generator, $optimized->scalarMultBase($this->secretMultiplier));
+        }
         return new PublicKey($this->adapter, $this->generator, $this->generator->mul($this->secretMultiplier));
     }
 

--- a/src/Curves/NistCurve.php
+++ b/src/Curves/NistCurve.php
@@ -5,6 +5,8 @@ namespace Mdanter\Ecc\Curves;
 
 use GMP;
 use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Optimized\P256;
+use Mdanter\Ecc\Optimized\P384;
 use Mdanter\Ecc\Primitives\CurveParameters;
 use Mdanter\Ecc\Primitives\GeneratorPoint;
 use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
@@ -157,6 +159,26 @@ class NistCurve
     }
 
     /**
+     * Returns an NIST P-256 curve.
+     *
+     * @return NamedCurveFp
+     */
+    public function optimizedCurve256(): NamedCurveFp
+    {
+        /** @var GMP $p */
+        $p = gmp_init('115792089210356248762697446949407573530086143415290314195533631308867097853951', 10);
+        /** @var GMP $b */
+        $b = gmp_init('0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b', 16);
+
+        /** @var GMP $minusThree */
+        $minusThree = gmp_init(-3, 10);
+        $parameters = new CurveParameters(256, $p, $minusThree, $b);
+
+        return (new OptimizedCurveFp(self::NAME_P256, $parameters, $this->adapter))
+            ->setOptimizedCurveOps(new P256());
+    }
+
+    /**
      * Returns an NIST P-256 generator.
      *
      * @param  ?RandomNumberGeneratorInterface $randomGenerator
@@ -193,6 +215,21 @@ class NistCurve
         $parameters = new CurveParameters(384, $p, $minus3, $b);
 
         return new NamedCurveFp(self::NAME_P384, $parameters, $this->adapter);
+    }
+
+    public function optimizedCurve384(): NamedCurveFp
+    {
+        /** @var GMP $p */
+        $p = gmp_init('39402006196394479212279040100143613805079739270465446667948293404245721771496870329047266088258938001861606973112319', 10);
+        /** @var GMP $b */
+        $b = gmp_init('0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef', 16);
+
+        /** @var GMP $minus3 */
+        $minus3 = gmp_init(-3, 10);
+        $parameters = new CurveParameters(384, $p, $minus3, $b);
+
+        return (new OptimizedCurveFp(self::NAME_P384, $parameters, $this->adapter))
+            ->setOptimizedCurveOps(new P384());
     }
 
     /**

--- a/src/Curves/NistCurve.php
+++ b/src/Curves/NistCurve.php
@@ -184,9 +184,13 @@ class NistCurve
      * @param  ?RandomNumberGeneratorInterface $randomGenerator
      * @return GeneratorPoint
      */
-    public function generator256(?RandomNumberGeneratorInterface $randomGenerator = null): GeneratorPoint
+    public function generator256(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = false): GeneratorPoint
     {
-        $curve = $this->curve256();
+        if ($optimized) {
+            $curve = $this->optimizedCurve256();
+        } else {
+            $curve = $this->curve256();
+        }
         /** @var GMP $order */
         $order = gmp_init('115792089210356248762697446949407573529996955224135760342422259061068512044369', 10);
 
@@ -238,9 +242,13 @@ class NistCurve
      * @param  ?RandomNumberGeneratorInterface $randomGenerator
      * @return GeneratorPoint
      */
-    public function generator384(?RandomNumberGeneratorInterface $randomGenerator = null): GeneratorPoint
+    public function generator384(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = false): GeneratorPoint
     {
-        $curve = $this->curve384();
+        if ($optimized) {
+            $curve = $this->optimizedCurve384();
+        } else {
+            $curve = $this->curve384();
+        }
         /** @var GMP $order */
         $order = gmp_init('39402006196394479212279040100143613805079739270465446667946905279627659399113263569398956308152294913554433653942643', 10);
 

--- a/src/Curves/OptimizedCurveFp.php
+++ b/src/Curves/OptimizedCurveFp.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Optimized\OptimizedCurveOpsInterface;
+use Mdanter\Ecc\Primitives\OptimizedCurveInterface;
+
+class OptimizedCurveFp extends NamedCurveFp implements OptimizedCurveInterface
+{
+    /**
+     * @var ?OptimizedCurveOpsInterface $optimizedOps
+     */
+    private $optimizedOps;
+
+    public function setOptimizedCurveOps(OptimizedCurveOpsInterface $ops): OptimizedCurveInterface
+    {
+        $this->optimizedOps = $ops;
+        return $this;
+    }
+
+    public function getOptimizedCurveOps(): OptimizedCurveOpsInterface
+    {
+        return $this->optimizedOps;
+    }
+}

--- a/src/Optimized/Common/BarretReductionTrait.php
+++ b/src/Optimized/Common/BarretReductionTrait.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized\Common;
+
+use GMP;
+use Mdanter\Ecc\Math\ConstantTimeMath;
+
+/**
+ * @property GMP p
+ * @property int N
+ */
+trait BarretReductionTrait
+{
+    /**
+     * Barret reduction - reduce an integer x mod p
+     *
+     * @param GMP $product
+     * @return GMP
+     */
+    protected function barrettReduce(GMP $product): GMP
+    {
+        $n2 = static::$N << 1;
+        $t2 = (($product * $this->R) >> $n2) * $this->p;
+        $r = $product - $t2;
+        // Possibly reduced. Let's make sure it's positive
+        $ctMath = new ConstantTimeMath();
+
+        $b = ((gmp_sign($r) >> 1)) & 1;
+        $rPrime = $r + $this->p;
+        $r = $ctMath->select($b, $rPrime, $r);
+
+        // Guaranteed to be reduced after 2 cycles
+        $tmp = 0;
+        for ($i = 0; $i < 2; ++$i) {
+            $rPrime = $r - $this->p;
+            // $b = 1 if $rPrime > 0, which means subtracting is necessary
+            $b = (~(gmp_sign($rPrime) >> 1)) & 1;
+            $r = $ctMath->select($b, $rPrime, $r);
+        }
+        return $r;
+    }
+}

--- a/src/Optimized/Common/BarretReductionTrait.php
+++ b/src/Optimized/Common/BarretReductionTrait.php
@@ -30,7 +30,6 @@ trait BarretReductionTrait
         $r = $ctMath->select($b, $rPrime, $r);
 
         // Guaranteed to be reduced after 2 cycles
-        $tmp = 0;
         for ($i = 0; $i < 2; ++$i) {
             $rPrime = $r - $this->p;
             // $b = 1 if $rPrime > 0, which means subtracting is necessary

--- a/src/Optimized/Common/JacobiPoint.php
+++ b/src/Optimized/Common/JacobiPoint.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized\Common;
+
+use GMP;
+class JacobiPoint
+{
+    /** @var GMP $x */
+    public $x;
+
+    /** @var GMP $y */
+    public $y;
+
+    /** @var GMP $z */
+    public $z;
+
+    public function __debugInfo()
+    {
+        return [
+            'x' => '0x' . gmp_strval($this->x, 16),
+            'y' => '0x' . gmp_strval($this->y, 16),
+            'z' => '0x' . gmp_strval($this->z, 16)
+        ];
+    }
+}

--- a/src/Optimized/Common/JacobiPoint.php
+++ b/src/Optimized/Common/JacobiPoint.php
@@ -14,6 +14,15 @@ class JacobiPoint
     /** @var GMP $z */
     public $z;
 
+    public static function init(GMP $x, GMP $y, GMP $z): self
+    {
+        $self = new self();
+        $self->x = $x;
+        $self->y = $y;
+        $self->z = $z;
+        return $self;
+    }
+
     public function __debugInfo()
     {
         return [

--- a/src/Optimized/Common/ShortWeierstrassTrait.php
+++ b/src/Optimized/Common/ShortWeierstrassTrait.php
@@ -1,0 +1,233 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized\Common;
+
+use GMP;
+
+/**
+ * Point addition and point doubling for short Weierstrass curves of form
+ * y^2 = x^3 - 3x + b
+ *
+ * @property GMP $b
+ * @property GMP $p
+ *
+ * @method JacobiPoint newPoint()
+ * @method GMP addElements(GMP $a, GMP $b)
+ * @method GMP mulElements(GMP $a, GMP $b)
+ * @method GMP subElements(GMP $a, GMP $b)
+ */
+trait ShortWeierstrassTrait
+{
+    /**
+     * https://eprint.iacr.org/2015/1060
+     * Algorithm 4
+     *
+     * @param JacobiPoint $p1
+     * @param JacobiPoint $p2
+     * @return JacobiPoint
+     */
+    public function addInternal(JacobiPoint $p1, JacobiPoint $p2): JacobiPoint
+    {
+        $X1 = $p1->x;
+        $Y1 = $p1->y;
+        $Z1 = $p1->z;
+        $X2 = $p2->x;
+        $Y2 = $p2->y;
+        $Z2 = $p2->z;
+
+        //   1. t0 <- (X1 * X2)
+        $t0 = $this->mulElements($X1, $X2);      // t0 := X1 * X2
+        //   2. t1 <- (Y1 * Y2)
+        $t1 = $this->mulElements($Y1, $Y2);      // t1 := Y1 * Y2
+        //   3. t2 <- (Z1 * Z2)
+        $t2 = $this->mulElements($Z1, $Z2);      // t2 := Z1 * Z2
+        //   4. t3 <- X1 + Y1
+        $t3 = $this->addElements($X1, $Y1);      // t3 := X1 + Y1
+        //   5. t4 <- X2 + Y2
+        $t4 = $this->addElements($X2, $Y2);      // t4 := X2 + Y2
+
+        //   6. t3 <- (t3 * t4)
+        $t3 = $this->mulElements($t3, $t4);      // t3 := t3 * t4
+        //   7. t4 <- t0 + t1
+        $t4 = $this->addElements($t0, $t1);      // t4 := t0 + t1
+        //   8. t3 <- t3 − t4
+        $t3 = $this->subElements($t3, $t4);      // t3 := t3 - t4
+
+        //   9. t4 <- Y1 + Z1
+        $t4 = $this->addElements($Y1, $Z1);      // t4 := Y1 + Z1
+        //  10. X3 <- Y2 + Z2
+        $X3 = $this->addElements($Y2, $Z2);      // X3 := Y2 + Z2
+
+        //  11. t4 <- (t4 * X3)
+        $t4 = $this->mulElements($t4, $X3);      // t4 := t4 * X3
+        //  12. X3 <- t1 + t2
+        $X3 = $this->addElements($t1, $t2);      // X3 := t1 + t2
+        //  13. t4 <- t4 − X3
+        $t4 = $this->subElements($t4, $X3);      // t4 := t4 - X3
+
+        //  14. X3 <- X1 + Z1
+        $X3 = $this->addElements($X1, $Z1);      // X3 := X1 + Z1
+        //  15. Y3 <- X2 + Z2
+        $Y3 = $this->addElements($X2, $Z2);      // Y3 := X2 + Z2
+
+        //  16. X3 <- (X3 * Y3)
+        $X3 = $this->mulElements($X3, $Y3);      // X3 := X3 * Y3
+        //  17. Y3 <- t0 + t2
+        $Y3 = $this->addElements($t0, $t2);      // Y3 := t0 + t2
+        //  18. Y3 <- X3 − Y3
+        $Y3 = $this->subElements($X3, $Y3);      // Y3 := X3 - Y3
+        //  19. Z3 <- (b * t2)
+        $Z3 = $this->mulElements($this->b, $t2); // Z3 := b * t2
+        //  20. X3 <- Y3 − Z3
+        $X3 = $this->subElements($Y3, $Z3);      // X3 := Y3 - Z3
+        //  21. Z3 <- X3 + X3
+        $Z3 = $this->addElements($X3, $X3);      // Z3 := X3 + X3
+        //  22. X3 <- X3 + Z3
+        $X3 = $this->addElements($X3, $Z3);      // X3 := X3 + Z3
+        //  23. Z3 <- t1 − X3
+        $Z3 = $this->subElements($t1, $X3);      // Z3 := t1 - X3
+        //  24. X3 <- t1 + X3
+        $X3 = $this->addElements($t1, $X3);      // X3 := t1 + X3
+        //  25. Y3 <- (b * Y3)
+        $Y3 = $this->mulElements($this->b, $Y3); // Y3 := b * Y3
+        //  26. t1 <- t2 + t2
+        $t1 = $this->addElements($t2, $t2);      // t1 := t2 + t2
+        //  27. t2 <- t1 + t2
+        $t2 = $this->addElements($t1, $t2);      // t2 := t1 + t2
+        //  28. Y3 <- Y3 − t2
+        $Y3 = $this->subElements($Y3, $t2);      // Y3 := Y3 - t2
+        //  29. Y3 <- Y3 − t0
+        $Y3 = $this->subElements($Y3, $t0);      // Y3 := Y3 - t0
+        //  30. t1 <- Y3 + Y3
+        $t1 = $this->addElements($Y3, $Y3);      // t1 := Y3 + Y3
+        //  31. Y3 <- t1 + Y3
+        $Y3 = $this->addElements($t1, $Y3);      // Y3 := t1 + Y3
+        //  32. t1 <- t0 + t0
+        $t1 = $this->addElements($t0, $t0);      // t1 := t0 + t0
+        //  33. t0 <- t1 + t0
+        $t0 = $this->addElements($t1, $t0);      // t0 := t1 + t0
+        //  34. t0 <- t0 − t2
+        $t0 = $this->subElements($t0, $t2);      // t0 := t0 - t2
+        //  35. t1 <- (t4 * Y3)
+        $t1 = $this->mulElements($t4, $Y3);      // t1 := t4 * Y3
+        //  36. t2 <- (t0 * Y3)
+        $t2 = $this->mulElements($t0, $Y3);      // t2 := t0 * Y3
+        //  37. Y3 <- (X3 * Z3)
+        $Y3 = $this->mulElements($X3, $Z3);      // Y3 := X3 * Z3
+        //  38. Y3 <- Y3 + t2
+        $Y3 = $this->addElements($Y3, $t2);      // Y3 := Y3 + t2
+        //  39. X3 <- (t3 * X3)
+        $X3 = $this->mulElements($t3, $X3);      // X3 := t3 * X3
+        //  40. X3 <- X3 − t1
+        $X3 = $this->subElements($X3, $t1);      // X3 := X3 - t1
+        //  41. Z3 <- (t4 * Z3)
+        $Z3 = $this->mulElements($t4, $Z3);      // Z3 := t4 * Z3
+        //  42. t1 <- (t3 * t0)
+        $t1 = $this->mulElements($t3, $t0);      // t1 := t3 * t0
+        //  43. Z3 <- Z3 + t1
+        $Z3 = $this->addElements($Z3, $t1);      // Z3 := Z3 + t1
+
+        // Return (X3, Y3, Z3)
+        $p3 = $this->newPoint();
+        $p3->x = $X3;
+        $p3->y = $Y3;
+        $p3->z = $Z3;
+        return $p3;
+    }
+
+
+    /**
+     * https://eprint.iacr.org/2015/1060
+     * Algorithm 6
+     *
+     * @param JacobiPoint $p
+     * @return JacobiPoint
+     */
+    public function doubleInternal(JacobiPoint $p): JacobiPoint
+    {
+        $X = $p->x;
+        $Y = $p->y;
+        $Z = $p->z;
+
+        //  1. t0 <- ( X * X )
+        $t0 = $this->mulElements($X, $X); // t0 := X^2
+        //  2. t1 <- ( Y * Y )
+        $t1 = $this->mulElements($Y, $Y); // t1 := Y^2
+        //  3. t2 <- ( Z * Z )
+        $t2 = $this->mulElements($Z, $Z); // t2 := Z^2
+        //  4. t3 <- ( X * Y )
+        $t3 = $this->mulElements($X, $Y); // t3 := X * Y
+
+        //  5. t3 <- t3 + t3
+        $t3 = $this->addElements($t3, $t3); // t3 := t3 + t3
+
+        //  6. Z3 <- ( X * Z )
+        $Z3 = $this->mulElements($X, $Z); // Z3 := X * Z
+
+        //  7. Z3 <- Z3 + Z3
+        $Z3 = $this->addElements($Z3, $Z3); // Z3 := Z3 + Z3
+        //  8. Y3 <- ( b * t2 )
+        $Y3 = $this->mulElements($this->b, $t2); // Y3 := b * t2
+        //  9. Y3 <- Y3 − Z3
+        $Y3 = $this->subElements($Y3, $Z3); // Y3 := Y3 - Z3
+        // 10. X3 <- Y3 + Y3
+        $X3 = $this->addElements($Y3, $Y3); // X3 := Y3 + Y3
+        // 11. Y3 <- X3 + Y3
+        $Y3 = $this->addElements($X3, $Y3); // Y3 := X3 + Y3
+        // 12. X3 <- t1 − Y3
+        $X3 = $this->subElements($t1, $Y3); // X3 := t1 - Y3
+        // 13. Y3 <- t1 + Y3
+        $Y3 = $this->addElements($t1, $Y3); // Y3 := t1 + Y3
+        // 14. Y3 <- ( X3 * Y3 )
+        $Y3 = $this->mulElements($X3, $Y3); // Y3 := X3 * Y3
+        // 15. X3 <- ( X3 * t3 )
+        $X3 = $this->mulElements($X3, $t3); // X3 := X3 * t3
+        // 16. t3 <- t2 + t2
+        $t3 = $this->addElements($t2, $t2); // t3 := t2 + t2
+        // 17. t2 <- t2 + t3
+        $t2 = $this->addElements($t2, $t3); // t2 := t2 + t3
+        // 18. Z3 <- ( b * Z3 )
+        $Z3 = $this->mulElements($this->b, $Z3); // Z3 := b * Z3
+        // 19. Z3 <- Z3 − t2
+        $Z3 = $this->subElements($Z3, $t2); // Z3 := Z3 - t2
+        // 20. Z3 <- Z3 − t0
+        $Z3 = $this->subElements($Z3, $t0); // Z3 := Z3 - t0
+        // 21. t3 <- Z3 + Z3
+        $t3 = $this->addElements($Z3, $Z3); // t3 := Z3 + Z3
+        // 22. Z3 <- Z3 + t3
+        $Z3 = $this->addElements($Z3, $t3); // Z3 := Z3 + t3
+        // 23. t3 <- t0 + t0
+        $t3 = $this->addElements($t0, $t0); // t3 := t0 + t0
+        // 24. t0 <- t3 + t0
+        $t0 = $this->addElements($t3, $t0); // t0 := t3 + t0
+        // 25. t0 <- t0 − t2
+        $t0 = $this->subElements($t0, $t2); // t0 := t0 - t2
+        // 26. t0 <- ( t0 * Z3 )
+        $t0 = $this->mulElements($t0, $Z3); // t0 := t0 * Z3
+        // 27. Y3 <- Y3 + t0
+        $Y3 = $this->addElements($Y3, $t0); // Y3 := Y3 + t0
+
+        // 28. t0 <- ( Y * Z )
+        $t0 = $this->mulElements($Y, $Z); // t0 := Y * Z
+
+        // 29. t0 <- t0 + t0
+        $t0 = $this->addElements($t0, $t0); // t0 := t0 + t0
+        // 30. Z3 <- ( t0 * Z3 )
+        $Z3 = $this->mulElements($t0, $Z3); // Z3 := t0 * Z3
+        // 31. X3 <- X3 − Z3
+        $X3 = $this->subElements($X3, $Z3); // X3 := X3 - Z3
+        // 32. Z3 <- ( t0 * t1 )
+        $Z3 = $this->mulElements($t0, $t1); // Z3 := t0 * t1
+        // 33. Z3 <- Z3 + Z3
+        $Z3 = $this->addElements($Z3, $Z3); // Z3 := Z3 + Z3
+        // 34. Z3 <- Z3 + Z3
+        $Z3 = $this->addElements($Z3, $Z3); // Z3 := Z3 + Z3
+
+        // Return (X3, Y3, Z3)
+        $p3 = $this->newPoint();
+        $p3->x = $X3;
+        $p3->y = $Y3;
+        $p3->z = $Z3;
+        return $p3;
+    }
+}

--- a/src/Optimized/Common/TableTrait.php
+++ b/src/Optimized/Common/TableTrait.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized\Common;
+
+use GMP;
+use Mdanter\Ecc\Math\ConstantTimeMath;
+
+/**
+ * @method JacobiPoint newPoint()
+ * @property ConstantTimeMath ctMath
+ */
+trait TableTrait
+{
+    /**
+     * @param JacobiPoint[] $table
+     * @param int $windowValue
+     * @return JacobiPoint
+     */
+    protected function tableSelect(array $table, int $windowValue): JacobiPoint
+    {
+        $point = $this->newPoint();
+        $shift = (PHP_INT_SIZE << 3) - 1;
+        for ($i = 1; $i < 16; ++$i) {
+            $cond = (($i ^ $windowValue) - 1) >> $shift;
+            $point = $this->selectPoint($cond, $table[$i - 1], $point);
+        }
+        return $point;
+    }
+
+    protected function selectPoint(int $cond, JacobiPoint $p, JacobiPoint $q): JacobiPoint
+    {
+        $r = new JacobiPoint();
+        $r->x = $this->ctMath->select($cond, $p->x, $q->x);
+        $r->y = $this->ctMath->select($cond, $p->y, $q->y);
+        $r->z = $this->ctMath->select($cond, $p->z, $q->z);
+        return $r;
+    }
+}

--- a/src/Optimized/OptimizedCurveOpsInterface.php
+++ b/src/Optimized/OptimizedCurveOpsInterface.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace Mdanter\Ecc\Optimized;
+
+use GMP;
+use Mdanter\Ecc\Primitives\PointInterface;
+
+interface OptimizedCurveOpsInterface
+{
+    public function scalarMult(GMP $scalar, PointInterface $point): PointInterface;
+
+    public function scalarMultBase(GMP $scalar): PointInterface;
+
+    public function addPoints(PointInterface $a, PointInterface $b): PointInterface;
+
+    public function doublePoint(PointInterface $point): PointInterface;
+
+    public function modInverse(GMP $scalar): GMP;
+
+    public function isOnCurve(PointInterface $point): bool;
+}

--- a/src/Optimized/OptimizedCurveOpsInterface.php
+++ b/src/Optimized/OptimizedCurveOpsInterface.php
@@ -17,6 +17,4 @@ interface OptimizedCurveOpsInterface
     public function doublePoint(PointInterface $point): PointInterface;
 
     public function modInverse(GMP $scalar): GMP;
-
-    public function isOnCurve(PointInterface $point): bool;
 }

--- a/src/Optimized/P256.php
+++ b/src/Optimized/P256.php
@@ -164,11 +164,6 @@ class P256 implements OptimizedCurveOpsInterface
         return $this->ctMath->inverseMod($scalar, $this->p);
     }
 
-    public function isOnCurve(PointInterface $point): bool
-    {
-        return true;
-    }
-
     /**
      * @param PointInterface $point
      * @return JacobiPoint

--- a/src/Optimized/P256.php
+++ b/src/Optimized/P256.php
@@ -7,12 +7,14 @@ use Mdanter\Ecc\Curves\CurveFactory;
 use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Optimized\Common\{BarretReductionTrait, JacobiPoint, ShortWeierstrassTrait, TableTrait};
+use Mdanter\Ecc\Optimized\P256\GeneratorTableTrait;
 use Mdanter\Ecc\Primitives\Point;
 use Mdanter\Ecc\Primitives\PointInterface;
 
 class P256 implements OptimizedCurveOpsInterface
 {
     use BarretReductionTrait;
+    use GeneratorTableTrait;
     use ShortWeierstrassTrait;
     use TableTrait;
 
@@ -282,7 +284,7 @@ class P256 implements OptimizedCurveOpsInterface
     /**
      * @return JacobiPoint[][]
      */
-    public function generatorTable(): array
+    private function runtimeGeneratorTable(): array
     {
         $table = [];
         $base = new JacobiPoint();

--- a/src/Optimized/P256.php
+++ b/src/Optimized/P256.php
@@ -1,0 +1,327 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized;
+
+use GMP;
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\Curves\NistCurve;
+use Mdanter\Ecc\Math\ConstantTimeMath;
+use Mdanter\Ecc\Optimized\Common\{BarretReductionTrait, JacobiPoint, ShortWeierstrassTrait, TableTrait};
+use Mdanter\Ecc\Primitives\Point;
+use Mdanter\Ecc\Primitives\PointInterface;
+
+class P256 implements OptimizedCurveOpsInterface
+{
+    use BarretReductionTrait;
+    use ShortWeierstrassTrait;
+    use TableTrait;
+
+    /** @var int $N */
+    protected static $N = 256;
+
+    /** @var int $size */
+    protected static $size = 32;
+
+    /**
+     * @var GMP $b
+     */
+    protected $b;
+
+    /**
+     * @var GMP $b
+     */
+    protected $p;
+
+    /**
+     * @var GMP $order
+     */
+    protected $order;
+
+    /**
+     * @var JacobiPoint[][]
+     */
+    protected static $genTable = [];
+
+    /**
+     * @var GMP
+     */
+    protected $R;
+
+    /** @var ConstantTimeMath $ctMath */
+    protected $ctMath;
+
+    public function __construct()
+    {
+        $this->ctMath = new ConstantTimeMath();
+
+        /** @var GMP $p */
+        $p       = gmp_init('0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff', 16);
+        $this->p = $p;
+
+        /** @var GMP $order */
+        $order   =  gmp_init('0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551', 16);
+        $this->order = $order;
+
+        /** @var GMP $b */
+        $b       =  gmp_init('0x5ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b', 16);
+        $this->b = $b;
+
+        /** @var GMP $R */
+        $R       = gmp_init('0x100000000fffffffffffffffefffffffefffffffeffffffff0000000000000003', 16);
+        $this->R = $R;
+
+        if (empty(self::$genTable)) {
+            self::$genTable = $this->generatorTable();
+        }
+    }
+
+    public function scalarMult(GMP $scalar, PointInterface $point): PointInterface
+    {
+        // Initialize a 256-bit table
+        $q = $this->projectPoint($point);
+        $table = $this->makeTable($q);
+        [$bytes, ] = $this->ctMath->normalizeLengths($scalar, $this->p);
+
+        $p = $this->newPoint();
+        for ($i = 0; $i < 32; ++$i) {
+            // chr to int without side-channels:
+            $byte = unpack('C', $bytes[$i])[1];
+            if ($i != 0) {
+                $p = $this->doubleInternal($p);
+                $p = $this->doubleInternal($p);
+                $p = $this->doubleInternal($p);
+                $p = $this->doubleInternal($p);
+            }
+            $windowValue = $byte >> 4;
+            $t = $this->tableSelect($table, $windowValue);
+            $p = $this->addInternal($p, $t);
+
+            $p = $this->doubleInternal($p);
+            $p = $this->doubleInternal($p);
+            $p = $this->doubleInternal($p);
+            $p = $this->doubleInternal($p);
+
+            $windowValue = $byte & 0b1111;
+            $t = $this->tableSelect($table, $windowValue);
+            $p = $this->addInternal($p, $t);
+        }
+        return $this->toBasicPoint($p);
+    }
+
+    public function scalarMultBase(GMP $scalar): PointInterface
+    {
+        if (empty(self::$genTable)) {
+            self::$genTable = $this->generatorTable();
+        }
+        $tables = array_values(self::$genTable);
+        [$bytes, ] = $this->ctMath->normalizeLengths($scalar, $this->p);
+
+        $p = $this->newPoint();
+        $tableIndex = count(self::$genTable) - 1;
+        for ($i = 0; $i < 32; ++$i) {
+            // chr to int without side-channels:
+            $byte = unpack('C', $bytes[$i])[1];
+            $windowValue = $byte >> 4;
+            $t = $this->tableSelect($tables[$tableIndex], $windowValue);
+            $p = $this->addInternal($p, $t);
+            $tableIndex--;
+
+            $windowValue = $byte & 0b1111;
+            $t = $this->tableSelect($tables[$tableIndex], $windowValue);
+            $p = $this->addInternal($p, $t);
+            $tableIndex--;
+        }
+        return $this->toBasicPoint($p);
+    }
+
+    /**
+     * @param PointInterface $a
+     * @param PointInterface $b
+     * @return PointInterface
+     */
+    public function addPoints(PointInterface $a, PointInterface $b): PointInterface
+    {
+        $jA = $this->projectPoint($a);
+        $jB = $this->projectPoint($b);
+        $jC = $this->addInternal($jA, $jB);
+        return $this->toBasicPoint($jC);
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return PointInterface
+     */
+    public function doublePoint(PointInterface $point): PointInterface
+    {
+        $projected = $this->projectPoint($point);
+        $doubled = $this->doubleInternal($projected);
+        return $this->toBasicPoint($doubled);
+    }
+
+    public function modInverse(GMP $scalar): GMP
+    {
+        // For now, we'll just use ConstantTimeMath.
+        return $this->ctMath->inverseMod($scalar, $this->p);
+    }
+
+    public function isOnCurve(PointInterface $point): bool
+    {
+        return true;
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return JacobiPoint
+     */
+    public function projectPoint(PointInterface $point): JacobiPoint
+    {
+        $ret = new JacobiPoint();
+        $ret->x = clone $point->getX();
+        $ret->y = clone $point->getY();
+        $ret->z = gmp_init(1, 10);
+        return $ret;
+    }
+
+    /**
+     * Return a new point at infintiy
+     *
+     * @return JacobiPoint
+     */
+    public function newPoint(): JacobiPoint
+    {
+        $ret = new JacobiPoint();
+        $ret->x = gmp_init(0, 10);
+        $ret->y = gmp_init(1, 10);
+        $ret->z = gmp_init(0, 10);
+        return $ret;
+    }
+
+    public function jacobiToAffine(JacobiPoint $p): JacobiPoint
+    {
+        $q = clone $p;
+        $zInv = $this->ctMath->inverseMod($q->z, $this->p);
+        $q->x = $this->mulElements($zInv, $q->x);
+        $q->y = $this->mulElements($zInv, $q->y);
+        $q->z = gmp_init(1, 10);
+        return $q;
+    }
+
+    /**
+     * Convert from a projected point to a basic point used by PHPECC
+     *
+     * @param JacobiPoint $p
+     * @return Point
+     */
+    public function toBasicPoint(JacobiPoint $p): Point
+    {
+        $q = $this->jacobiToAffine($p);
+        return new Point(
+            new ConstantTimeMath(),
+            CurveFactory::getCurveByName(NistCurve::NAME_P256),
+            $q->x,
+            $q->y,
+            clone $this->order
+        );
+    }
+
+    /**
+     * Return (a + b) mod p
+     *
+     * @param GMP $a
+     * @param GMP $b
+     * @param bool $reduce
+     * @return GMP
+     */
+    public function addElements(GMP $a, GMP $b, bool $reduce = true): GMP
+    {
+        /** @var GMP $r */
+        $r = gmp_add($a, $b);
+        if (!$reduce) {
+            return $r;
+        }
+
+        $cmp = $this->ctMath->cmp($r, $this->p);
+        // $cmp = < -1,  0,  1 >
+        //          lt, eq, gt
+        //
+        // ($cmp - 1) = < -2, -1,  0 >
+        //                lt, eq, gt
+        //
+        // (($cmp - 1) >> 1) & 1 = <  1,  1,  0 >
+        //                           lt, eq, gt
+        //
+        // $swap = < 0,  0,  1 >
+        //           lt, eq, gt
+        $swap = (~(($cmp - 1) >> 1)) & 1;
+        $rPrime = $r - $this->p;
+        return $this->ctMath->select($swap, $rPrime, $r);
+    }
+
+    /**
+     * Calculate (a x b) mod p, using Barrett Reduction
+     *
+     * @param GMP $a
+     * @param GMP $b
+     * @return GMP
+     */
+    public function mulElements(GMP $a, GMP $b): GMP
+    {
+        return $this->barrettReduce(gmp_mul($a, $b));
+    }
+
+    /**
+     * Return (a - b) mod p
+     *
+     * @param GMP $a
+     * @param GMP $b
+     * @return GMP
+     */
+    public function subElements(GMP $a, GMP $b): GMP
+    {
+        $c = gmp_sub($a,  $b);
+        $swap = ((gmp_sign($c) >> 1)) & 1;
+        $cPrime = $c + $this->p;
+        return $this->ctMath->select($swap, $cPrime, $c);
+    }
+
+    /**
+     * @return JacobiPoint[][]
+     */
+    public function generatorTable(): array
+    {
+        $table = [];
+        $base = new JacobiPoint();
+        /** @var GMP $x */
+        $x = gmp_init('0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296', 16);
+        /** @var GMP $y */
+        $y = gmp_init('0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5', 16);
+        $base->x = $x;
+        $base->y = $y;
+        $base->z = gmp_init(1, 10);
+
+        for ($i = 0; $i < 64; ++$i) {
+            $table[$i][0] = clone $base;
+            for ($j = 1; $j < 15; ++$j) {
+                $table[$i][$j] = $this->addInternal($base, $table[$i][$j - 1]);
+            }
+            for ($j = 0; $j < 4; ++$j) {
+                $base = $this->doubleInternal($base);
+            }
+        }
+        return $table;
+    }
+
+    /**
+     * @param JacobiPoint $q
+     * @return JacobiPoint[]
+     */
+    public function makeTable(JacobiPoint $q): array
+    {
+        $table = [clone $q];
+        for ($i = 1; $i < 15; $i += 2) {
+            $table[$i] = $this->doubleInternal($table[$i >> 1]);
+            $table[$i + 1] = $this->addInternal($table[$i], $q);
+        }
+        return $table;
+    }
+}

--- a/src/Optimized/P256.php
+++ b/src/Optimized/P256.php
@@ -294,33 +294,6 @@ class P256 implements OptimizedCurveOpsInterface
     }
 
     /**
-     * @return JacobiPoint[][]
-     */
-    private function runtimeGeneratorTable(): array
-    {
-        $table = [];
-        $base = new JacobiPoint();
-        /** @var GMP $x */
-        $x = gmp_init('0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296', 16);
-        /** @var GMP $y */
-        $y = gmp_init('0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5', 16);
-        $base->x = $x;
-        $base->y = $y;
-        $base->z = gmp_init(1, 10);
-
-        for ($i = 0; $i < 64; ++$i) {
-            $table[$i][0] = clone $base;
-            for ($j = 1; $j < 15; ++$j) {
-                $table[$i][$j] = $this->addInternal($base, $table[$i][$j - 1]);
-            }
-            for ($j = 0; $j < 4; ++$j) {
-                $base = $this->doubleInternal($base);
-            }
-        }
-        return $table;
-    }
-
-    /**
      * @param JacobiPoint $q
      * @return JacobiPoint[]
      */

--- a/src/Optimized/P256.php
+++ b/src/Optimized/P256.php
@@ -61,7 +61,7 @@ class P256 implements OptimizedCurveOpsInterface
         $this->p = $p;
 
         /** @var GMP $order */
-        $order   =  gmp_init('0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551', 16);
+        $order   =  gmp_init('115792089210356248762697446949407573529996955224135760342422259061068512044369', 10);
         $this->order = $order;
 
         /** @var GMP $b */
@@ -160,10 +160,17 @@ class P256 implements OptimizedCurveOpsInterface
         return $this->toBasicPoint($doubled);
     }
 
+    /**
+     * Computes the reciprocal of the group order
+     *
+     * @param GMP $scalar
+     * @return GMP
+     */
+
     public function modInverse(GMP $scalar): GMP
     {
         // For now, we'll just use ConstantTimeMath.
-        return $this->ctMath->inverseMod($scalar, $this->p);
+        return $this->ctMath->inverseMod($scalar, $this->order);
     }
 
     /**

--- a/src/Optimized/P256.php
+++ b/src/Optimized/P256.php
@@ -4,6 +4,7 @@ namespace Mdanter\Ecc\Optimized;
 
 use GMP;
 use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\Curves\NamedCurveFp;
 use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Optimized\Common\{BarretReductionTrait, JacobiPoint, ShortWeierstrassTrait, TableTrait};
@@ -52,9 +53,13 @@ class P256 implements OptimizedCurveOpsInterface
     /** @var ConstantTimeMath $ctMath */
     protected $ctMath;
 
+    /** @var NamedCurveFp $curveByName */
+    protected $curveByName;
+
     public function __construct()
     {
         $this->ctMath = new ConstantTimeMath();
+        $this->curveByName = CurveFactory::getCurveByName(NistCurve::NAME_P256);
 
         /** @var GMP $p */
         $p       = gmp_init('0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff', 16);
@@ -221,7 +226,7 @@ class P256 implements OptimizedCurveOpsInterface
         $q = $this->jacobiToAffine($p);
         return new Point(
             new ConstantTimeMath(),
-            CurveFactory::getCurveByName(NistCurve::NAME_P256),
+            $this->curveByName,
             $q->x,
             $q->y,
             clone $this->order

--- a/src/Optimized/P256/GeneratorTableTrait.php
+++ b/src/Optimized/P256/GeneratorTableTrait.php
@@ -1,0 +1,4942 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized\P256;
+
+use Mdanter\Ecc\Optimized\Common\JacobiPoint;
+
+trait GeneratorTableTrait
+{
+    public static function generatorTable()
+    {
+        return [
+            [
+                JacobiPoint::init(
+                    gmp_init('0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296', 16),
+                    gmp_init('0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5', 16),
+                    gmp_init('0x1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x88b13398542d5c8e69a0be9fe51bba8fffab23c970e684814e4b1cf45751336f', 16),
+                    gmp_init('0x4126885e7f786af905338238e5346d5fe77fc46388668bd0fd59be3190d2f5d1', 16),
+                    gmp_init('0x8d761fd160e5bb67afe5854016bb02b6f80baf8d4b7fce3c852842092b408ce3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8cf6f359c28335db9598cf594050008ef6d1d4b3f6eb9c56f274bc89996cf794', 16),
+                    gmp_init('0xbab81c492426f90381395727509d18b338185a6563de88ff7222a779807378bd', 16),
+                    gmp_init('0xa627cf275950e7af6c3cac85c689a0ba6c8bee32c9b71350d31e3012fc5246b5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3323341a2fc7e5476fb3b8121b1f067ab6a3b36f8a1ea5e230ce73db7a041e1a', 16),
+                    gmp_init('0xef43e06c37e7483196c416b2158b49cef7c0130d7fb365ed509b237d8f881743', 16),
+                    gmp_init('0x2316121e4aec6626d02254f66732d05510fb4e201e1bb0d7aee69cac7266c74f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x454413ffe59583f2577a5c615b58e983dce9e599b87a3353dd3163f8beaa3fa', 16),
+                    gmp_init('0xe679d7fa740a306d6b3a191338fa01e154d97b37bba202dcc2859c33db0ff14', 16),
+                    gmp_init('0xa9abe4c490384e13bff0ed5885745fd30094c576916725ddc207334d6c19bbd0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xee0d64f3094bf7e35237a70fc79efbae10a77b6e880050859a220a6bb026d4bc', 16),
+                    gmp_init('0xd6a453af7af58b4f01557276ad1da471cc1271f4ffd194295234c426d6973b0', 16),
+                    gmp_init('0xaff9fbb574fda99c7f92a901a44f1f675c0b14f736335b52efa1716fb7114a05', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x195f8eb0dba7f7bbd509565ac473c73788b2c2531ef2b5a7f3142ebefb11916c', 16),
+                    gmp_init('0x6c59156a09c573d98fa91fd0ab1ec6b3e636afb9cbd31699f7a6677b170898c', 16),
+                    gmp_init('0xf8b271b4c943be439577d13a11e08e4b49abe0477db8c6caf8c7cef865ef9cdf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb7a7e7ee010d8dcc06362d7cb9d42a4f12f588ca3456d891d0e447cde8b6de01', 16),
+                    gmp_init('0xa8ebc2064b979e866a6c4b37f505f0cd3a3623cc5c0ecba8b1d8d13996d7b5cb', 16),
+                    gmp_init('0x8234a3414b59e92e576596c2576d2517722230efcad264130f80703ec29b5609', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5dc84709a5ad18d949b8c43c5c7b6d71797a064d9e29ea53edbcba0e92f40318', 16),
+                    gmp_init('0x4e700d0315c3db962f76f545474ecccbcd689b67b63fc8de34e5165552225181', 16),
+                    gmp_init('0xf9e3ba1793c4acef5e6021988b492f37ac3c3fb9a2c5a1ee62893755ebe0dcd3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd1d8fe7952b25892a96619523b1f7a001ac735d102b0c322c047a4bbbbfaf268', 16),
+                    gmp_init('0x72a0b65a46ef331a2807e67aa05269c611cc331abb6a9665251a62fd1e3388cd', 16),
+                    gmp_init('0x4aa430201305bfaedd078541a34ec72ada9b5f1d1048b03252e1c129d7020332', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfc04f345c4d0fbd2273a40a769ffc5f069a34dce6c5a046b4fcc2fb7b532409', 16),
+                    gmp_init('0xc22fadef3f816779d1ca94f362c42efb0d2a9d0f91f3dcf3834542f4ccc818f', 16),
+                    gmp_init('0x772b97733bb3db366c9e3345ec3b2a95d6980bda480796a4021827c903d08cf1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x54f5f96861f908574b8d015bcbf4449f2f4214c11d2627d477d8d2c5b4420f05', 16),
+                    gmp_init('0xe29ffb684164907f1889c580d43eebd5092760105f254c547a7c5e8c61e6fe3b', 16),
+                    gmp_init('0xe3087f5cf66697b27a0dd11c46b15ae9716d714d373702db896ff6c4e7301a20', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4f288b396269d65ed9e8fb73be40d20e7accb39d7f12dab097f1dfac993f423a', 16),
+                    gmp_init('0x3b3450727bc7f2cf879fe621a6cfc4b04848dea94283c73c94dad2e370c3c094', 16),
+                    gmp_init('0x2fd92fcd6fe2e7a4b89c4725c5ad674e5fb9466fd25a095b6b343bdf9e511a61', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcce66bc1de80ff7d11212d3513c827bfbe7a89b064b0c60c0eb0e4aecfc8449b', 16),
+                    gmp_init('0x1c45495cc3d023881647cb1a750b5943b5ffe612a528324bc0b18d2d5188a9dd', 16),
+                    gmp_init('0x458e7715993c3da7f0f75dfa0c99fb229e59de3f823000f4751714dec71cdb5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8b53cc88d4d402727055374545c8d70c60c0e61746922dee49c2edf08726e430', 16),
+                    gmp_init('0xcefc20d3c1644fa7f5107a6f8d01019b3602d62bac7388e7013405af0f4141ed', 16),
+                    gmp_init('0x80b16391ead61d3b1e51c54028eb1a6d0320d71a5b26e95bca05f347548cf1cf', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x560c44e762500117756699296c8ec32eebbd27d4936f8d93a3bf81e96d57af3f', 16),
+                    gmp_init('0xed0a0366dff582ea02c9feca790f1d4ed9d2481e2a8cde32d8d15b76e70a4ca8', 16),
+                    gmp_init('0x231b46b7475fcb0fc4dfe62cdc0397d2809406d48a4741cc953fdc71bbecf293', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe31e53eca6c0773a86ec5119e58c9e5cd34ac64154e393268a5f2bc2e65d3a17', 16),
+                    gmp_init('0x6f431ffcb0389d85220c0b3e049a1b4f0eb652e3c4082b8e81dfebb7f77c87b0', 16),
+                    gmp_init('0xc1810ff38bedbde033dcd6f2bc1d8a05d55d9be2662e0c1e40d66f6b8771f626', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3073c9e8c596deb46e4689c51360760ec7ef893fbe841dd753cc4cba1c409046', 16),
+                    gmp_init('0x53ef2c65a479eb69f8ba8555deed8c49bcb190ca7b3863f4d9faa40269729148', 16),
+                    gmp_init('0xa15288c59287c514d3cb12debc8961c0f41a5de2c0bf3ca063cbb70069b4ff94', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4f7e3e359f44c25ded89089e8c24243d0aa54f492bc626f3c90b3122e3f0097b', 16),
+                    gmp_init('0x5db10fdeaaeebb425c5f29685931ac98f137d43c735b903c3030b5aaa520bb93', 16),
+                    gmp_init('0x6a3f733e14abe4b8724b4ed453ad551eea99a27fc6cf8b39e624a6506e3ccb99', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcc9e910add054dd1ab93aa2a989e4dee30c434642c5a1728d2d01f49607d5132', 16),
+                    gmp_init('0xd8a131aca7c2bfaecaa0854592352561fe27668bd9aacc9bc60330e3df735abd', 16),
+                    gmp_init('0xefc16d53cc157ab636d988a23f759dcd234ebaa66d562c7856420e87b6f5472a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf877b76a382192df6449254412fcc905f5240a5817e33bbeda2488f64c9619bc', 16),
+                    gmp_init('0xc827557eee2d2fa6b9867f58ac0448acc0ba16d64b1cf3f493cb70c3e1a7cbca', 16),
+                    gmp_init('0x96a71a9016c9a7165f0a86bd2e939fbbcb8c69e79c246b92466a7cdbeb2d6eb2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf3a0e072f7ed54bd34b9a2fdb39ccd087ca6b4a3ae70594e69e89a224a5a5707', 16),
+                    gmp_init('0x21cba462df90cbb51fbbb7a0696b39fdcd0ed161d7b634980c4c678c9c1fd4d9', 16),
+                    gmp_init('0x79c835919170ea4f283b9f203b1c6da87432d2e8978216886e8a7703c3f68394', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe6b517a90966648be374c0dc0186d6c78afb91793f6499da8e58be93f9b3725', 16),
+                    gmp_init('0x115716b24895d558371888e82772ccf25f8f68ab993d8bee23677693692888c6', 16),
+                    gmp_init('0x218b4d9c2e70865dabf84dde57bf889a6a365db05b007223cac694db10c685ff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce38e542b0ad7edfd7f05d84e5d0bda352d85c57fef24fd1bed4f0f31b7ce228', 16),
+                    gmp_init('0x41fc558b4b19f7560de6f79ff0edf9825aef7f1f9d2491c28db9109d26a9a865', 16),
+                    gmp_init('0x5ecaf537773d91799044fa3aa817369fa00dcad940b78149bcbadc12d0a8920', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x445c3c2cc8964425edd01ac77901ad8e488f5078f303ac722045d9e23a8cf1b8', 16),
+                    gmp_init('0x8deeb313616c09eb16425d2a884e47cfaf51441096af60582fe971a1363bbc16', 16),
+                    gmp_init('0xfd26fd8b943eccbccf73273d9814aad7def8070e00cbaeb0e62aeee2090b6b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf889d8bed9ce71f562eddb1983abff8d8287eddf8a288ae407e2247fd1afd8', 16),
+                    gmp_init('0x767eec8af3ae4fd8e0976b2197beec9083604afb2ff6398041827899d83fee38', 16),
+                    gmp_init('0xde6167cdb2a2c1ae854e4b84c22246347ff514773170ce424ebec4af449fe913', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1ca81b07bdd723630403c411c93f5cecb09c43d552a03b27603f65292ed03685', 16),
+                    gmp_init('0xda5f428730644ff867a7192db324d915c604891c44eaffff5e7686c72491a5d6', 16),
+                    gmp_init('0xb35241323dea2b27705560f39ecdf2f261fa05ca70b61b8b464e8d9ef4256504', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf5ef12fcbd2415fc608a4e455d3395fd71c028d59a8fd79bec99120c297d429f', 16),
+                    gmp_init('0xefa4e8f5b80383fed452b9c1e4752b44a6ca53323d7e66df88cd3dd17aaac188', 16),
+                    gmp_init('0x86f78d346dbdd2e3b5c4cbcf3691bd20a3d90e6113161bbb2a964e0c66c3ccbb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x221973cdd5c58d432700a304f8b6ef18fcf213538933145f3d15d165d5e25b8f', 16),
+                    gmp_init('0xa8d3d37ac45ff53847b7161fc816f69e76d008918eead87bb0f18a0f64f79187', 16),
+                    gmp_init('0x8b1000f572902618e3e3b7bad8b80e81b1efa38f66f3a427875c4e4ba3a7f000', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x23af5e459f84083fe54ff8bb58f9e6b8a7af024321172fa520e3474f39813946', 16),
+                    gmp_init('0x83c10500fd17598bcc61b31485c52e176ca31690300322c91233290dc1db275a', 16),
+                    gmp_init('0xc0f170f04e6f9e9a955a7dd7e5a70bfcf640953bdabbbeb2217f3877b6754558', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x304f151a8d40aa8963db2e66ead02e983ed4d0c63d4124bf8589eee7e65f4fa9', 16),
+                    gmp_init('0xbd4c2193e633728bbca339b60beec241c7756eac00be9285368c22881eb60a25', 16),
+                    gmp_init('0xb75abd9490992bb57e618e877d3f834b38580eb2410f630a86181cb69dadbf82', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdd52f92e30f0fba51995a9f5e58b8b53d93fa0be90acc108865ed2d1cbc5f1c9', 16),
+                    gmp_init('0x115b313d62c17539edee8f7f4fcf3fee25555d734e6ddc429cefce5265bf2581', 16),
+                    gmp_init('0xb2cb7b26d5869dee1cc3f5a32378725c58a2632c9531ad8a8e7d39042cfd1b0f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57613d5fcc9079886b0255394c46da86d14123656b468f76b0e959514147525', 16),
+                    gmp_init('0x27e82bf1822385421fa235fb89a5c24b89c5d1b3dd33c84e8371acb2dbd437ba', 16),
+                    gmp_init('0x94ce944fb9f3c1bff13defbfe1af763be6bebcbc5cbc7682f59a9392f08b08b8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd03a683131f52ec212222f6f72356fbe029c54ee5e5a44a052282dec3d3e3c85', 16),
+                    gmp_init('0x2ad1efcd1e51b7cd41d259d9cf73c94ab6f0b0f66d7924a88b03db93e31b3f6a', 16),
+                    gmp_init('0xb0bb838407088bc6127a6c9635631e8e8192999cd449995f169a17bfae1eeca5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2a9b169c98b09a42fcb36391e83f7f397dbcf5f5c37742eeb4ee8ae43d3269b9', 16),
+                    gmp_init('0x77c2cd22632ea10c9352d3a59ad578ca10a84ed68d54780f250ca6aa6ac3b620', 16),
+                    gmp_init('0xa37821058c51abe54e2e2d16d91e243d3a7f099a5d902890edfabc4d04c1b37e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35b8ef13201f31d3a974bfea3c749f3a9f744be790c90139188bc37cf10669df', 16),
+                    gmp_init('0x17fea3a2429c9e7c21cde073558c5b731b7df2416c7dcff3c45ee33f01299039', 16),
+                    gmp_init('0x675c007e8162a0a9503ba86436be6994b6d2faf257c91598a2e0778220bfa6fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb1213e8110855da5a6cceade3acd18eda6b802381ec6aa0cb73f2bf43073b787', 16),
+                    gmp_init('0x2481ed1707ac8868ba85a7c19a9b91d24b9113f45d6e19dd2687a66c58fa07a7', 16),
+                    gmp_init('0xc6a4cba05145b4dad5c869458020e1bc6c625c1bb3d7bc52b0ef3834e304968f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3bad98c8b9e2b54894f9a0dfbf9e2ab0189927001713e7d6cf199deead0cb432', 16),
+                    gmp_init('0x22f05075364a8107e7f8bc7ce207fcf34eaaab80eb2591fad4ac634290ec803', 16),
+                    gmp_init('0x16843156fa7521d5e890fd0022ec65f6b7ea12ee7ca557755a8e1fcbfb0a2aaf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8e00a2b6e0633fd8de9ffe74af22cb0db3247b2f92a06406d017ef79a920f66a', 16),
+                    gmp_init('0xb57394cd2a55258450f1fe44a84d6a83ffd0417762186204633f81d9954e3ca3', 16),
+                    gmp_init('0xf82946fc258c348b8af7e123fa989e1f51ee92d4a0db6ba4c5f4e2ef935f8d37', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7c3b8283618ce4345da7a55077f50c7cc32772f65ea70553072db58c393626b0', 16),
+                    gmp_init('0x796d7824bdbbd7fccbe7c2051367a508bfc89a41a11e617fd45ba93fb21eeb22', 16),
+                    gmp_init('0x16e19d6fbec749c37a6a9010cc0e369f7f7064e24fd6b3b356216bdb65f1fc95', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x11d8009f421c685c73f347ab85f1e7a3f2ecfe5e62e6b772bfae0ecc126b5f3', 16),
+                    gmp_init('0xc8f7305b28d200c664a78f0919a12627ca48898ccaa195174e220789b240f0c7', 16),
+                    gmp_init('0x34efe9e217364f5292040c6e3aa42a3f54bed425bff7fee321e49e77896b5495', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d23f62537a0ae4c5e9bacf2e710177004539e93971ba3c5c5dbbfe5e3de0923', 16),
+                    gmp_init('0xbe681b7c1a7da667e0b9080221a177ef40d95df4e8a685dd7b186e2123fd87d2', 16),
+                    gmp_init('0x9a98a0e60ab1a829a42709fb32f6a2d71e31c60b8551504c5520f4c2766b2afa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xea121c07ff5930d620b372e40c9e427bfc3e99b924d8865af24c441ff30d292f', 16),
+                    gmp_init('0x9a787fe903adff4771e91cef3ae5e0b43ba42ebf06cda13117fb70e5e9ff39fb', 16),
+                    gmp_init('0xe98327e7a6435b0eebd1dc3e109fcd5b9d02848c0ee00740ba55b64aac56cf70', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6fe2f61de3aab9a5a97ecf6740be4e3fbcda41b39a38172f05241645458d73b1', 16),
+                    gmp_init('0xc8ab59dba61805aff84775d4a1b848b417942b09339d65c066e2eadb6c9beb5b', 16),
+                    gmp_init('0xd25eb416cab2b66389155f354d54ed8d59f398242c8963a4a9d7f0becfee0a76', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x16321dbcf7055ee5420d6aabd53d7bc01f589feb5df5c644140be78bc0ad6bb5', 16),
+                    gmp_init('0x84742044df51290e0306b16f2c7a476dbf39c2ef744975f923791fc485fccf7a', 16),
+                    gmp_init('0x72ad6911248a54cfd9f96c06b742e3ade8f82198731a8ec30625ab0da4732045', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xb993864a01bece05eb1dd6e37bd3cd203ae77a754817843312957ffa5df44ccb', 16),
+                    gmp_init('0xef65cb7253823201c648bf038fbef75bbc6c6d4aeeb60b81f7b5669bab471715', 16),
+                    gmp_init('0x4a1a19ad8ebfe198913c19b348c2d9c77042d3427d315bef37680f18c6919d99', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x896c177fe49e6d3984c2309ea9c19c038d5a3b941a8726a94fd08b491d9026c6', 16),
+                    gmp_init('0xd0b4edee987e79ea4625b7953003585409bd2e78da8b5df52442d03a5de44bb7', 16),
+                    gmp_init('0x506455d0d01a6a865b4621b778ecb18676f21c968a1ca01d06c395329ad4dc93', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5258861d5557742f4e96717231ad8cd21077520564f7e45c19cb25a8a2a74490', 16),
+                    gmp_init('0x4fbf15498385dfe3f5cafec18afa5a449c43bebe05152c32a8eaae8fbf86f3bc', 16),
+                    gmp_init('0x331fb25e7c493b634dcb053c60da2d87a8d2baa35cde48781a3471377afd6dbc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe881081a5a620892024f801e0afc97a560884ea7d0e4857409a9de0d338f891d', 16),
+                    gmp_init('0xd814d2220bde137c2e16a549c41e09a133484da4cea5a34fde62d5ce8e53a399', 16),
+                    gmp_init('0x91e9280d1af2134556640fb093df70c22da8f38ce5cb68ec269d000364d2f3c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc83ec0bdc3d487f88850b0ba600ce6dd76cf7b0d8b758eda58ab47d623fa49e6', 16),
+                    gmp_init('0xb10d8c07f71fa741b8b08973d203a8db31ca40dd62dea3d94bb42bdd6009bb19', 16),
+                    gmp_init('0xb02fcda746ed0226822a3c8670808a33b41e8f4134df5197b3cc503f0ef8bbd6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x831c6e104d746d00a68eecd782c06e7a75c82a1f87a200b9603b993a2fc93267', 16),
+                    gmp_init('0x4bea9a295ec567471fbbfc90fea8eac1a67aa7d68d82eada89a01d68f2fba23', 16),
+                    gmp_init('0xface326561015ebecefbe8aed562fda3c657107d41c81b539dcf9fe3a95dbddc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x956ac733b740f992f7280b09e0d9aaf684a5c7f49f8884083f9ee785e3c6af3b', 16),
+                    gmp_init('0xcae98c11bb577155e37e0e87b016f545a39f86948b9dbf829c5e8451c921f37c', 16),
+                    gmp_init('0x272a17253d8aa548d48c035674d9aaf1dd9106148c8dd9211db5e68afd729f69', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd07c4d14e6af9e844ddc77be08b37aae88ef646bea03f6d813cdd533c6ac9790', 16),
+                    gmp_init('0x905af613537c98dd89605ad367d758624e750e07a74f2f60f6479f8fc6b872fd', 16),
+                    gmp_init('0xa282df162670dc9a65d88357336a28e2b5c2609708eb5ad5d4ebd92e79078e34', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd1158092be6864fcf14f47c869e6687e5f7cb814b0528f3e745302ddec60716b', 16),
+                    gmp_init('0x264cd9f5f00bcf5a2c377c7036a81aada1b8094ef854d45e206e5efd3ca996e6', 16),
+                    gmp_init('0xf6d9c6682cd487f7758ba42792d27d7c331a7ea37543a3162366a1d9a7426348', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe08d77ed5a42e704f33a0189f2cee3e4a0813dbe53e6ffa12cb85432be37ef50', 16),
+                    gmp_init('0x39cf83f3433564096854219a83ec7577697280485312c460b7b34ee6fc694379', 16),
+                    gmp_init('0x95d83f57599f1813511d1c291ee99f0d3e66417fd34524559655ae281ffcd1b3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa2ae49b66ebd4f1377a1e0ea18346e310a4a10310a85410e4a563910aedca4c6', 16),
+                    gmp_init('0xe737c2bb4743efd2d1704d1fd932493c60c7118f0c83d2eb316f2befe0071cd2', 16),
+                    gmp_init('0x5f524fc4fba2a8ec5e1996b4a8b07d0f8726c3623b68d5bf4229548d32fbbe4e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe8327af0c9c9fc64de1b0b250bb57f3008f74c30fc0e0eda5254651cd8e1ca9', 16),
+                    gmp_init('0x6d8df0b00ac5586ad178f0bc392f3ad8e1a7b49e8c681db47a5d68a1605f404b', 16),
+                    gmp_init('0x856db09d6083de1bd2fa943dfc9e0881859f771416d45fbd81083653e7c8d010', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3c7322f4a75debb8a96a409792bddfeaa1e6cd65c76c73ac974de5a696f78ae0', 16),
+                    gmp_init('0x176f848a2aa40c3637b3ca4104cd212165965266670e362f1e936e0a462dbe26', 16),
+                    gmp_init('0xc887a47775209efafea1b112f76ab4981c3634eccb5a3133126af83c8f6f395f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf94a6b3c6a114e12f08ae3f0779c871efc4a825ad373714452b7d4b761a491db', 16),
+                    gmp_init('0x33ae094ce93885807d4ca63c6ee3241351f509b477daade27fa67b0d3bcd9e6', 16),
+                    gmp_init('0x6208f17d1beef5503b5824209d7865a1a6bf7ff503c8488c76ab41c35656f65b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x62edfbddbc2c9af7543defdb68a6580b63b9a82276ddf016c0a1f0040db05239', 16),
+                    gmp_init('0xc36800c7111f5c022f5da04ebfceb5f1799098df10f234ff5b0428341f903e36', 16),
+                    gmp_init('0x264089b568bfad2399b49f2058348015e3a9ebe60a883a1bd4c014933d707399', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x25c903f80ef17e552200f14d1fccf1d77b976af28d8a1867b65dc445c62d1010', 16),
+                    gmp_init('0xfa0d51734a50184b9de20e3e91be2e4f0714b2a37bb294e5e05af3c46c01fba4', 16),
+                    gmp_init('0x948f980c267d01076be2c02586bd73f75dbe6a0a5d4156ff6eb1af9b6ac804cc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xadd8730704bec598f91df918d6653e726e48454501afab137831e594b92379aa', 16),
+                    gmp_init('0xc67de5d9888b88f23f6a5f69fa1e4787b20696cf0b0db3d9051ef92f6da15eb2', 16),
+                    gmp_init('0x19540b92d035fa34c89ac877e874da14ffa8ed8b84694a661d447ce2d0092c33', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4fe454d0a083bea708228d7f61b269a51b714d1114b4d1a54a264d4fcdd179be', 16),
+                    gmp_init('0x8b703dac41259a0934c2564414c4c668825b603c0c6038fc3c6215e5121606fe', 16),
+                    gmp_init('0x61a15df473d83d0ea5bfa8b71948e3cd42b496796759a47077e5a4c32f1935dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfb43d0439817eb8dc06b1a64d925d36e0c019bddb35032e7a638cbbe7297b63b', 16),
+                    gmp_init('0x5fa2458e124cea9a5365966daeded62381e5d67d1f551fbe70daec97e58f4833', 16),
+                    gmp_init('0x116050268c9f465b37058c7c9229bce952d68abe5622a0162b134e6074b34498', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x903e3b925295e7faa04b2b090dd43e63fc66029527b6afc8cafa569eef9a8906', 16),
+                    gmp_init('0x4a75c1b8e89c6f9a84e50017452a9c288081ce924abed24b06c593487b386db9', 16),
+                    gmp_init('0x4242cd12e2ab1a438f5912b2e0ebda3716fa04cc9392641df3f0ea5128666eac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x592a6d8f62952749e0b9ed18498958eaba2a664a606350d858d4bb15b0180d50', 16),
+                    gmp_init('0x3251a0a9d5efdb0fdcc86c8a9dadd679c1f419fd7c3e3b2526e447f0533eefa1', 16),
+                    gmp_init('0x67fa4d564a30f2466d504dd762a01dac8014df84ca1aa9e9e765454916d2d38', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x38c655364f647469eed1e080b8d451064d0ab1f1908df1bae882b97b28eacd55', 16),
+                    gmp_init('0xe98b48a41aa8dd1df8ea65d245921ed3f2c5b00b9e622d0aaa43640bb719d89a', 16),
+                    gmp_init('0xc0b270e505c3342a79fea25b89b341f37faf743ae4d92b03cd3b5a106a823a7a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa37c168acaf75cff6ef364fb600a174c60a9c71e817db9f3bc8e7f182fc70eef', 16),
+                    gmp_init('0x45a8c5146cce9df7fd89c5bd8dab01a8aed3c61d180291d00a20b912863fca32', 16),
+                    gmp_init('0x6ba6f4b4c129a211941b675ebc195267caf446b5ce2cc96a6447314ef5ddd9f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2d3ea625b0947d853204f5b6761730ca5310817210dd9801bb860dbb873d71cd', 16),
+                    gmp_init('0xc7322f8a275f6d0562e5531c5a5f7919e3f56e29596463d0a511db1853e3b46c', 16),
+                    gmp_init('0x1edae36b7d4c634aed205950515e6859be2828e98cc66d466a01b9d61cfa5da4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcc217caee5c606cfb2ebdd09f96452b835ade6c6a5a90455e20db023f0f14736', 16),
+                    gmp_init('0x265aec95d98982796087a51076a08fab19ac5bae3abe617a71a50c3a34eaa69a', 16),
+                    gmp_init('0x9a4ce0a912dc4985cf3df939df5d4bbdaf5b9a15409d8d48d491d627fe17d031', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6c6bfe288e670511bbc37af4d07aa5a93eaa393caff3df678572399a42333317', 16),
+                    gmp_init('0xbf8b96794f5ab5c627a7769d6356c1cdf7714899c782aa3d678494df54ed159f', 16),
+                    gmp_init('0xec00dcb518d2dd4c802d60f85f071405bf1b218d7093f400fa94af2cb171489c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xba622ad3058b47989830ce6bb98168a624332a8edc52986365343c6971ef2c6a', 16),
+                    gmp_init('0x954e3a90164c31cdce744fd8bf1a296d1456b9cfd481d55427b216a805114a9', 16),
+                    gmp_init('0x5368bec000102a64d406d76c100e8fb2e343deefd1e02f3665c55fe4839f20a7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd5a358b0d67e4a4cd250ab94b4983d4e8464f2dca2650928844d61c84badfe2', 16),
+                    gmp_init('0x5ae2aa257b0ee4dbe917e80b297a12e2c89ee62b559fd61e5bfb468cfa932b71', 16),
+                    gmp_init('0x21c89fae817ab1e01157ab11b4f10016f47996edba5b641252628bc517882e8a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b0177cc324fe0b690f1840afb138c5e96dd3a874b6ea0fb2052d3506e9eba02', 16),
+                    gmp_init('0xcb84da36e80900b9f7d05d00b6335ee0261b0bed49edd2856c7cc7122ba1d6f', 16),
+                    gmp_init('0xa3561461ed308184761a688c7ac3dd5d2bcb60549c5297cfdef537909a97adf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd32aa307dd7b3c8ac896221f66df724971a142ca888fa84ea4b0bde51fcd5a20', 16),
+                    gmp_init('0x7af716654f311444c0256b79f127c05e4127d9ad9f76c162c8153f756f1d139e', 16),
+                    gmp_init('0xfd277ea79268ce94c5c918b40ef7334f28679df5471a401b50c64fc3d922299d', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x7842423508111974c9a804ea9843df3041e58cb14147348290e27c7e17301e49', 16),
+                    gmp_init('0xa518dd111cfa01b8f75f7755a93ed98abe7d209b32f507c73c0d958b57e54a15', 16),
+                    gmp_init('0x7c89c4960a88c3e09bfdca34fc258cc70e805f32ed930198d76cda7ef71ec0c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6717d9dc29d7353e6076efe9f1f1061c7f921699cf011f0b0aa6416b334e10d', 16),
+                    gmp_init('0xaabfccc6c18e9af623d1fa724a95ac0f05e66aab1117c65db7c989f385a81b05', 16),
+                    gmp_init('0xcdcf4d64d39ee44ada48d766031a5ef6286da134d96236683d0bbea71fe3abfe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e1986509a4785ac78469ed50bce1af5ed0b265e647dd72d2b6d5e456f8f6ece', 16),
+                    gmp_init('0x2367d516e3346773570151ce60f35fda0610cebd5c5c41f680556f1619b7cb47', 16),
+                    gmp_init('0x2b58b32aee0f28e6d19e2fb2fbf3ce518cae1e87843c8e6fc8741c5da9033d5f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9e1ee2a0b6be8e0d6b3a79d9c37ced26ccf239e583b699b75e86a718c6c776db', 16),
+                    gmp_init('0xf6986f9986cb238e589e23f2f413dffc7b1149c6b137f78d49d8d4a7a3c06b49', 16),
+                    gmp_init('0xc0dc6c7ffeeba9e509fdb62c0a1abe13d4c128a584d0b6ba45463e1257b0732', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3acf35618f1b1719c9504167a539ad11cc24a473a18334ececa174295eeccbf8', 16),
+                    gmp_init('0x35f42130a566b143072639a8ff203cd60fd2882e91d81e415b2667c05f85a96', 16),
+                    gmp_init('0xf15790fa36fcf38e07fe9e0750878c122bf120c205e3e511d8f90605601f2290', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4b8c4a5916654707f85ac6f33cb8a3883f7f8f270cef176a0ae925a7acafa240', 16),
+                    gmp_init('0x2e8e9bf944f1034cb54aea2c810f015bac74f174e5117408f04b24d4000ac247', 16),
+                    gmp_init('0x5e4a8571cacfd750152205eab258471bbd0e3f40c8b437dc68ee12c4a4ec66ae', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x158ba08c19998ef1b29c6d465d3dd9bd80be71d94eb39e360b99caa6c48ec7f7', 16),
+                    gmp_init('0xa33cce90f72cfd9e7f7becfe98d842c0b21aacadf395da0b01de56d6d73e6b66', 16),
+                    gmp_init('0xfda19afdab30b2c08f7e9ca4ab8a64da00d5f9194643b6d193f4e7d3981e5295', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xecde0ac51a9e9f32091e456ca43154bef6bb86833d3b8df8c6c19d6be77f0087', 16),
+                    gmp_init('0x63e37a2d139633bd55e5b3a72b8c0d8fc278aa5d60a1576259d9ade0b9eae84a', 16),
+                    gmp_init('0x27334295ba76ac1b3567dca4c7e8ef691d7c623980a551fd77d413a5f795bb2b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbfc4813df103ffed1068019ba880b081436f07dc6378500bc88cad029c700ec4', 16),
+                    gmp_init('0xe094c8ea39e7f5026be9f00eeb422445a78a268e110e27e9a88acf9fbed66b8e', 16),
+                    gmp_init('0x44afd0cd532b4f45874efb21ecac3f89d56f21a63fb08809bfed390c58a899', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x37bf590a4ad097282ecfbeb48e6261b935627930063134137cf2bafc8e6baea3', 16),
+                    gmp_init('0x69b978a0880a721f691f8e3b8b359c0f4d28ee212ad65c5af8eaa50a7b807374', 16),
+                    gmp_init('0x2621352bc67c2c57d7ea4b03a73f74d1384d0eae99f7c44040bd66503e2bdb05', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8c9b36cefebb447d72bd5a8b0e116b69f85bf664457278fa8d2acbb86d487da', 16),
+                    gmp_init('0xc69ef3d0b284083a1f9adbfd60db1d61a1797a7f449ef98c76c6f93539980a56', 16),
+                    gmp_init('0x6ebeb955708b5287faf63cb97eb8561756dd6e49b565ba5d48ea306308652c5b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x171fe9e860a46174f8f207f53518f39d3eb07d9d68f4ad334b09980053a98e74', 16),
+                    gmp_init('0x2f757c9bbdbc3b696303a811076f55f14c573afcbdbd65ced18983b9bc00b2fe', 16),
+                    gmp_init('0xabce334196c190d5a973e4b10e38b30992cb22fbc061a2a9c601d9df22d52b38', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1b8127ff2b52460d85ebc54513a8e84d26269c816fb7d4b709c4ab212c425cc8', 16),
+                    gmp_init('0x18ba792b5458a0477f7879a87783e50efb247852c2d327e9311fee7e29c59370', 16),
+                    gmp_init('0x2552121753a903ced22ea9ade6093eadbc9cff7ee4482c0d94838778563075a5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d19089856d833c7eaf58316914bf8a0e042cb9ac3705d13a778b2a170a81930', 16),
+                    gmp_init('0xc7123af5fed125b0aa3ea111fa92f15a68647a9aaf8fe2c7a05bab0f0f2bbd5a', 16),
+                    gmp_init('0x18f042fc475a9181326f6a6b7d5640750475436ccb25b5af6ebc1cb637200ff2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x26149adf14e75252436b57c4d34744763ae894e255580c8acd0f45d689eb9ea7', 16),
+                    gmp_init('0xc7249871a4383cd5357b841bb9d59b7231d318473ea6c56ae0a615247e8759d5', 16),
+                    gmp_init('0x10670ebaaa848b5cfc4f997b1bd7902d8b3d66bfc3585dc8b6eca6a649354fd', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x2c507c8494163fb294df079ffdf84ea1adf7fbbc8050226f1c4f8a7b6de64ddd', 16),
+                    gmp_init('0x7e54f91ec8ce6ce7afcd7a5950f1391dd095c0cf7e1c9ce25a8e7a0760752df5', 16),
+                    gmp_init('0x980d3383241b8b7837871d0ed09b6af1c9e45d5808a8b2e7afe9a426c266b96b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeffff86c7f88f01ee42cf793e987f77a62653a08a7d1510d0945908293e01d60', 16),
+                    gmp_init('0xf58c4cb96c873756876eb01d1d21a1dec05b74e7cb4887afa6da8d1b5bb6c034', 16),
+                    gmp_init('0xfa2731a1eb2769a544f388866c56ee2de8c3c235521f39ec8878b8a3647d00b9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8f932ff0e6c25554c5bd363b14e966a9f0e200f7ef7afc4c816889cc59433b0d', 16),
+                    gmp_init('0xfac345d2235e2a826120ce5f9fd0e4ec4c0a6ec5bea8f0cebfee95315c6d687e', 16),
+                    gmp_init('0xb14c5fb18b4be73bc7a37461b1a19dd0084f20da4e967c0c3fa596a3018f0680', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x53eb8b9d351106bd8fb493a2df4e8045c86ef1ed3a804b9764955a5b71daabad', 16),
+                    gmp_init('0xbe5cb51c4e48c817e2da5e6cedce341b35f6160af5202090fbc95824629a8b3c', 16),
+                    gmp_init('0x1a8faa1543c7c4a2f44b975d27e758757b3140e6b07233691d6557fbcadf3407', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6aace56c1b4a389abac9f751e0989c351b220d52318c2279bcf615e428f71849', 16),
+                    gmp_init('0xc4f1609702508503a27bf04ae9da7c6e3e263834f5a8dab6b7346b212d347337', 16),
+                    gmp_init('0x864d9112952617ba326972b5c705bb725514db4de3ccf8d779355c8afd89196', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xead4308ada3cde7bfebd1118cb50520ea942b5919f706e4f70c838c3de075daf', 16),
+                    gmp_init('0x6bf76957ae59e86d5f6d9d2751b03059f440d3a27e436e72fb47822cb88d49bb', 16),
+                    gmp_init('0x53a2d1977341c6d0dce50110c4711fa8f782c83770fe39f368e62c34cdab186a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x197d0a351846dde01f7548e8037d989dc7c74b32b27cca062001314b91173218', 16),
+                    gmp_init('0xe4179101a56de13b7e8ad5d8eaa2766952ca284dfd9c239571820ab0dd92a05', 16),
+                    gmp_init('0xaafd155b532d0287af65c7bd275cdeae5b6ad36642a7fa5785adf2beae50d7d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3fccbf2dda0f078433d72b1275d70db82515b2f65575e4127a8537a382cb017', 16),
+                    gmp_init('0x87f5d7a2eda0372b935ce232318be31b6367e45139c8c4ebc7f4cc5e641838fa', 16),
+                    gmp_init('0xf85b1f1bf562cc4b0d7cc942c9dd41ab69ab091ad2f9bb1da3ac99d665cbb854', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe4bb99d7816977a6f3fe342eff646d1099f1e59c365c6113a27cb78a719eb786', 16),
+                    gmp_init('0x28ff0668548b6aef107f6de08a321d43bb4a777b4b5b315105a940aa9767a08c', 16),
+                    gmp_init('0xff681d03cabafec54b430e2b0f5d1adcfbb5683502d2b9375ecf1948748d06ba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48ebeeaa39cda70345f0e96f98b56354601f486301455e2b32dc917425dd548e', 16),
+                    gmp_init('0xd52d8f3d09e6e4ec18a8adfd16c31de793d061ce5c22c1ee2ddb9fa4fde6d032', 16),
+                    gmp_init('0xb8b9138d01ac9ddd1ecf724f5d9dd8bec8ad662250b16a7c7a0fe3924870ffdb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x487d444810a388ced3a646ee728a78e47d1388421e7386c0483920d869c88884', 16),
+                    gmp_init('0x832409739a9fe89e86c060fa2f2e56e786955c0110a2342ee8076fe738eee091', 16),
+                    gmp_init('0x4e187a9cbbf37a3b5d7ea1b6d30672b6128c68bb361c11b956c8b64f1090729', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x262ca0434715baa73ca29f3dde0aa743f87764e997ee7d948d25033708531e5d', 16),
+                    gmp_init('0xae132185a9f95a86844d8b032385d74f070498570948b424d3781a4a4b849b22', 16),
+                    gmp_init('0x957e97834bc2e282c0b952699b8966132a73d5b625df98503addefa5a3752570', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb15457c379c449075a2365d8fbcb71ca3f5a66e35fbfae2d2fda513e4ce67a33', 16),
+                    gmp_init('0xef4ad22fb2d040957ec6ff0b4522c2c68d042c15790e0e5f4d8773bb8850a00c', 16),
+                    gmp_init('0xd959adebf1d3f00e9a28de70b10e32ae7647aaa01349204ab4b80d2ab0cfa571', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xafe7f919b834259270d4a8fb29ffd554deb26621d2efdccbb0f0a3e85d0fb79f', 16),
+                    gmp_init('0x51f431137be46af599c4cb2654a92ed1afcd7830617cdb758a453dfb9af6d74', 16),
+                    gmp_init('0xf13b477ff4497033d313c7dd074f3c1299daeb8c07e75c7bb89559befb5bc6d0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8072ea103c6173394b9e7e96f380f7cc14203d1ccf076f98d56b543977252ddf', 16),
+                    gmp_init('0x20542895220b3097005b2bd6d58ed74c892b9d0d72569a97f9d3b60aa48e7500', 16),
+                    gmp_init('0x9c9cb7abdd31e4e5ecb57aec85b3646d91eb03d9a6aee7c7f1ea4a3fcea05de8', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x205c8e018c27354746b899dc9399c509437a1b383efa6bcd5912a3854549c4c3', 16),
+                    gmp_init('0x2113361556746a15a0be93cc31405e779830666e24347f86b6673dc9348fab7d', 16),
+                    gmp_init('0x42f546ba3c44c69e8cdd3e9b9b56cfc74475082182f4aa5733d4b0a9959bf9c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x47b36492bfbddb4b2c05fbbf3910224013288ecc61c7284aca5a854ace9c432d', 16),
+                    gmp_init('0xe37797206e95428d4b581adf21e88876a7c2e27124041d58b14b3f937f04cb5b', 16),
+                    gmp_init('0x86cc2eef9c2d06db81103cc241c5280ee527a891a8c5ca7012ec686e92ea5e64', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x95f9c6e876c2ddfffe8f4b63bcf2b04dff586d3bcdc0b0b3e0b50ebf9a34c273', 16),
+                    gmp_init('0x5c5698070af1d35626bce094d5770e76307e42c1ed4213579e500617b484786', 16),
+                    gmp_init('0x11f627ec47875b49aedc8e5c80271d90eae5b5a2d81f54cfca460c8a8ab5ad15', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc23272e1e43ad0dcfa524b65ba0fd61d811d27e23c01a6e32be038aae4c1c3e', 16),
+                    gmp_init('0xa45cfb694802e0afc058522a03b71d03656f98d249e50dc8a876bd6dd4224f3', 16),
+                    gmp_init('0x1567e99f2709979c44a76fa4cd54e0cd497fafefc88757c2fab453ef021d69fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe0758c331e77722aef0768c7a08ffa9bb8d3f0d07c2ae338f667b8026d786e2b', 16),
+                    gmp_init('0x8a088c49aa1d7eca588c48d0fa063f9d9a54680b9e32d04afe53192df9231b9', 16),
+                    gmp_init('0x9f1aa409273bccd486e74212345a395d6592e44541627974a23eb1f0f5c67e23', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xee54cbbac56c96aacc8645873e43686ebebbae7f86d66ff186bf6d1e91e7d649', 16),
+                    gmp_init('0x23856273296454ce03a9de56c318a936490197cf0342359cc832c3357e40f520', 16),
+                    gmp_init('0x4dcc021d064f425fcc1885b606871fe0c5cfe9eb4405b05f711b5576a23026e2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2d2287f000cd0a08c03e696c50d00ac933d315027d5ea4066dcf383b30c2bf45', 16),
+                    gmp_init('0xa9a8d90ba190d117daf6dfb2925f2e32ded261a9b5844f7843a2e8c380312490', 16),
+                    gmp_init('0x526495b756dab97c0e46528bb12942c91c32207ae9812b6cdf9a43d34acce8f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4f0e56d06607deb8b1756a7ece30803e3a1470e536d6b16d51fb4578b80d726e', 16),
+                    gmp_init('0x2fd67998a1f9bd695f4bf133a1db8987e173230f48cf7620262da0980319a41', 16),
+                    gmp_init('0x34e854d3dde5422568029b43acf2f291f605ceb2fa8567dccd12f8b135552fd9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd74d10af12b7d45a0d40095f26fad767e0b22cf2b855f079760f60e818fd39b6', 16),
+                    gmp_init('0x228e25d567439ac0789aa15fac0c87b07c2fcab16f02c77a1e97a1676bef6191', 16),
+                    gmp_init('0xd1cd9d6423c981604472c1d4861b82152941d0ecaa428f80c923d4d6b96ab7e6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd530a08f1f2e4483dc93cfe0cb2bfc92856e56330acbfb7a5acd9e82d4dbb39c', 16),
+                    gmp_init('0x4c2176c65d0bda01f30f96b6492d2464623b705c25e7988453c7eff369010c24', 16),
+                    gmp_init('0x5a4afb8e5bc2e453aec1a5a11f22f1edaf1200ef93bf3a8317fe659fa13df79b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe28eedb01bb1e62976c332a860941d44940819e7db686e763181e7e9f7342500', 16),
+                    gmp_init('0x9979e5ae336c3acfea180a3873341e61c9fa0d020f078082224807d800e80497', 16),
+                    gmp_init('0x805d59bd1284bfa2ce3ffed508513efb38de8a7a6600802a82ad64f1490c769c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe981bac403975bce1d95a4e5c749f2961fa5060b5512e6c74a7dd0ac279f33ed', 16),
+                    gmp_init('0x40e2a01f47235ad0cd44c2a5477a184d0a7cd2d73bd976d408b37bb1e52dae96', 16),
+                    gmp_init('0xafcf914c714ba7f45640fd7ee4f1adea9bcc24f2786989ffcc238fe0bb5bed0e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc7d460f911fe00ce20a5a6f46f9de182ff8880589e7552adf7c4d91aaa00647e', 16),
+                    gmp_init('0x4ef08198dd17e9959847170dfcbccf7e9abce81febd748461f09d90031b7344', 16),
+                    gmp_init('0x883242993b2cd707f3033efd2653f7c89a9c2119d6553837bfad23b0b9eda00', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x98ecb964b202df810f680fed5d21c40d9991d2d6187e24a8e8a2e1cd60fff687', 16),
+                    gmp_init('0x4bafc511a110cbf3c18b70854e72a48199d8f1ef8e20d17bbab86b2264165f49', 16),
+                    gmp_init('0x70c7d39940eccede60751152b8379a89f392b4bc5c180b3602c6a4cdf6c661be', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e2bedc6c9c7944ee0169f6de563896f5b4d2ed26d48e99cb0001498c2117ad', 16),
+                    gmp_init('0x3a934537a5876a43994b562d15c2911b7a6749fb2720e31131296cf27474b242', 16),
+                    gmp_init('0xf1bd707d0e6d53c64e19618bf83e4d3484ac3a4784c79a7478a44c2d8b33292e', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xeab0f45188a3f33e854345124918098cc8e7d8cf8f4213574c2600b5e2aa40bb', 16),
+                    gmp_init('0xe326a326862a0cf5843cd71d8ce6101b15c0ad7a6813388423527892218bb142', 16),
+                    gmp_init('0x95c542bc9ca57f4d9effd44406d6a6639e88e7f1a97c00793bfac55319fc579b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1395de89d2ec558e9dd0db2f27ca8c1776c725ee9f3d82ab40d37348fb7e0fb7', 16),
+                    gmp_init('0x8e8765921b93f6c32c0a19293babd22ea0b97804367399a54aa960358076476a', 16),
+                    gmp_init('0x178d324337938aea8e97922d35e92744edb798daa64aeb258221212811b07e70', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbc4089b3d881277c72b9a438696186417a4bcfe429a8e8c4d2412a9e56ddb5e7', 16),
+                    gmp_init('0x11f8ae02b973295388bc1579b44fc45524ae1a24fd3395c3bda197bbb5747a34', 16),
+                    gmp_init('0xd2baa9d93d9444293f35aa73ba82204f716e01d600699ba98a301e7c993ea78d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91f9fbfa8bafbd571f9b40f161055834e5a026f28dbc5394536fc818d3e89cfb', 16),
+                    gmp_init('0x491300e0f963c74bebba3c1600cea6091ef298e9183c44451a0d7098af56583d', 16),
+                    gmp_init('0x637fea525a0f784caa1ba336dde71805c963121c67c5f1a301df5f2abe08c652', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec16137342924f1b8f87deec0ee8124fdb3cb0976f935f464a36f999bdde1b50', 16),
+                    gmp_init('0xdfa0a767413600022a8dabcfd7b6080a0fb86f7132f06b62a3206affe40f0e0f', 16),
+                    gmp_init('0x97eaf1ec727ef9afeacf53131a8f5d33bbc04cbf4f6c1192c5a0cac196eac3af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x33635ce2759aec977d8fbd698f6cdb965382aa944b5e359fdbc9075c05169eac', 16),
+                    gmp_init('0x7832226eee3ce7a0a876e59d0db02dff782cb57a23be8ae648576e41b8aae605', 16),
+                    gmp_init('0xdfa28d3df73791cdf11238bac1c0bf4b2fe7fa6dce7cc3ca1414ca026fd1f533', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9db7c1dd056bf2f17aecd1d3bb5dc4c0232f594138e7a673a5f7f5b61e759a6f', 16),
+                    gmp_init('0x9623a94ed72941f3a8499232b63196af0d23b2478f075b1277464ebda165888f', 16),
+                    gmp_init('0x8c90022ab3dd95a8d3904d1072aaa9e30eb178983eda3a9dd68900aa8a9758c7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc0cb96e288ce81aa8e623d4a2db3d41ddce58d1c220ea1802a4f566102372baf', 16),
+                    gmp_init('0xe2390acb942bb77a4ad51ef372917d0e93d56b0f1d24dcf571ed3724a1ea9737', 16),
+                    gmp_init('0xe465a241acfee0371c3b22b0fde0c8362beddd13bc3b0cb2bb805f0cc6036a9a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x155eab22419129d95bedc60790064d1c8d23fd4862825038e9c403fc2e5b9d7a', 16),
+                    gmp_init('0x616e80fb8435a0fb78fe5a487d26cb4f0f71ab811db42b6350e3df953739fd2b', 16),
+                    gmp_init('0xed91ded31fb8110593d3877fdf14ae1a7efbe61541b779e878d8f5a58c51670f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x66a3abc86cd45e163754fea10e1fee5550aba471d8293dfb6315a8f152a442df', 16),
+                    gmp_init('0x3fd2f20d78926d4ab42f26ddc70a3ae2079a311b605caef21cca2ea6e4e34955', 16),
+                    gmp_init('0x53923818085bea3d09b93ee5c8a30b67f77f14dfc0b831e810a29f18d3d6666d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbb8ef7936fd934a3e7cad1c0a3cc03d52d73ee49b429593ad44d6b9ae80cf4a8', 16),
+                    gmp_init('0xbbab9ae906b720b064af633eb6f05bf968df985abd152a3addad78a853681a9a', 16),
+                    gmp_init('0xc3737cbde8d291148690bfd649a9a301941631b65adddb7b47befaee6cf59a62', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7db94967f567e10b26dc74f7028a46d75253fff6c54357f6d256f9fb2fb37c6b', 16),
+                    gmp_init('0x37a6c501b8895b4405a470a69e62e9767a8437c69970cb90ea3b24cf197e73fd', 16),
+                    gmp_init('0x6c48c041df5d157950c5d39000fd0dcbd2c6407645c8d35ea5f4c2f776658d23', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb075d3e70bee6e35f5382c1cf118e83bcea329c1577ab72bac85a951516941d0', 16),
+                    gmp_init('0xe8994c282a8e7d8f59e6a650e5a7426be2c81c85090b4bfd7e15b284b0f8c49', 16),
+                    gmp_init('0x439a7d86f5f79d75168ac70ac6cb1639d63742edb6f1ee3033e6875d6e5b53f2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4bbb0c02dfe4a7bb8ee8cd1f3707acc2352633c2cf0345e396072760a20c7261', 16),
+                    gmp_init('0x7b849c9fd6e85e8174a03ac9c67db0d92b36fdf5b838ee3bc37f3ef0a2125d90', 16),
+                    gmp_init('0x384ddebca68ad4e12668a5ebaa64e45f51034fe31985766893f8559cb43bfa6c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd230f0664ba48e14d48e5e83814bf3172d1f23a1fc118a39e4073bc1d8c67b15', 16),
+                    gmp_init('0x7349a4443732fa680b6ed168b374b0bce2ade0a5f7dc8ac0d06a453036d1cfc7', 16),
+                    gmp_init('0x325f8b8811260995e3b671f453e9326d5e4bcce8597c1d7dc00aa451b890c768', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x9b39dffa87e5679fd56920573050441abcd1d8649c7fa887ca981f170f617d48', 16),
+                    gmp_init('0x8a1dddb758d99f78756bdeaa503b84678d049ad3bf793c581c3157c7c9021c3e', 16),
+                    gmp_init('0x286847f80f0769771c5f89b0c13baeb72674a183ee08abd0c95752720de06ccc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x969fcfa6c891c222866f5bf095044a75d2473bf80b1426213c10a3e91fdc2cdc', 16),
+                    gmp_init('0xe41a8f4192c8c8e7cd3c5656ec578df93a24f8cbf6657f8cfb2acb881d77df2b', 16),
+                    gmp_init('0x8bf8030709888e9e2465d82d25bb3e3b40a477e0cce387da746f181c2eb977bc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x99044d94b0ea01f423c5eb9c5ef4ee9c2e553f13f9bde06c4009441d9e338a76', 16),
+                    gmp_init('0x8de5f472d44f4998d7f70f75837b6a6bd0d24fc8082c6565a9086aa920bbac7b', 16),
+                    gmp_init('0x643c3f825cb5e1fe3b43f5a1e6c55d1a401fe537f3d44acb6a43aaeaf582f169', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xea6722bcdaa7317631759c6d0a936187c26939a699223841938487142341ae6c', 16),
+                    gmp_init('0xa87f564d787e148e1087cdf6cc94bca4b1cd6f415e44f76e516bb697664b32f2', 16),
+                    gmp_init('0x95bd52ed4d9c842f8fc8de1e278f7ea2c2a3a1bfdf6a6ec720f91765831cfed4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb0278900e0cb87a73aa40fa8fa15a671e828e508b664f96b74f84eb71fafce43', 16),
+                    gmp_init('0x99b2262b8bd73fe2b023dafd7620fd57d7c72413c435b08d40e71ca963d9d742', 16),
+                    gmp_init('0xcf0c304531f1d8169eb648b3bef2eb2d353f011e6aa6a18a778cd35f28ec5f85', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x65ba2244bcbd18534d7daa5fa65a39513212145943b7b54080157d4e0ec7d2b0', 16),
+                    gmp_init('0xb1a6a4b6d3f4f970269bfdacae5c0ee0fbf67c747d27dc03aee294aa38ccc7ae', 16),
+                    gmp_init('0x3f0f8d9e007fcac886c3b967b11a476ced51303a9321a976cc58b37479d1e5ac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8223ef1ae16b18ea53530f8cd93aa26bcb3ffee15dcea76c5bd2aa6a94acba0a', 16),
+                    gmp_init('0x88e6aaed433d55769efb48a413aa492092aa14d84cb36a8ad221eaca24b2642e', 16),
+                    gmp_init('0x8efdf5f4a2f1aa2ab3512b623bae8744eb64f3dfb445272c82ab661785ebe7d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x94a38844f574a803f990e12fbbc7a01fea617ebebbda0c67f394a5554d1b8880', 16),
+                    gmp_init('0xb9ea767c91ac5212d3efa59fe4c30936e5219e91776b1880d1c9edb2efe9b0cc', 16),
+                    gmp_init('0xcaae496bd3df1e9e36effd9224ba9721bc93f4767ddaa586d11f7bb614875b2e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x56d53d1c3fb0bd73af2c91116c929bb15c1418978ba1d0e30c872506b32d5c84', 16),
+                    gmp_init('0xbf874ef2eebde4be7e989410a06b405d0fb85fad968475a33b85029e23d1be0c', 16),
+                    gmp_init('0x6342dfcbaf1cb56a5c4c6b4ceba0d5a5483f2305b1d2547fd3abd3a83a612231', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d104a2be319647306a32a4392d76e21210c2d665ccd7f5ed48a0273d0101f53', 16),
+                    gmp_init('0x68d3309e17a6acb480e6e5eab0ded891d522f27d1be94cf24a8f12657c678160', 16),
+                    gmp_init('0x37d181862ca7d4dce57f8eb4597f5598d1770c270b02472953edf1a126bd9785', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x40e2b179aa318178274998a62942e427f35b178651d02eac185a505cea886bb9', 16),
+                    gmp_init('0xc13c776dc98360b70095f9cda4d8438c244b588814ede1788745ff6b437fffda', 16),
+                    gmp_init('0x4acff9fb214059bddd180d68ba28c94ae4c1def74876f251f247b422cb3b3bb4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca63a44fe35bb110c21e6b4071d65c7f7ab353622108c36810e533c67a9b380a', 16),
+                    gmp_init('0x8b5f624f083a326d2c274eb4b48cbf15cc9b030e73e24c47f904d6ee0f9ecd5e', 16),
+                    gmp_init('0x8a20e77df6e31193f080975ff56f87f4e4aac314d90d55f888e21e1396c5d4af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb6e62eae104c497be0d2288b2a462ffdd365137793fef00cb69eb02b7928ea54', 16),
+                    gmp_init('0x274ad07ac8278f5be858521336d283f1d817cbcfeb23eb63497ece9637bf811f', 16),
+                    gmp_init('0x8e4b5e5da2608d6905e0a029dce30ee89306ba6aaf022916b01e090272e9b260', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3d62ecd5c78e81fdd7be8174f6d9d7f1b37c211ddd70d6ed6c0709018107e68', 16),
+                    gmp_init('0x768a1d4196f1e50c7d8b0d95b595ea4be509a29a858ee0a7a87f900ad3624847', 16),
+                    gmp_init('0x4ebd22a26118062168f7c9d86b40616bae384c14f41c5e26d1368f9341c7ac63', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd05844c9d7fbfa69992aa093d80648d36bb6773770b29965b36a1619e49b04ac', 16),
+                    gmp_init('0x2bcb26bafc80b2dab8309d8d21bd30de6f3e6076a349cbfd22cba33853ffaf63', 16),
+                    gmp_init('0x357b990fb586a2bb247733a70ee8e27ca62db68e80b97bde8f309c1daa0edae9', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x7619069f9d69bbfb8623967e3bbd69a23ec9b5b531e54b36689058490dc82a8e', 16),
+                    gmp_init('0x939bf2d7cf156e761d24135f0599877754839eaa043490959860d67c18bf6ae5', 16),
+                    gmp_init('0x34689d84479c5527cd6dc61109a6fa3d4fd2d201d96dd5b60c2a37614b236268', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d949391367b1192e396fc8df548350b6724f5450b125027be35d6ef1f46c421', 16),
+                    gmp_init('0xec86742de0cae77c0c6d6757ce5cd4745c997c7d05e3cfd9998f8ceb891e34b4', 16),
+                    gmp_init('0x9fc246a6314982ddfc265d61c7546db00564349ae7b36efa25b1d756d81db387', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x13e6b36c694547774e761c0ccab1d305a963674a4463a85bbf946519a07afd40', 16),
+                    gmp_init('0xe384ac6eb98d1c03f1368c29a9adef151aeb6bedd8ca635c2574910f8123dd2e', 16),
+                    gmp_init('0xe9450f0af021e2ae634bb663b4f59d8fbd26ac05994be3c606b5e258dc110387', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf4f05b2132e093352fae42d3564521e8d1b224c33e675cea69392f0550bb4dc4', 16),
+                    gmp_init('0xe4b76760ff85c8f95a0854e0a91cb34b7b1d95af567c2ddd50170fbfcb2ffad7', 16),
+                    gmp_init('0xdb055b2f334fdd0c80aedd9bb2f1da08c8354859bbfb60c5273ab95c154b6d78', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x912754790e5ce37bed6a9432a134b3ed3b04f10cbb5246472393cc84124a8b35', 16),
+                    gmp_init('0x610d0d32b2d5bc74ea90e922ce208ac0a112e73fa4eca7d6dc9e37eb0cb6665c', 16),
+                    gmp_init('0xf2bbd7f8b0b444708a497e85478cbeaf72a7cd25046047b92e6e3a8f8ef6f961', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x635338834bf5be866e3eb91ffd99fae1149c036bd98f4ccae4522388af3ff045', 16),
+                    gmp_init('0x63c38269dabef84fb87fb897cdbeeaf864783e698dfd6a125390348e085deb3d', 16),
+                    gmp_init('0x424ade3ca28aa0767f34fe2e4bd729da10b297a3fec9e74813263e737c262462', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x69ffd36b34c1d971f72bf84474fbcaa9996147ac1877d2180f05936ac2ceef6a', 16),
+                    gmp_init('0x4dab4a86f3d320bbca729df7f863ecb5ed78824489c5d75bfd95e876e897d654', 16),
+                    gmp_init('0xc1a0f18965a12125dc770313856945027e72fc2adc91968f15970ca731d7a498', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c974cddc5ea368892b351d66a7a04695ddcd50bd0b828794632a9f88492360a', 16),
+                    gmp_init('0xbbd22fed9ea702f21ee8b16ece3c90c80774e21d40712c3403d33a37ef59b185', 16),
+                    gmp_init('0x342565db259b6afc6debb6d1becc830c1045c791499b29cf54938c7fdfc91522', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae986892a1b79264f4b181c18288c868baf3b7ea3d91781f8050fd6084161b35', 16),
+                    gmp_init('0x981f5a446627bdb204151f50f53675fd7ea9b221768d57da8707ef60c763d24d', 16),
+                    gmp_init('0xc3ec54cbaa387f8a7bab02cc52c75437347041906e97d0388bf1d58c5cd6f98d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8541dde04c7615e1fc66b56a8fdc560e0f09b781ada13cc1a933174ee84c4ee0', 16),
+                    gmp_init('0xacd4207d46811385b2453426cf4dbe5e894ba664279a4342a3dfda775cf9f00d', 16),
+                    gmp_init('0x80aa1418dee76989789e0c6ef1c210dc2ef1fcdd29447f146cbae5ae4c56a05b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc37dbb0598e10c727af70f475bc20e351886aa2d29c4c43011b0169466cef88', 16),
+                    gmp_init('0x3921179285fffe180aa9de61d2497c23e3efb3b89353efd4c8c14f3bbbb2f6be', 16),
+                    gmp_init('0x9d2cc0950db14472f288fc4708924f095ab42eb4371aa8fca35a9a260f6c04e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbb3fda62df118e16955a7f7155e608238840a1066c0b61f967f4a5ac87691a08', 16),
+                    gmp_init('0xe37987b9d8e956fae25b9ca276c0f5b6911bb6600c3f9be17f9c649ae93e0a7a', 16),
+                    gmp_init('0x19a61b19c3c82f9a0dbc0c4413bcdce596590d1239b997ec042fac6e0e0789d9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x79029c1f9215d5fe066ba3f7dcee3280a423ec2d0e2787d29070774804f5f9db', 16),
+                    gmp_init('0xde72224e59d70b7c8c0617c756ba66845232335bc7f8d1fa7fef28e8cec100e0', 16),
+                    gmp_init('0x90a3ca58c3cd9376c2053a56b338cf1ae94798fcdca42c4404c3269b3791bdbf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55237112cf46c6b11b41fcb8715b6abe74ade05bcc878063729e73d223bb6fb9', 16),
+                    gmp_init('0x3d269a3ee1badaf4dd04cb5dd4762e802c95c761cb4d05e07814b8faf748c78e', 16),
+                    gmp_init('0x33d231101fa4fe2b0e4b9fd1e38e3141ad8e5d7326a5b1f5d454accddcb360f8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf77ac8ee07c7db12b8901eb775c04681f8591bc87c0d8994ab8c25d7dd1e327', 16),
+                    gmp_init('0xeb1a19c1917f47f94fee0362fd4a41d5b27369f5110a1c816acc0b7460eb0a0b', 16),
+                    gmp_init('0x322b0016927ed6dc87fa34b1add8b4f983829ee4825a495b4320b2e498fa2b5a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x3833c0cb9b52edfd67db2a81b5027202e1ff223009e58a2e8f3e36235b7dc8bd', 16),
+                    gmp_init('0x8091a25a4eb478ab8dd2ff155ceeffc7e3c47269160902b78f05d9bc4a98f5cd', 16),
+                    gmp_init('0x9e18fbee52c36b212c76abc7121e193848646136ac6936576e424135a4630121', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa8b6c2aec965f6f911367c7d6da45d4304b7575bc9345fe2d1cc41be57d2f039', 16),
+                    gmp_init('0xab106b686a6b60717d26d9a10c0e24277a07c91cddfd000da167ffae5219473b', 16),
+                    gmp_init('0x612a436e65bec22b7e3d83924b0ae5e603af40f85920340d7b5982cdf49a0aca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x77b2d81847ec84138d0711e5dec8189cb3fc7617c3629c0f01ceaaa9e52a8bc0', 16),
+                    gmp_init('0xa7885cdf472a3ab37669e6f8ca18756411b3d59504810ac5aa5f49f5b51dfe10', 16),
+                    gmp_init('0xde8ae5c5d6ff6ed6cdd62a680eef270b070e11e6681729954c5ce46215fdc80b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa11f8e16c7f48e780bdcc1b6b30e2fb0cee4ae6af9bddc9a2973ac97e1edff62', 16),
+                    gmp_init('0x97fb25292d7420b3a1d4f39e0c99bd098ec186f6b6bc9ebab257afc1c8d30e38', 16),
+                    gmp_init('0x3feb44d5829a6405c01fe8bc0178f74520c05d60adb9bfb28d0183edbfb821c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x744a91681eddad4c19156b4f3076dd0abda365dfa7565a4320b33c1af2c854f', 16),
+                    gmp_init('0x755c88fd264fadac7f5c885538ea736691929cb77cd5c341be26ebd696171780', 16),
+                    gmp_init('0xc0d5af8bb46ef3ba70cbf0ab225fc628707568d42faee78566688146f82b39a4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x965a321a9b8210000bf16b2f1975b22b8869e6b8e5669248bc6b9ec9b583fa7d', 16),
+                    gmp_init('0x42539219c1f69a5a7fb3e2f8429dbd480c2b401e37569c58f420bfc85860c1fd', 16),
+                    gmp_init('0x6940d48c5afe9bdbfdaedca9ddc16f0e2268ade72fa69c98e5d6936cbf244104', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x915ddb60d412fcb9eed635d3172f28c7e3c36b2a5f49d052aad10aa1ce4e20f2', 16),
+                    gmp_init('0xf789fc1d687278ce97fce8ef89b21c6bef186086712242134be7fb2c7ad40871', 16),
+                    gmp_init('0xdab29296d17e949094cacf9513e300a25984f2561cf7cc6f602d319d3dd77ceb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55ddc67bbd53105af240da8e7f26a876bd2bc71cb627395084be413f86214e25', 16),
+                    gmp_init('0xb9d34d6bc103b50d59ec17ad727549173a900bc080b76e87d444b4baa738766b', 16),
+                    gmp_init('0xc8df594698b7b56f449555ae687e824f40d8eba7654f19c23d92446dbdebc3ad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa575b07f4a899fc79ab0bf6b68ae240b4780ea9a61f7c9f19a74307cbb49ee1e', 16),
+                    gmp_init('0x1646a6c7f47edbdce9d06cf1fe66a646a06efa7566b60a03710968cc2e806a28', 16),
+                    gmp_init('0x72bb4a98025d9358a6690c4b481af265ef1e8b182d034875a572dee871e2bd58', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeff27b16103ace6b9d67da35c16c8fac73be6200e5d11d48d8e96d6dfc7f5d4a', 16),
+                    gmp_init('0x2e507e4f75c97d42ace5be36c4301bb0f86ec0720e10889db465cf0001e03330', 16),
+                    gmp_init('0xe8407da51964fd1e05a98425c7ae3c612cf710aebb4127b72333b3ac946da4b0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6f4203fd3b7bfc11a50a8be3be195889829a31449f0e06afa4e4201ad291532e', 16),
+                    gmp_init('0x44e6c706d38859c52a686f3dbe7ae6f9a60d6df3d17b0dfdc7f6e254ad9918a5', 16),
+                    gmp_init('0x13d2f145dc08e885dc74c7dafc7e542a45ff6980cbac57a4794e9c106d9aa011', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x31354d3e658f274ddb05e46cd0da1c0c0744f9e12ec01e75f14cd9e4201d2d02', 16),
+                    gmp_init('0x79e4f319d8af9456715a17e7368d73feafa601d7cf25475b8de51ddbffa66092', 16),
+                    gmp_init('0xbf5799e6b6aade0b06524fa02c4283711e8ba76d163e59b0d986e9c3f977ff6c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb4d3766e709bf300effc828efbca27227b361cf4fa1227ec9c4c801c37eb6b39', 16),
+                    gmp_init('0xae7044d9dc7c2d941474f84db995ef35696bd5b6f1937434ce9c911173a05a29', 16),
+                    gmp_init('0xdc9e99a83887ae8c06e29806d245fafb375f22467d3d907d4a7a4bec50c101e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2caf5eac058bcd628873fd2f967c40b866a457f91aa69179382e621782406f79', 16),
+                    gmp_init('0x341509c6d516243c24b837b01d9649475c72c5d83aeaa70c5e2bd93ebd9b40fe', 16),
+                    gmp_init('0x91b77c76a96f1b457caaaadd3e228357fda13450d139b947274fbc7898c18663', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x670c823a396faf4975d83e44b1e99d932254f1771d1f522eddb305050492d5e4', 16),
+                    gmp_init('0x37017bab13d48efcbd381e77462ba6dc2b439953c46095bc9fddde8edc8c99c', 16),
+                    gmp_init('0x4765689ef1c4f2f45d4164c96b7cc827d993969e5558f00d94f999fe77f5c3ae', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x32e07f5c7f3a704db58379ce9ee101911985c7945bf95d83c81b86c24fd9a71c', 16),
+                    gmp_init('0x4830d437ff818365fa6df71a031e77b8eea1c49fe2c872f6f4c26551be89bbdd', 16),
+                    gmp_init('0x724a8db0d7cd3c319415433c2414862719b26ffa7565e9f089dad7e89ef38a8b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x179de0b630d6da74bf2710fb5bfbc00c22ae40a0bd65bcc94ad843d4b6d8752', 16),
+                    gmp_init('0x9f067f7d756638bc6810c2256aa6b7fab2fb5464e07aa6980a7de920b0a59ae2', 16),
+                    gmp_init('0x1636d8107661a301e556eaea71e2430ba491c88560a0ec170532814fe5e69748', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x30139de2b29404b97e457b3a1d3b3bfc64fef7e70806efbd1442943678931f4e', 16),
+                    gmp_init('0x47effe3c0cf063d8960f01d712a1f17081bb118a61b8a858872846cc304f9ea6', 16),
+                    gmp_init('0xa8ee56fbf92c4507559276889c75d4d5b16259e739fb0684c88c9dd966df1e43', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x78d90a39fb8bf5b7303a9944e37c001da0fb7188115b21e684aecc6519813fa6', 16),
+                    gmp_init('0xd8836496d8b0ee7273a407a2042c7e9ae0139fc2c37057abb179873202c67be0', 16),
+                    gmp_init('0xa53555c1b0c265b163ce7a41b6239503a7ffce51e8180cca1731faef91def631', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xac5952f563e15bfe31bbe5ccea3a917d04ac20224db7d1cfe19997f098157de', 16),
+                    gmp_init('0xd1ddd3027e5e72da558abb2dcbd26de6d2dc459fabdc65542e3a55cf7f6ed2da', 16),
+                    gmp_init('0xd30fcefe485a4db37dee2a906961dbf7bb14008f7e7d611e0cc63872f9a2575c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x218839d7be3cad307add2b48f9702ef00c30083e26d346ef4fa883c70484f8d1', 16),
+                    gmp_init('0xb85e5b67f8062b187dd7db58e418ade3933cfaf4858c429aac32c962d5ada566', 16),
+                    gmp_init('0x3c6337610a5c74b0b6419c60098f536b20b888ea79a4b4c61ab3f9a7cdcdd18c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcfd3dc540ddd49055a9bfce1399ab36b0ebbb2021d2c6e1da2fdf52e20dbe440', 16),
+                    gmp_init('0x4aa6277944ebe7da54d0fa048f571e2be74e87370f91627f4c9ece1ae4aeb8da', 16),
+                    gmp_init('0xc42fa099ed76b8146760af988fccdec69ea7e857354d6bcf2752d282bd26638c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc6bff5af9e360edce16cfd3675066e3a3907484447a5e5a914aaeb75b14d265c', 16),
+                    gmp_init('0x17c45c2511e832652130b79ecb6e7bafb80e5fe0b024211cc5ae2e0e74164719', 16),
+                    gmp_init('0x3f04ccdfe2902745884d89276837cd50937eb1d2e6c135242a4ec9682f63fd97', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x450ad9df5c7441d76cf2c4797f1e3837ec02adab9c52be5d467d583fd7217f02', 16),
+                    gmp_init('0x49f43f42e7364f47c398d209d0ba8ce92c9553f8dbc79d0e1d5fdf265e7a3ff9', 16),
+                    gmp_init('0x3f445f4f6f7a0d0b0a504256153b50b0d7341e06e320f662fd550a48e19f540', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x488d362b74f50ccdf24e31898aaa77d30a53f57d5ef4720b8c1ddf9d81d98fb', 16),
+                    gmp_init('0x70ea4a17f02549704d1d43ca85ab3d8df919901ebfb835a4bf0d44d11e6a684c', 16),
+                    gmp_init('0x8638bc4af4836b83a4e459bf60d9ed36736152e2456954881f7277057423be0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x56f1cda026f7acd54af752a93a2afe72a69ff601ad3b0a599e0446855f3398e5', 16),
+                    gmp_init('0x8eff3ffdf5cba9deb86cc27aa53884e6fbd2fc0cdc3805b81091c504a05f9eea', 16),
+                    gmp_init('0x9ebc1dcb392fa1018931b1279b2a1e19169087b7f8373f1aea4095e2e20cf70a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x781550c2d08d52f6e2a80daaf7bdc6cda2fc25f4ed3da740b99d0dbf8473e62c', 16),
+                    gmp_init('0xfdf6d0ce2ad2c5fe3a561d05a180180f2381af930999f30e075fe88f2340045c', 16),
+                    gmp_init('0x42b39989aa3896b9b1041eb57bd9d0a46e22a5be39a12f1f771ef7c2f4b67333', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1ec0c5091162b1c112596cc24554a96f4da88d0a5ed3aa18e699b39414808e8d', 16),
+                    gmp_init('0x3730ad1a661ad4922d2e5527a76b52e4b229e6f6efe1e22b35f2708a8b397f11', 16),
+                    gmp_init('0x54545fa0be4f7e67fe935b42e3bc81ca669b3f198400c953138213b11d2a4383', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x21f50946f49e680015c468e33bb3138c8eb8c8980c8d160bedb61a33e77a9e28', 16),
+                    gmp_init('0x7718ac63696f113ea02fb6d9dd3ad8c2c30448fcdf70c6a44f78f319d6e26d9d', 16),
+                    gmp_init('0x82cbb2c7519a7fadffd949cd8220a2d430043415035c5e6a692c4dbfa3461f8b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2f8292e7569d95c801b7b0374ef41847299b85cd4c6e6c5071bf460bb0219c43', 16),
+                    gmp_init('0xaf9f5847ac2e01a8437e29497193ffc2f4462a557cd47c2faa9f1ccf229876fd', 16),
+                    gmp_init('0xeb238d9e390617cfc028518e670d19879406375180861a2b69fd78bd22ef0efb', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa81f53cec7f80450a8568ee7e06b01d09a95ad380fc9ed97cf693f3386c34147', 16),
+                    gmp_init('0x1ce7daf699b8fe702e9489cb6e8b57f939e7b09932fb726577dc709e09d125e', 16),
+                    gmp_init('0x84adb08cb6a83b069cf6365b45478a1e3c13adc1027a09d3d75dfbceb98c0eb1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1bed98035c1bafae66dccf4604af22c8f1cea606720bb43f129ea1345607a15e', 16),
+                    gmp_init('0x4189bce2913d1a5437cf5dcedcc0791c7ad597a3899b7de833840f304dd4c9ea', 16),
+                    gmp_init('0x2de0fd2b44089562f51a68a7ffe594a7be20f2c699db9ca9a36774acc376f751', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc4007e0f2cdf8443590ded647d7d818ec3c940215a92857d0898a4566f2b20e0', 16),
+                    gmp_init('0xf60f6ee21c06d7473f8b1df74300d8e2e2bfdf4e333c649a90d9002a8bc1f0b3', 16),
+                    gmp_init('0x4c77d31b90cb3bdc355d20fe8a12e1251f98fef12c8f2c8da1d48ca01d5864c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8be432c64448169a2a3b48d781ddad4ec3dbbddc9f31b9be68720686a89460', 16),
+                    gmp_init('0xf09b2363badd1b837c025bae474501964d2b87105337f6913e1003e849fad134', 16),
+                    gmp_init('0x5abd4749fb7c22831dce5a47e9abe512aa0477c201fb28f02856dc353997b8d7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x671ba9d644961a07440542ecd38bdc309b8e5ab8083dbc637b98dfe449b4f795', 16),
+                    gmp_init('0x86adfdca66a5d26c71e70e7e43537964de23ef77c9a51fc73cecd0324e7038ba', 16),
+                    gmp_init('0x6b2783cc01b85dd3045f466961fc60653423ecbaf393aa968d0e3458dca338d5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3adc8004121dda35d1c6458b3cf8a043761adc614d5883a231deb2bd29e910ac', 16),
+                    gmp_init('0xe979422343b1df7169b554e5e3598bff179ea07bc4fb5e25a7aa120f3390b76c', 16),
+                    gmp_init('0x77b4c750f91720c2b5ef2d6018509170a0ee189782683d0c2df3862007265320', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcd2e4f3657a11ee3f4eb069c7d7fc2ddaf11e23d0a48090d2721937f7148c7f2', 16),
+                    gmp_init('0x3fa55535be12b8cd8cbc872b2ba39e65a9cf3d5c893b7efa94b8ec7843ae292d', 16),
+                    gmp_init('0x4ae9601952d7b1c438c34c85987c4da9869d9ba799ae00a72bb7809a2f160fb0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x454eb72cda43340623acd794337bf133623a21b5012d79780ad317b7910fad42', 16),
+                    gmp_init('0x70de0ffb34d2a12f3fbd3fe065021bcb297364cea29aed08a46fd948b8748f9e', 16),
+                    gmp_init('0x5fce2cb0e68e38f015fd30297faf5331548a91409405c8cc81d6d957881eaa7c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27fb28f2a36d2e471ee6439d035c9d7daf5d624f6a1abc0bbf4f8fed8e0aae6f', 16),
+                    gmp_init('0x679a1729788a52e0eb7d9745495dd545886aee85339ee9187e617028f43f2662', 16),
+                    gmp_init('0xde9b94dc41c27fed186d666ca7998159804bcafd9097311b5a23530f545ebdba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x70f7595f3eebb6534e950c2ef5373b3297adf011fbd0ece95523856692d292f1', 16),
+                    gmp_init('0x53db38ed5387d02ec8686f3acc8692108411b3185fbb467299850bd6d95ab36f', 16),
+                    gmp_init('0x90f7a901028a900f69086d841ed3b391ef3d5ccc5019b0610bf1738f7983bec2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6004f9b5dcc4f131e92f466fa8db50d861e470ce9c5a5dc3de77f8a0bdd813ce', 16),
+                    gmp_init('0x857037b866fa2d0144401c5b0fc7124b6876205f7cd0517cd49673e474794e2', 16),
+                    gmp_init('0xa558e9ea445aa393c0681721b385e47ba9316560168d3b955f55a47b25d8a87', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55f058aeeebda32fc2d66ce4bf9b848b5ac03bb08d585e9793b9ff7ea52a73f1', 16),
+                    gmp_init('0x3d67f18f9bb36673948bfd017eeb268951a70d0c26a24994aa26f6ddbc883739', 16),
+                    gmp_init('0x5c1e470411b249844f2931cd348f88ff8a83706ab703bf7463832bb771994a18', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8f666e1585099f2b6d8fb493e0ca63b2bb0c01ea40bf69cdbae6ec1776435b66', 16),
+                    gmp_init('0xe50d0cc662c31ecb9abe53a2b5c590a4bb6c9fe3a7dc0e032a43500117ede6dd', 16),
+                    gmp_init('0x84dc0f9e8494086ac7ddfd46856ff2815bf3bf76e8012e333144aa52cb41994e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x72b0e13d036c59c5236b6f5269e36e64b8d87807e4dd4b880f49ddfeebfdbb01', 16),
+                    gmp_init('0x304fcda98a4209758078448641ec9c8b63badcba9ff26f864effcb164b941970', 16),
+                    gmp_init('0x11afa172cab1fd89ef10e639c805c8188fa00d83d039a79c1c5b049ee4df6da4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2f94c0f0288aa9ea01bbd70da6d46bb9ffade3720761e7d6d483fe5b35e15433', 16),
+                    gmp_init('0x3d30b77a43c27b78b75dddd2195861f1a5c1326cdb2ed44790de2a320d9b12ae', 16),
+                    gmp_init('0x16a699665f9e62a47aabf77c4968bd304e4c77cfb1aee3459545f1eb9e522d28', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x4560c9e388257055775189f1875d93a336552d84ce3aaf9f69d19edc9f3d8456', 16),
+                    gmp_init('0x1ed575397ebcd3404662ed321110eadcf5aba237f021fc3f13e2f35e9f078638', 16),
+                    gmp_init('0x814821d323ddf9b308772c278ad9f4baa0d90b7a8152f48e0b66f629e5608e2a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf2b99691fbac359435f074102ba43e267a96b04449ce54b76466dfdbaa34acee', 16),
+                    gmp_init('0x48536994d95249f68839f3ab349c9c0ac7dfad887b85945ebfb88be69a5bdb', 16),
+                    gmp_init('0x1779417d4a4be8268db0df6895c274803380bd34e2bcafa3f43fc8c7f739ae7d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x75b84ab079a30187c72d9ab13bdefc2c8e38818f31e659596fc548be8afc25c6', 16),
+                    gmp_init('0x5deec66fc0458fd573d5802b6c91557b8bdb39aac749651d6ae88183c74fbe45', 16),
+                    gmp_init('0x91ba83a5fed53c2589b5c5bd4d632f99dcf8e3adde66551d3450f913dd1c8c2c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7514cc96cb18477d9fa058fe313a7115016201d407e94468c66b53f6b9ae1619', 16),
+                    gmp_init('0xe76f4d42d59e67999f83a6d9cf5af4778cc962cbbbdac8e65ee9f2abdf5c3649', 16),
+                    gmp_init('0xbeef4dea813f873f6dd97ef5a29facf31a2d80d2f226260d4291113478f10ddd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb4f382aaa1378430ae84c5b882079d3d5a2d99502847bd2a87e6e9f2bfba268a', 16),
+                    gmp_init('0x560b6af186e076ee015afa6a3b5ad257be894a2e46e02c2397d71bbb58db07d2', 16),
+                    gmp_init('0x337589cb224ad64d0ee01de8faa460e871ab1247057a1f4579c833271e9d5f1c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x714d41ea2209894bf2a07f3301f4c64ce10e2861b79142fd56d4d5787a211abc', 16),
+                    gmp_init('0x21b96e5adb0420cc10fab5c2ab99a6af67a920462af374603b8fd80b07c00679', 16),
+                    gmp_init('0x77a4f081194efe94d4fe0ff2c4c88dbdeb6d57429e4245dcb139e521d8957e46', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd906c4ac721bff000fb04c85c51919be96a906f5004201a6585b901c2d1df1c9', 16),
+                    gmp_init('0x389ff89a80190c102578f429fe82727a0245555649e2504de39ffc670fccbb96', 16),
+                    gmp_init('0x87c9e8aff8251174ea68187301a61d07ff3bbb6aa03305a2aa3f92d692ece13', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d75d5da2994b16bf67695c7c2c36693566184e4694e5364123af3903b260a07', 16),
+                    gmp_init('0x270cb73bd9cdf16e8be78ec7064deaacb7380ff62a6330ea68bc55d8192798ca', 16),
+                    gmp_init('0x627b05071e2739a8cb2d806621eb069361cc871f2056709cc84759759da5c76f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7fc1d3da5165bfe129f957c2ef6c011f7449ec7d25527e3f82c699332ee9fc0d', 16),
+                    gmp_init('0xe02f793d3c49779c50c7a07180972c8b3487894d973f2e1eca3fdaa2c4ba3196', 16),
+                    gmp_init('0x9f13a61fa491020a0d9f7a5c431d22688e245f637c1da4a10b261fd42eb9325c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdcb97dd792f56bcf3c1cfe4c1b4ce89441138b990b52ef9861c565d1c8ba6540', 16),
+                    gmp_init('0x5c84074a14539c62fe1a05fe0f9cabd383eaa4301a6dda8be7f62c4f69e9feb3', 16),
+                    gmp_init('0xbd804385b94dd9d43cd468e655c66f25fdb5fda6347b5f05ab4cff91fd2a38b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91018fe2c5e5703e8e19ebe4870e6856f00034e728b68f2b7a9b019c2c377803', 16),
+                    gmp_init('0x5504b706699380019354b70a28308375a0d831ed24fec6f65e52b687c0c1a0ae', 16),
+                    gmp_init('0x68881c650501bcebc8dd83753850bf228eea5afe76eba14172cd2f3f4d68a5f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda19b65b2186c6009f573eaa2d34e6a27c1d5bad8d12203256589222d3991a9a', 16),
+                    gmp_init('0x66c9c4b2b3cd057d9c865a6375541fa7db2cc156a8057ecb59314e426e90e8c0', 16),
+                    gmp_init('0xe3b69f01f9a7ac58ec99919f068f100554d463d546e4f88cadd4d3b38bcc295d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x56fc64ff00ce0ead7571929921b17600456c90c3d65e61852989fa920ef7c7b', 16),
+                    gmp_init('0xd8924a17e45d3ce1f99d509b79d44dfe0748ed7623724848410249c4bb7e4966', 16),
+                    gmp_init('0x8236f339436e52808641ed1ce0a8fcc700786837e2bfd4860db0cf792e512c20', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x310635a131362885e9ead6148de7680f75264898db2cf635ffb048628f6a2856', 16),
+                    gmp_init('0xd47d873fe94aa1b5701db65e5839241339bd903294b1be55e6e39a9e8ce8e06b', 16),
+                    gmp_init('0x401755a17dc46c8736bf9e748ba3b91d383760bf0b830d16fe55b30a46c5dcd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x59c7a4c2fe1f3094cf6e8c9c3a662b1b6ad3a036a02a5e6055132a23e1d4d753', 16),
+                    gmp_init('0x47f3a96ebc96c85cee7ce6db0ef152b632d3452c9d720a489193064bb73d2dc1', 16),
+                    gmp_init('0x450955ca842089dee99ced1cb2f45bd03ac4219ce26c4f0fc34219e20807bb38', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xd76ab444abf7c430fe6c065ec377a46141eb3d0b792eca8b4da412e6c70cc528', 16),
+                    gmp_init('0xee11a4bde7b6e26250335d4204598fc83d68189edfb5c06b5260fcefc1e5bb58', 16),
+                    gmp_init('0xf261a538d15257ccf8b9668dff6ab5408b8bd213fc19e13e72d59c38bd0dc7f6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfcff6bfe069e87a5fc2ed8d36c9f586ed23cf637bb1cf798d49b9eddba2d8a41', 16),
+                    gmp_init('0x2394b5c041dcb1e64691197c82e9a5d7f6fe40bb44e0739c90c1aecf3d1f358c', 16),
+                    gmp_init('0x7cf4dbb8a7f1d4d14b16121804eedce159908d6a589eb9d94580d1a4a7d4a75', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4bbf46c8e5a1e1c4a653eac2e47b74019b9b229a03fd8832b88ed24fbf330521', 16),
+                    gmp_init('0x240571aa14ca783e68f53eb9b47d62bd9dfb2d85a7f569b0e363e677478d64e7', 16),
+                    gmp_init('0x20f2f1f4e2eee6a948d9b95a773822156b78095ab210c187033ebd182285c205', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x46bba293f5a3b414613b6019fae0aba968bbe7e8845877d0f5cb8e88064907a1', 16),
+                    gmp_init('0x243435add67d8520b9838e7e6dff942dce76b773523c5740e0c96a679e227091', 16),
+                    gmp_init('0x8309b431a4678f74df9477801c00255f522ca8a1789176123fb3451e10fae3ef', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x752d89808f1445cc888a07f368a58c525e6c82bf50b10ad98b5bcccb53b6814', 16),
+                    gmp_init('0xc738f6206e7100f8f6001c23098435884dec16a5ffe63f08ad042c9f86c48412', 16),
+                    gmp_init('0xe2998ad382e1c1bbe5c844609a1d13884ed8e2a06468679f7c22a893640f01f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd55d04bc3386809569522db23e5140b1de88a60962a9d42cd74bb601bc39338f', 16),
+                    gmp_init('0x270aaea650ff122d0115627154f3af35d1d875f10bb0d59898cbc660b810ab98', 16),
+                    gmp_init('0xdaa60d408574fa3b52438d3532105a4038fa66ecf566d328fe1eeae677526b26', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x650d4c1f4b92b6c36bb497a00c06cd592f434664bf708fcc9e91e97fd5a56d9a', 16),
+                    gmp_init('0x4faee5a476ed2dbb30c97e8b61250f88723727f8d7472204a44fb18718b9557f', 16),
+                    gmp_init('0x7087bc34fa4c637afa00a0d8decbcb62854e61a51d026cf95777eb3659094bb4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x942ff6f1325a9df78e0bc4d5c5db18ed72ff1d37b3b479bb9f0b5d7171906bf4', 16),
+                    gmp_init('0xa1b626a0c3b6561a1ad3b686ba982f55d3b483683d38551bec277609275cc9cd', 16),
+                    gmp_init('0xfb69242ac5f5d2e90922dfea5145a9e7f4e9d08a671e4f020a7533235f54752d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9df381b2c7efb506856844c470d74128378d6cec17ba5504add04af280f2c8af', 16),
+                    gmp_init('0xb5587629fd11556ffc7383b756f4003d4d8d8fced721c132747498e1ddeaf39b', 16),
+                    gmp_init('0x683fb32fb2c780cc6a56cd038e2221838114b0a84c1b9708ffeae858515c18cb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d49e027d3f7cc1f6f255ef2d82319011110b0b36f1817c91a4a729078a0419d', 16),
+                    gmp_init('0x25ba95e82df136d60c148be6a85ff9d8c4156ea1060c7aa687ad83d91e97def5', 16),
+                    gmp_init('0x29e437041bf246b2d9710e75c6e20f5fd8734156b0478b83e5115c49b66c8a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa3a6b9470e79e3c25fbd7bf1390aef1f8ce345d491c6bf066115afb3ab3f17c2', 16),
+                    gmp_init('0x34715d51d40c423d23975671d1360adc7570d1ed6a92e27486dc0c693146950c', 16),
+                    gmp_init('0x8a3a20e67992bdace9bd1d92a1f1a994e221894e351177f7ca2cbb2cc3f4d5f6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d1bfc8f12ec1e447c1e1b781ecf8b4d40775e8c6647651a81b4f54af5bc0a14', 16),
+                    gmp_init('0x499d8eac06e55ad4532388799161da0bd28fd52546621ace44398d5fb248c427', 16),
+                    gmp_init('0xf745b66a769f8956db7a069d7e41ce8fdac43f273d41e75e903592378377cef3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3515432b9d1a4af6d78f6347a94398ed149defb684b6bcdf1325400bce601ac', 16),
+                    gmp_init('0x662699858e7b8f99da07b7e000f664d694018329269fab245dc7617c824a1243', 16),
+                    gmp_init('0x13b66fda9fa559aa95e778002b4ea6afc3bf88dbe31d8596fe2fced0664c12c3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x266e8763dc4c3335a2c096b4bc31460f2f195d38360bace30ac63e282802e297', 16),
+                    gmp_init('0x413ad3a65dbec61667ede8a334bd0f2d647be27ad8769af95571eab53a717f1a', 16),
+                    gmp_init('0xc8bdcef2f15854cc35c64d138699598d3251f3e5a6852b14cae01fc2c162a431', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdd731db1a7095511569a4fd9c9d227a175e2a9008fe1dd07f9f2b373705ce437', 16),
+                    gmp_init('0xae35d61ccdc99acc03b8372024c42436998f02f619d8168e1665d4f322750f18', 16),
+                    gmp_init('0x81f3f8a8086c1e2f273c802063b50fe4be9b723bcd8ab7ddd5b16ece40500073', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x931f4ae428a4ad81ee0aa89cf5247ce85d4dd696c61b4bb9d4761e57b7fbe', 16),
+                    gmp_init('0x7e88e5e6a142d5c2269f21a158e82ab2c79fcecb26e397b96fd5b9fbcd0a69a5', 16),
+                    gmp_init('0x2626dc2dd5e06cd19de5e6afb6c5dbdd3e41dc1472e7b8ef11eb0662e41c44b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc0e58b550d1b83cad0e9398a5ac9ee0dfe84f352143fee0c6e61e1f8441d5af6', 16),
+                    gmp_init('0xcceb44a1b482d5c506c9be9bd197b5f356c2e528d01f79e2f2c76f57c95991ae', 16),
+                    gmp_init('0xd2a8df2375ef95a02e14a58cba2630f5b0b44972e6d72d6fbe6cce707d86b022', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x43248dfa65ab5e70ef45402ea5e4adf65f04b81f8c43b55a08832a4bca1751a1', 16),
+                    gmp_init('0x1e71e282069cb0962f6781a1ee3ec411808c9a8458aba46187b9415d49a8875f', 16),
+                    gmp_init('0x6a2a703dd6fade37a3e7b43277b50c56abd295c6383a75e2982862334672a710', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x81fa3274198f188d2e7eaa0583306a57b7cb094cbcb1cc6147b6398bbc6136a1', 16),
+                    gmp_init('0xf3e41def1bfdfd6d1d5f5fca1aefcee53c36bb89d1ec4ba5bf49f983165bc206', 16),
+                    gmp_init('0x358ee2259d39902be8845d98ec296777d389262a71c7f2d34fefa1f4cca7dc7a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2cd64845d3a8a520773acb37069b12a91f06a0fc04e6f306bc3500cfa73a7b41', 16),
+                    gmp_init('0x20e4ae2c7d0448c0f853dc937e452918501e091235f5fae94e968fe275a484ef', 16),
+                    gmp_init('0xba68b7edcc0605872cfee46e6e3a8b568cff0dbdd36db7f50051593598db9019', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x634c5bed456c75941d5ce6e57f00b3c65d18b237a8e1f51bd8209cda3df34a3e', 16),
+                    gmp_init('0x289bae793c881ff1d26f9a6a542653bad7aa4a4ef3cbb07dd0125de8b4aff65f', 16),
+                    gmp_init('0x4c9b58c88108870b161ddb774535ffb2eff3a8e04b712485737aaf370e45776f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca00afedce5e57787c9b9001019a8bc9339214fb33b0be29da1d2ba741bb7d3d', 16),
+                    gmp_init('0xd75729f5b241691c4f7d2ccfc00353d344d30fbdffa63c4adf169096a13499ac', 16),
+                    gmp_init('0xd6d763c8c8bf6e756896072b2e82309d004c394922ce4f72e5b3c4b667e70013', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa55067e7fbd744323b8d9d1d3b5f4d4c0882bfd055420a2a449e96d216da7a1b', 16),
+                    gmp_init('0xcd703aeb058c3d46b8712e623ac0641dca73484b6e3b5ac7cc1eb2fe7973e80d', 16),
+                    gmp_init('0xae133f3176fb9a69572cbeb7b1fb4848c338274ac9e3dfd3a0b1b5ef21cb7253', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e7e38730beb3441af4a02a6b9a8dfb7f37050b6cf99d06bcaae72c12797bade', 16),
+                    gmp_init('0xd657d0229e5c2677f3c01e99fd30e97c691ce786a1ae7c750dfd2f51ab7aa3f', 16),
+                    gmp_init('0xbeedb5b2a33d5a633f21de36f5e3f024a78a61c48b5a3da534ffb0857082e59b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x671a0d65458edc624936a854182d0ebb96b37829a5e89a3ae8732d15427a1b4a', 16),
+                    gmp_init('0x2b0825f6895b59f54ccccfac2b0bdb95aebb2d2cbdad287622b843616b391d28', 16),
+                    gmp_init('0x3a4467c81c0ecca4fb9b71665e39a4cbe1cb3c910f92f63a614c46a688c8e204', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb5d13be5787d12eb8e03cd68492d6f92195b8008b092fb199d2ec3d7517f3e09', 16),
+                    gmp_init('0xf3c9119fe594576e1f482069f764b72408fd3551cf6a3c491851ac37d67efa0e', 16),
+                    gmp_init('0x99097c3e0899c95fc50cecd88ac9dea8c1e7a8b5262764416321a1008f4b4e15', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe67b7d8934964faa3ec40bdc303d5bc412539caaea03b4d0de9eb6ea3e0f285b', 16),
+                    gmp_init('0x9b40c37e62b490b36a605467db04bec5df13d1bece25cbfece1dad3b4612b5a5', 16),
+                    gmp_init('0x295f3d4bde09f9feb68448623cee7801085da59a84cd18ea7581e6883745fa7e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb5c5a4d7fc5e94c090a389d1eeabfcd4248b381f139a59d3f3a1f02c80c6f48e', 16),
+                    gmp_init('0x2fe8bb3242df152a89377548aa1b8f3b8793cff6c86f0c44c344e62e60a7950e', 16),
+                    gmp_init('0x12b654bac6916f997cb699fa0868d774a128c621303251677bf448881e241f20', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2bba3e22a47dd310d976367200977bb09f45baf0207d4402135dad65ef9d90c7', 16),
+                    gmp_init('0xf41c39628b194f556ded254442e91eaa87b9f8847a1885752bd8007e9f07d090', 16),
+                    gmp_init('0x81b66cd305be627b0d31ca2fd85299606f04069862866d58d85d5c587db2cd39', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9ef737f80b0da80be29defb212a358e05cb0b3a1cfd9848daea79b047347bcaf', 16),
+                    gmp_init('0x7b5b7ef1ebf9edeb3d83175ec74e8b37a8ecd03d1492771d6dd89e4eae606841', 16),
+                    gmp_init('0xc849753d8654a1be7a21dc3c806cd05a045b8889d40b3fc010855b2be768539d', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x204840d4474202039d3056c86c05ba5d40acf346c353756a1d09a560533d5a89', 16),
+                    gmp_init('0x21774599a4caafc9334ccc5656090c0e2c54fb7797d32ea8bb3f0efd8a7a99c9', 16),
+                    gmp_init('0xd61e5aec9a633d46c41557f06add0ecc2e59076aa716e8844b291fbd34c40b7f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5974d2fc0b36a25c6d3c1ced19a9ff2ee3f5e431ca8d4e493140ca2dfc15e82a', 16),
+                    gmp_init('0x3f77dd13a4d0be025f5542b02233b7064e8a2ed50254dd4c4c78f478f64a0a11', 16),
+                    gmp_init('0x58fa88bceea7964c7a324836b9fd0e16f39495673853d60542cffd3bac63dddf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d859468a7c7ef2ba784454830b1333c9363980a459a6c80df1b71c066f38dfa', 16),
+                    gmp_init('0x436f6561ecff8e64aa38e78d389612489c6f949d4321eeb9f737e74a8abd976d', 16),
+                    gmp_init('0xbcc644592cbaf8363533071753a49b45938ad2d53d66311ca61f6f0f47dd4a47', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe6422265f799d6c150ecfab23886754b9b5c1d15166ab9252f60f7b0896b1447', 16),
+                    gmp_init('0x356e16ec12e1ffa7bf33ca2ee191c73350a5bf3c2220904b8259f99900637139', 16),
+                    gmp_init('0x13e85a26e3a39330b5dfee7042fd0a483ef0d60e9effb2526f6d361c7025412d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x813ed37436c41ff1ab12ba47d49218d781c74188767ce61f6d2e3d22ae35b8f9', 16),
+                    gmp_init('0xf1523047b317e27ae29efa35beb68f0608b983570162b8861742894cf7108832', 16),
+                    gmp_init('0xded2291d25c373c90f51c41f67f52e4f65343415c6901c3b21ee19ae17409985', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c979b4e161f793a4f0c2177101a5ae140d30c4380304f26887ad0200ebee9c', 16),
+                    gmp_init('0xa25e9b0fa110ea59e0c1f4a020b85c564e27d66c05d1b9648dfadc01417d8794', 16),
+                    gmp_init('0x7dc08bd9be89d3546b0687ec140c0dc5484026f04d2f356af5af71d43092b76e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa0bb37eebff8093673fd2b2a15157f2277c95fd8f4da15a3d6c6be2bab69de4f', 16),
+                    gmp_init('0x8d9c6f2ec71a22869ec5eced8a8a8632b76f16c7b4adbbedb2ed6c4124122d2b', 16),
+                    gmp_init('0x9006afa632876aea540ee086b1a336da89fc1e3c9aeafedb9fe3b1d006aaec1e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb7dbe6c27e5aed6ed4517ee6d7bcec9f1e12adbe6a5e04bfe388b64ae61dab86', 16),
+                    gmp_init('0xe284930daaa9baf37df18778132850d65cc376b336a65c23169df4c67219b695', 16),
+                    gmp_init('0x39b0b6722e3590b7eac85935acfd0aaf63d08c3a8796e3214619781bc7f70498', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf52ddce30581e09fd2591a2bd1e0732f0626e383669805c5ac5d7d617370d9a4', 16),
+                    gmp_init('0x19b031d453f00022044ca5b218edb2ede93db3cffe4289d148fd4f321c41c47a', 16),
+                    gmp_init('0xbac5591477c5a3579eeb65854aefd37b5a1ad216c055634100556888a6227b6a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e29c4a1d63c525cd4d9dd6f2c28c34e253b18d95aa0707847c70cb75f9aa84', 16),
+                    gmp_init('0x25ab8bba2f86f0d6126859cabfe5b318b800b7d8cba239dd8e8aa4f502342ae4', 16),
+                    gmp_init('0x24b27edf337db2633b00cae2473a51905a89226375923deea77e87ad3689a25e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57f3dadb21cc58afc77794ef56c63f70d5cbc23c75cd34f24a2332578d7a1e87', 16),
+                    gmp_init('0x658ea624f6330e08b0984e3cc855a945d4d3965348dce9e7091e0c0b4a84dc9a', 16),
+                    gmp_init('0x19b9217720ace31ff178c92911d29fe2c5803c6e97dd2cc6f756134cf0e7daf8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2db3b3d51129ba19d59a87d38da9bfc3e188599a666de243da6bfdd4ede5d5d', 16),
+                    gmp_init('0x1883e3e1ac365ca3e3d1a4975250f0fac1d943e67748abdca869a00cceda96ac', 16),
+                    gmp_init('0xe5aa117c8ff58774edaa568bf8f44fc9baf49342d4761ccbafa1a6ceb12b6fdd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x207df6dfc421fde0d01f9ad232d710bbe94a07faf81eeb02be49ee8e0444447a', 16),
+                    gmp_init('0xdf9992ed9c64eb46ef0557d21ad55d3b4cdbcdae25dc31a16fa69e49377ac511', 16),
+                    gmp_init('0x2bef5c20c2714f0d65304eab3811c705443b6c8c4c39f34836dbaa69580734d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcae62c9d6d136e6e10d152299fb9036220e35fd87b13dc235e435006e24a8106', 16),
+                    gmp_init('0xb4dac4b9b2870f622e1ecf3e4deff08b86bb275d30e967257151f1b8801dff89', 16),
+                    gmp_init('0xe9ac91418bfd9bf385ed65b03c60d7cde28564e2825cd0ad5236ba200dc26dd0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe87b2df5ad78e41ee32fef326648c8c4f68c8a5f234ec40acd8bf5b3b6e2317d', 16),
+                    gmp_init('0xd6138664aae370e8d275c1d265da526657bf4a7004f6d04e58edce50674ccfc5', 16),
+                    gmp_init('0xc0d3de963ce7f48ce9a8077ec680cce13f31a9e9ef52bc7c2df1ce9bb1522d44', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x5dfaadd753136d6f5cb99e683b5abff1953160f2ffccb81d32d0a41c24cb975f', 16),
+                    gmp_init('0xef0b2a69b5eb161d0285c131619276ea7096c99cfa8f0c680562f8776bf7a835', 16),
+                    gmp_init('0xb1ff6fbd0526afd648e4af80ff5096fb0cfdd1f34843bbc81abdfb55692ad6ee', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5af872c19f6802ddc2e4b4b632bbb84e8ce7c8ba82ac9e0edccf9fff229bc1b2', 16),
+                    gmp_init('0x686aee9145e07fc5f158732d08316732ee09ff5a8fd500d754df3d8ec7ada8', 16),
+                    gmp_init('0x3fb57ad58d5e17c0b597e42ad3cba1d4b668df415ae1b6c0c62328080376a54b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf7f527f633ef4a74ae1eac8c901cc1c62665c939066b3ffd845f495788fced50', 16),
+                    gmp_init('0x96d7a1667dd9dbc3c548e1bb70a46157545ba2cf6fa0eade4f55389d19ca7317', 16),
+                    gmp_init('0x55a193b57cdf80fa33c190ae1a4856dcc0acb90906b7a44b9f95ce0c1eeb934d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x90c1fd96b7583b830354917659fb929112a14f89665742016b35da9e8014ecce', 16),
+                    gmp_init('0x6be0a228a8b87ab8d4997395fbc91a78c1748d0c5600a786e08f58a708805941', 16),
+                    gmp_init('0x2c3f27155bfb141e3c73ae6cf1fe1c2a15c3ca340d37852e57134b6101047a0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdb7b49ec9aefaceb92831df0b7112fd3a5619081f0599ddbbcf6f42a99bb8db3', 16),
+                    gmp_init('0x7463b2c497cae6f7384f2b8b7ff8b6fa4f1e878eaa00c24f509c5ede4c7ece61', 16),
+                    gmp_init('0x7e4a5f6e3d4808026d89bcb6fc41b7c5229fd3487439c8bb7bec2eadfda02cc6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x89bfa1d5a33130aefcf9332aaf4591ce57eac67da2217afa4c3530ff98c6015a', 16),
+                    gmp_init('0x82d574f606bf38595ef805d289ca2ae9b184dcc305e175d32f3c11c3d364a91f', 16),
+                    gmp_init('0x466e992c068cb66e24be5f40443f4483b3e3aad24cb89e50e89d1d4159849c68', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcf8adf1870ffef616523764effef26f3d44047f9b393f5ed61a5147937373fd5', 16),
+                    gmp_init('0x34b18763ed29e8b76f095f896bf81b23aeb2f4c720b4da5099edbabd3983bd54', 16),
+                    gmp_init('0x51ccf58fcced66204501a5f218bca9a38f57d77b5bf5c94edff321c28450f06', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x72b7dbca4e242b083b73143c3b007b5da110ad398537baf356ba7ff52695abe5', 16),
+                    gmp_init('0x4a2628a144f1365444bd2b16edd6da96a0bfa35fbbfab75cca6bfba7d95a4ea2', 16),
+                    gmp_init('0x8b9a8dac9d52c575d7ae0342009a6dbd183bc08a268e3fae2aad227fb03be8e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc5d359bc9680bc75dd6e238873bf17737060dce2c5d0c4774f87b9ff828ee5aa', 16),
+                    gmp_init('0x1efa72064b5f11d627addec84d5cd47264b4d00a94ec953a11c2aa40c47b0139', 16),
+                    gmp_init('0x46588ca805eb31e28c235b55e3c99eb907dfa684de8a8a421e009ee49cd28078', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe3198eb5c44fe55aa09819958e889d3e4bd75d68e72c73863d90fc321dab3619', 16),
+                    gmp_init('0xdfa0ac5339bb2fc24cdf7900ef4d3ac4bf2e74ba9c75bf9cefd29ff595cebfa', 16),
+                    gmp_init('0x7e0776b0f784bb077fa2fa15ea99f0d6627cd327795c4173478bddb9bfb56c62', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa2016a3187ef58957da3d22ecef466c4c9fa3c7bd2a393014dcc44c68ea4ca9e', 16),
+                    gmp_init('0x5655d785017f048d16393b515e426f3ba74dee75e75c3580d64c2418010f099', 16),
+                    gmp_init('0xcde279cfea2ca9ac858487d5732314ba310c3c6e11f84a0b12182202f93e9136', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xde8116ce8d82cec64d79d181dba456b5471e8979327f6bec8ab05e262b8759da', 16),
+                    gmp_init('0x7b9d9ca67e574f570de5705e6aaf255ac88063167bab0f9d0698a21b4d2f2143', 16),
+                    gmp_init('0x8903b90942308a6b95485f9949e5d1476e3f7ff41c12b13c7a9fdc1de3ff8b9f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4e52440e054e0c30975622d0588b54bb1cf6601fe4b64d9032f05e83a008d068', 16),
+                    gmp_init('0x8b8ca3b31e9f22f783e07d421eebdb0cdf79eb941aaeb212bbfad1e46ee268fa', 16),
+                    gmp_init('0x655d6122f64d36603644836d7877714c3da9348328b850ecfbcc268083be409e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf29e2ef46371f9fc8a9ea162b3cfa3ab0c24579cdaf5f48e0fcb78ba035ac59', 16),
+                    gmp_init('0x83fb187b9dc9ce3a6f0d92ab2d4a87702ae3fbda85b75ca353a17e335daefeb1', 16),
+                    gmp_init('0x3e4b29ec9477fc38f1b10bc0e768ce523ea94732f64f18da4186f441eb9c393d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x19f62465fdf452adbc8290af0291ab84d3425107d41a31d5478af4d7715827b1', 16),
+                    gmp_init('0x58927c3e41d0d0eb91854cba0275ce9f897ddb70dd4e7a77e63bfc4a58063022', 16),
+                    gmp_init('0x66a0fdcaddc81972c6a2f4d1d298cb8a124eea934dc40e0b65cc3a79fa6af119', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xee6bb2b7f313144c2f8d8ef60e021a6ebeb4890eb1c0eb81b4868cd56dcdd2d7', 16),
+                    gmp_init('0x7e48b004604e7f99de8af7b0403b6a3ca0b0687a1fcff66d46a14102f69cd0f4', 16),
+                    gmp_init('0xb3cadb5280dbc0bcdc87311a0ea9c14bba2fbd2434e7229a87315d4736237b28', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4cf595d795e451844673d88219f4b1c4cd01b978d63bf00b1ac3c2c102b00248', 16),
+                    gmp_init('0x87166114ddc9df74805bd95815ab6028d26c4136667d370d6927b63fafd4e0d4', 16),
+                    gmp_init('0x330aa964495e42ae52f155929b36d0e1c06cf087c250c18220d1bd021390a508', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x908c668a79f9362d3dca2ba65b7252bf7ce0db435c800a8fab87a169084571da', 16),
+                    gmp_init('0x1cdae54b86bf6b64b7eda30f5bb55dd546857145949c60928c7f128c27f69d16', 16),
+                    gmp_init('0x74e781e292cc0eba750775b62640a3a3daa24a492e1ebf5db07e357d230709ee', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcc1f62343b3931f37157625c56a1cb99a322d8f7a8ba8a432ef39294d2f7c894', 16),
+                    gmp_init('0x48da5cd9849d4ca1d013ac76c443d5f3dd6d8ac4b0a92903a3a237079f5cc44f', 16),
+                    gmp_init('0xe16a3e8a371c94710866a0839e4bc48eebedee2d781b2a7ef39217fd15b37261', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x95ff0dee20f3a637a7648755fbccd5e9e9b35f89f3422a7482bbe677d0c2f7f1', 16),
+                    gmp_init('0xb7b1d2de5e174e29cb76a86511fd1f788bfd05575ca9b9f0986f82b727c2ff73', 16),
+                    gmp_init('0xfa60bcecc4236b043c57095b62cde032f006c9d3dd34a5b7f17243707f4e4ede', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x526cacbec41326f0db1b6f0dfde6eab99c4d0923b1e9fde0e2e82a1ad15abdf8', 16),
+                    gmp_init('0x56c0c9f366acd54f1aa2a21a1b01441bc843b823937955d4e6ae6721cf8a54c8', 16),
+                    gmp_init('0x3c40f9d18aa523c1c66fe8988adf514cb06df2f7fdc23071732bbd8ac13582e4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc19b3d80110b23b980419af3aa61f414b16c542288db1003f5453149c9db96', 16),
+                    gmp_init('0x455b91b469757acd49dd372733579a3d6ffef3de49b01cb79ded2ca70cc83fe9', 16),
+                    gmp_init('0x9352d662a3c09adf1941bbc7c106c01e4b7b1a5598bf2f0882abf85977e370ce', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcf6804c8d90091ec1f3b1c56afa7466605bfeb6a42b5939851b3c0353ec7b7ba', 16),
+                    gmp_init('0x2a8691c52b0a03be1a092211366a92d095081a74e19e1cb84eeabeb05aa17a96', 16),
+                    gmp_init('0xf85a74b9d9ebfe825c0a8acf934019786e675e0faf35b36f2c5e6cc234d1c1e7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4d6759d50777c7eac141504e3a5bb8ad544b48d9434f72fe98c1a357ed7ba974', 16),
+                    gmp_init('0xa89fe7c777ccd331fca30718aa070ce2505eeaec2d76c90b3b09390295a03739', 16),
+                    gmp_init('0x2399b84ec560da5169dcc6fd2174bf89542c2b4ccc9860d08f4d8b9fc364410f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb9cbea18f1669779c1e2d2fd1c1d714a2a367e3d392e83627c6b5b54c3b16f1', 16),
+                    gmp_init('0x46630419ec73b88b80c15ee1795851109c2140d14add12a78851e8bb07c6f0a', 16),
+                    gmp_init('0x14ebe9d252ad99852a4d7347348c3275f4a6d5eadbb2e5c6bf47303e4cf81462', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x24d9e9408026a104d54ddc043410405f26acdaf221b163cf47a137c9c0fb1a24', 16),
+                    gmp_init('0x8c472eeed93a07cb8ca1186d1f921cd340af833d9679787a86e74ca93e804dad', 16),
+                    gmp_init('0xb9253b943c1095599f2b55edbb3ce79113d2a10f51e8bb5256546943c84e167b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcbc5c23f7d253ac465ba0da12920b352340fd4259f112bd45d9f2d204624572a', 16),
+                    gmp_init('0x567bc370c2439d7038ae307fbf938ce05d91ced32a27f6cfde27708de0d46766', 16),
+                    gmp_init('0x711200d3aa8a82a48d0cef2c3318bb549b74c18e8f015421bb898b3ed96ca217', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x70c83fd36d62b2b18d26e6071b767da1a702fcdbbf564f99921a1c0dced829e', 16),
+                    gmp_init('0xb52bc7a536cf2077b1cc34f0b5ba3080f2ea113001014208950ee9fdb6d50649', 16),
+                    gmp_init('0xa3c97ea89a1fa3bcd1f01acc84cfa095a7ed7fd311a18184198d253901dc54fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3640d59d9819bff787836d45b7e297c4da4116c862ec8a54b901771be4f7adde', 16),
+                    gmp_init('0x5d639cca79add92409660715528520771687f68a07c314e5519ce9505abfaa50', 16),
+                    gmp_init('0x31a043b516b7b7b3ef4984c72c932ae7bf7c428dc6ac7c2f1e1daa5c513ae97e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfdc68cedf62322ad911991904c943f062714feca35a057f8ac33d243ebcb598a', 16),
+                    gmp_init('0x84f8feba2ad3c741456406a47c9f9172329ea47f8607c4d9d14755adc1aec72b', 16),
+                    gmp_init('0x82b5db0ca2c43ba9a68543764285c0fddef9863a7f98b2b7a2222bad13be5aa1', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x65d5ebe60a13db55a86f355ffbca86aa4c3184a9ae0d1d5c47032f27de17c5c2', 16),
+                    gmp_init('0x76fc2f4c75878289b209624f61fc7ce6c95340323de675f768364cf46fe27782', 16),
+                    gmp_init('0xec0841cf16aa1480a113461fb910d92e7f9364a1ce09ba96bd176f729bd2f711', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf1d7b80c07ff75de691551858e43336b15bedf88d57b2575991664d178201f43', 16),
+                    gmp_init('0x355b985b84e889f8c0a9d713353395fd35a2f2ea19bdcc02bf22d5178bfbf5b3', 16),
+                    gmp_init('0xf6470554e170adcd74493c5b19142e53c7ed36d91e1bcc57cf4521b4b15dd3c5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x158db1e162a904d00886edc84bcc253e58b491fa759497c2c49fa250a869d43c', 16),
+                    gmp_init('0x46d7f727058e57bc4f2e209f4489c37ff850948f1a46f5b4a6c36c7a5d2d6ef', 16),
+                    gmp_init('0xb02b18ead6318afa14cca0b3dad0c4594c779492c09f3df627cbdd62c01a67f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5dabb895dc5e6dc07b4aab64976f42c4b1ec70122625211e74e9178b21a354bd', 16),
+                    gmp_init('0xf2d22991552676035697c4359f95403508cc999d1d640a00fc9c071d5aea2f37', 16),
+                    gmp_init('0x53d9a7492d24f9caad65216bd0b88379557b037d73b9e0032ff5d38af7b3bc2a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf661a83cff7fc465e050e1d8d079e085af3d5929401c38d087472c3a92e2972', 16),
+                    gmp_init('0xb6ca3fad8b8efccbca67f55af7016f0f072334037dff3a1da23c0c962d55454f', 16),
+                    gmp_init('0xafcd60ca7430111e5ae5e2d0d5a29e3e18ea08e436009f15a0d928d01630c2b0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2de7d62dcf9a4ef5cc782b2230ffe2c5cfbf969c6ca6bbde85738aade553c26c', 16),
+                    gmp_init('0x73335372a37eb56fe905644484b6d25b80b0ce0a265b0cf73566c4a164a114a1', 16),
+                    gmp_init('0xc63078a8780e268d96d5ef2531c2532ed894c592c6b60689179b56faf4bbc73', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5041e4c3da85d3c7688b3ea326db8fae1bf2249c5b2952704efea2eedfd86976', 16),
+                    gmp_init('0xa0a71f6fc887b15128555d40bedb228ece364c960aa0da9014d80d7f2d62e9f7', 16),
+                    gmp_init('0x5b909b636c5ab47505cd2baf0b578001f6d7cb9fe9e221a05b045aa479faa31c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x46d1ed3d68589861e3d0e45cf6f8e194f2428f16cd61bc5380e41fa9f7503672', 16),
+                    gmp_init('0xb2e68d0d0fc1e6c7dbd68d29bb156a3d972866f9aca69ae8c6b44a19860be856', 16),
+                    gmp_init('0x3bc20e5ef77c470a27a283d9dc94776b7b3a1c858d5c8eed15bd095f21b83887', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc2c5bf1f0b4e9c031a9f275406449398a1bbec27a449d64a06eb5e45b1d6733c', 16),
+                    gmp_init('0xbd8ecb3bdb99ff2bc92683d5506e4e0ad562c6f0355bd55558fb121fe5fbd507', 16),
+                    gmp_init('0x69b9ddbb594deb59b90a26980bc5431792c798ba127a51d1e5e358f2c83b2644', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3a3c312f919fc404a81b92248f144c7fde4d34654f217b331249a8d7cd5b34f2', 16),
+                    gmp_init('0xde106e5a968bd9517b88ce5853eb16ba9ac03297801ac1fd9b167b1d0a3e34eb', 16),
+                    gmp_init('0x8dab3d7cd305f46dfc2fa841292d5a3572cd963fe974e2e390ebd96b25f2f412', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xed69c19861d4b19ffeabfeaf6853802165f2b52b9f89f2995bb90c5cfa700662', 16),
+                    gmp_init('0x31a4977183c3507865ffaf1dd191d741f5db273990b9fde3635a9b8d84ff5524', 16),
+                    gmp_init('0x3d4c4ba737c1e623e752443e858290588067a244cebb0f8a4f38d6fbad32cec3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x545e57b98db114dd8e2a3050669dd4820c445678f361fdb8dbc7851760a607f3', 16),
+                    gmp_init('0x4d9234aa29ad2b8b38406b25465aea80f71b3872a9cd4370fcb2ac97ebdcb50c', 16),
+                    gmp_init('0x4a335ddcf008686e6129bed942afbe00de29c31c2e7cda490162c2a85ee1ad9f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82367b3f175b13d0d2a2e9a958171e44c270b2fc95042149e72a7394cb3a6ac5', 16),
+                    gmp_init('0x253ec54a3d182955b18d9a0de294191c080f04cdb8faff2ef18ee0a17ce5f92f', 16),
+                    gmp_init('0xcaa272ce2dc667bad54043c8c9d2784fb63099fe4d9dfe399f58a75688d5663c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9a8ad7ee1f9301e7145b3e718ea970feab730d3f8b95790da7c48c02e7646afb', 16),
+                    gmp_init('0x99276cf113d9688e6fe84a4bc2f09db5512e18de2fdea4ae2e3d0f382abe6ca8', 16),
+                    gmp_init('0x6fcd30a5fc9a2c856d698d968bdb817a375e90ee351a0f3c39a158a4530e6818', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x248196c472688b125599673c8156bb257ee83260c4f19e1788bf22ddcbf10d3', 16),
+                    gmp_init('0x20b437dd5b7336df0e3b27255228e77f1194afd945968f85aecb3f24823f7e92', 16),
+                    gmp_init('0x1708ebd6f5977695bcc14378f90e52b16a7367e6c14b67f1aac771cbf45e27a9', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x171672a5f204999a2fc92bccf878b2a5cc7727a4083407d152a2ec5c1cab8606', 16),
+                    gmp_init('0x7270bc833fe973e593c830052c87e05afa8975d9a13ef1c7d79bdc1dfc060ce3', 16),
+                    gmp_init('0xa819d14b4a22b04855270f2558404940d5575bbf44c532a25efeeca9eef45be', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbbe532ab163bea6a838e239029c3ad86e4e3397e13dcd73624d123af25d4f085', 16),
+                    gmp_init('0xc9192f1faf8c634066d6f8476048e5ea775654643301983f33daa42632331423', 16),
+                    gmp_init('0x88baba05691a99149b71f98d9ca69b5c0cd72fe8535bb37e1fcba0e8d725697a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x97a3a7f043248a9747bfc2d87000c0de14069371f940ddf058afa0335de27b62', 16),
+                    gmp_init('0x1ef3f303a5d3f7a114fada477c1feccf6963957dab2fc0c64203c88045e10746', 16),
+                    gmp_init('0x105dc5a8c56117fd47be37ae51d2123cebe60e3dc68a61808d71d01de0263a9c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x773e8b4fe99691e816ce0d74879aee141925abda4de8d4ef9669a7875af79afc', 16),
+                    gmp_init('0xe89537a01f07429c8c717fa4c1bc6bb8ac55a987d1150a0258fd57efd24dc00', 16),
+                    gmp_init('0xe2ec6fa8c88e16e634fc2f8e21ff7ecb6c79a779dec9751df1cb2af28c759c84', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x73b2393b02772af380214227fa25cef86191896dbaf7e825c9e8c4761dc34fa5', 16),
+                    gmp_init('0x679ac9bd5ef1b8c99a3fc672cceebf1d1227c3b21dc9586e2e12c308851f08da', 16),
+                    gmp_init('0xab44092c08ad89f990d46fbfcf50fb23c6120423660b94b857b9d061527257e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc84fe39bf60d0ec3e89d0e176f84309d22d340716bfb3d56772008238ffe9ce9', 16),
+                    gmp_init('0x10f1d51208cb20302f881f4a904d59c87cc2aaef0126280e5ec03a72627da681', 16),
+                    gmp_init('0xada197b553d56027ec18374d9fbd6f4da62da8b96b409972b16c35df001cd0cb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb9fbfe75dfcd0ae4d9232bd443b064417ac52d0972f658ffacc329e45f985e91', 16),
+                    gmp_init('0xe5d8dfed050ebaaedfe2152f3f26adb895f913ad75dc3b8b93530dde9b454da8', 16),
+                    gmp_init('0xeb64ad6d668e06f37b26b299bd8c7443cfe10163e1039c541e5e5d41b2e56b1b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe1cb688c6753480f4a1197a7fbb185ec565d8129fc210e652e2a65e87feae9e', 16),
+                    gmp_init('0xb496b69317e55b1b4e0a87e7decf15f13ca0301696761e2830af0c1a9e9b0ca', 16),
+                    gmp_init('0x4f0040b79707e83d64d23bec6163d4fb81cdabf56f791944cd66f4d026f090cb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xddf6631b7d33ee15e97109ae289d664d3a5d4207776da74f6c2c7b8dcfb23402', 16),
+                    gmp_init('0x99eaba2b08f33fbcb9f87eaf828ccb2226d77b84d0455f443c87c673dbd59c81', 16),
+                    gmp_init('0xef599d8b67c3a4a76b01b00bf2953df1578ea7257a50fea2521c2b270423f3fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa4cfe847c28387cdf58eff93e75b11e0092a0acb90cf04ea23c2f8df8bc6a60', 16),
+                    gmp_init('0xe3a50aac9710dc1dc10967ae374f28a2472ee9347fdbea0ee346b9a2b827d0c2', 16),
+                    gmp_init('0xe33f64411aa035510c82b13df85d2d7a79eb134f085061643b461038d8a16060', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce0d4752b4db7d3db76ca1e16bb7e6dd80402345d6beb2461095958f65df5ee4', 16),
+                    gmp_init('0x25faa5047d5b5cb0318594bc7d3606a93b357ce299a113cb05f053d588708e92', 16),
+                    gmp_init('0x66f5002899c76ef64df18e96016fb21ab6257034790a079b3bb536745a6e5f89', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec784ec5ce025658b27487d48decb68a0786571df2094a94c23ae3d7282f6c8', 16),
+                    gmp_init('0x9062d27c5d8a7fa0664aa89a38883160c244005d14f4e033341719fb88e209de', 16),
+                    gmp_init('0xb27d995f2ebd38b7c27e66546ef3118b8a73cac62daf40b31ee8d27f498c6f5f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e918d104c4e2d027fdca559c52397784ffcce1ab9bb9ca9ba803e8ff912e008', 16),
+                    gmp_init('0x56354c5e6390c75166eb4ee3e48240c496629569753b862337295103d5c0c1ca', 16),
+                    gmp_init('0xd3569b678cc056d06eda78efd584bba6fa2a98d4807ac56aaf76660e8c7a93bc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x80f2187a837d0c252bc910a74aa0d213c360d9b3137bccb47c3d294100a5d44c', 16),
+                    gmp_init('0xa4a9eb23edcce45b9df7604b710b7da6e251a1726b4e615f69976585035e58fe', 16),
+                    gmp_init('0x197f6f8c7a15ceb279d5165ffa277732e8567ae55647408e7b1d1f9622cbb376', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb84137b7faa6c92595d3966765f0f2dfa37f3774e31a1e1462044d480adedb6', 16),
+                    gmp_init('0x91c02a3e1339d4473cf5ba57807e836b54acc2c9246e926bd51f592bdad6a9fb', 16),
+                    gmp_init('0x887901120b460e87aadf586e1a861dd823054a89dd602d7106754057394183a2', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc6db957126dd60faeb1dcb7024df99215eaf16fd505018c3f5fc2f5889040ac5', 16),
+                    gmp_init('0x334852d72b598b709cb964f77e844217568df1f8835b2cf475920a2ee2e6cb6b', 16),
+                    gmp_init('0x6560bdc98f49e5e6f364b5d04157caaece8620891217203150aca608b1dbd14a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x291a57c26b412f32aa340f73d8a3549be3888ae6400dd9ea04a2f71c442336e1', 16),
+                    gmp_init('0x1f0237ee723d32796f0b061f66e4e61ebcef43b1e34ecd7e5e85ccaffc1c4e4d', 16),
+                    gmp_init('0xc33fe6a3a09b984ff3554ce75e4bdbb553527e70551b20973f961b8b280e68c3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7ab833119f6a9e5d5eeefe90e165a9a0cf8681cad1d4835ca52f1989dfeabb86', 16),
+                    gmp_init('0xc32f50702e31aac26c23f6994c87ae3ae8d0aa063e531c150f22e6fd8ec58907', 16),
+                    gmp_init('0x514b65abb34af1f614ab0a91117413e9f7dbd69267b3eea5c4f7b3307f6bc4a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x702f182b35590e666e707127e56fe1835f027535fcf0dc83965194413fdefa0c', 16),
+                    gmp_init('0xe6318cf6725ccc9b86a54b0bc1dcee6c4e75d26cc4a839b384d21606d1630404', 16),
+                    gmp_init('0x33fc0c02bea265a4640c3fce04b3d3277e24d28fe6a6d99f81208d715ac3aac5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8585bdeacb5454849160e6c1a2675927253be082cf066148902bd38f1eb1c118', 16),
+                    gmp_init('0xc27ac740f9bb77dfa163d45837b127ed3f614d471d47a7debedc730536fd6548', 16),
+                    gmp_init('0x5e209bc4e6e339f4aa5bff11634da506303c6932dda2fe382d3c3a16662b4ea6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x79778ccccd47eb6fdbdf07cfebe17f1de6148ca1aec74b41c9da124dd7edde7', 16),
+                    gmp_init('0x9aafdf7658ce7af22a2c0cb2249ea3af4831d88005e5cc1362d3a72a19bfabb', 16),
+                    gmp_init('0xc39452e5d161f083fb63240741d6cc0b2465e87f541ae18bf1fbbabbc1b27803', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x18a783d30feb5b33a42647c6e4b935a43e8dcf956c97c3f9b193a0cea3890bb1', 16),
+                    gmp_init('0xe1ae6dc7ef5a62519ace5a2c0c38da219a74da3742fa045c94d858687b953b10', 16),
+                    gmp_init('0x7f5ae94ede9bad3a91f8934b67b5506244ceeef4599e12d7af201258d0702f96', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x473f11db7da8006b69f8ef278b92d9dd87a48b6d9511b90bf7a9a38c045283a4', 16),
+                    gmp_init('0xc2e270bc67d5379d0b10c570c6053e949744a6fd50134bd933cbe5fc7e0afe01', 16),
+                    gmp_init('0xa9802915e85019cb1b1439169a339b00edeeae673f81eca4b5d74588c2e9bb23', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf64c21bfdd1ef118770db7e82a058629c461560fe3368f778615097212d2bb5a', 16),
+                    gmp_init('0x4a6c2b3f63f3190f78038eb475f6b271efb35d45f50d7261977f86f28fdebb18', 16),
+                    gmp_init('0x6aab855f48192404820e5beccb83b7d8785c5f4176bc8840fd84ffdbf73286fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe3ab937237bcdd77ffa21a227370dce9fa37e06a50121a4e5b28e372b90cd776', 16),
+                    gmp_init('0x7d07555d466046defae7c9f6a02e8e16834fe9f74dd55c2c0a62ee88dc0d3697', 16),
+                    gmp_init('0x7018ed7df7b0cc97cc2c1b3816accdafe629aa0c4c38a6d9ba2fd35a9e0ff31d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7bc6af7d5ff05e978f272ee67c4b0a6c2d23318de4a9f51675aad8590b22add8', 16),
+                    gmp_init('0xefbafb7ad9ad58202a7816d789b0f1ab6958d3eadec8b3e270588974aef946fe', 16),
+                    gmp_init('0x570554d1d9c1e29cee7eb54cd78352fa17447714daa5acc4fc7ce318a47efae0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xacf585c46474f24f131a227339633bbb06f9c334e6cc7b5b460d788c53305490', 16),
+                    gmp_init('0xe271ceba867521b0ad7e180c0c6d780f0883c40c915279720f15bc836caad9e0', 16),
+                    gmp_init('0xb63f931bfec8f13b11edba23e480f8eae280e4a9bbb5894a941086e034764424', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x767d15872d0b1d37e717e1a85c0119da81f9d539d6bbdde5c39f8a8d50005ca8', 16),
+                    gmp_init('0x586f44db295a0b3e2c77570776a5529a568de18812826559cc23d8297824ac48', 16),
+                    gmp_init('0x47df24b68aed6549adf1a40604bc40b425592754ed5dd1cdf4e6e34bc6c4026f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7bb0fd35d205780e32b4d2b7b8cd45f9f65b7ca4ae3af34b650227d46de7aec7', 16),
+                    gmp_init('0xa00302b49887fa07fb0bf950295654c48ae91cd32e930d628eb8dd6d6836e63b', 16),
+                    gmp_init('0x4b8e056c4587fe6f82aae96d26dcebbf71acf639adc9ab3c99c200450271ad21', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57ff206d37ad5624d3b72216b66ac0237e0c2be5ffd92618213b088669f0eb5c', 16),
+                    gmp_init('0xd871cc7bb5033d6cbc4224cf544d586e2d8fe29267ec165fd866fa441b9da78e', 16),
+                    gmp_init('0x9c3154244697975bb98b8398fda064a3e5dc9a0ea9e5c346fb9945d5e6591de1', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa51710b8f51202bc984a85cc799c4512566b4ce478e8e1295c783cef329c875e', 16),
+                    gmp_init('0xbf75103fa60162f5b89733a25d2cceacb1ad2c44fcf7ceab5419eaf46ce5235d', 16),
+                    gmp_init('0xe695ea8c4f0ca34b96aba34907c9af720df205391a177cfc8d0000106841467b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x37d55aee69e8d9810273ed1d9b2d9a892ce9f549aaf52987b33c962a6cc07de3', 16),
+                    gmp_init('0xb91c307af10821bc8abbe8080bbea6128d33fe4dec2dfe20a286d166dbdf3815', 16),
+                    gmp_init('0x66d8149adffd7f1de339b6c4e938e4ff0f7acfc75451e31471ece60eaa37530a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x573b165c1a29a0d24ec8bb0ff2ccef6db311a93a309defbd4ba1aa7165a4ac13', 16),
+                    gmp_init('0x2b23b6f7fc2605d3bc106666b7c14e656bfe544de11d7b4e34b24e12dd0e1524', 16),
+                    gmp_init('0xdd387030132f192fe3eb6ac0b8fff5efe9466637955cbf483c4abef5c0df59c1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5c0be487f0c3fa5016525d377c7c7e007f18812fe69b5cb2b10d8c87bac3e6a5', 16),
+                    gmp_init('0x97de0944d6d417dbdf12389d6b6e86438cd80684795ba9d8c1eaf384b8eb0280', 16),
+                    gmp_init('0x97d25e631934997b93dbc87d208aaa54f65379e14ea7acdb6f05baf90e98da29', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf6e923e7aef22a1a99fddb9fb34cb0345b815fd437bf85522defd080fe88b2d6', 16),
+                    gmp_init('0xc65dd6be90bde195dff6adf074eddc02eda2543a4c673b2aef53fc01781434b1', 16),
+                    gmp_init('0x74f46cb60b671cd059a4e7dda05051834bfb06c2166c0d2ffeba97dee759fcde', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc2ff475dc31fcb5a9a70b263c7af1bd46ff093c210626b6351b50a1a58369bbf', 16),
+                    gmp_init('0x7859958ac90d1a2d7b248f105fdfbf17ef6eb7ed261388e172eb2a672c1de606', 16),
+                    gmp_init('0x531497e5c1eafd301d8ab9b6864037a43eb5214b114ca1bfa7fcd1d43613c7e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6f9cfaa90a0a3b2ef43b5e2a33006f4d689b3dbd32637a001476158895d6e605', 16),
+                    gmp_init('0x9a5987b2ed6869fb9d8662a4c68d939d1890c7cc83c39e8e493e6a91ef81370c', 16),
+                    gmp_init('0xa78885c269086ab8bd5465d4ecdcde61e5aba677d48b3b49670198f08d6c740a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdcecc2eb3b9628ac71eed307127687b97dfb934933f2f06c47377052ac4fd58e', 16),
+                    gmp_init('0x58484f09141455d074d0d31fd642cba808532440f7b89c42c916c96c2baab1e3', 16),
+                    gmp_init('0xa55015eaee6480bbde992e2f0d2f77e4159a5f0237ca72bf4d4d3bc35e5b8587', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7c25400cce9816914daede50baf04945515a07c04ada1d49b9ae64032fd2d86f', 16),
+                    gmp_init('0x7e5d6b2a49274579acd20759be3522ec82970cff9654a9d1749f44d53f835135', 16),
+                    gmp_init('0xdd93337bc5085ca5f6957686a44df5e45862bdc0fbe70120ed3db0ccf70a1851', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4c8afa6e2e2502b40c80685774cf6913c1130699191bdfa0e3b8a760605b619b', 16),
+                    gmp_init('0xa663fa2be326a23ac8be84341184d758350a78dcaee02b14e442b4addfab962b', 16),
+                    gmp_init('0x1dd4cfd11dcbd2998756d5b17c0394aaa20f36e41f765cb33f052738c3dbc3e1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xac1002b5c292f212e2ca0de3a9308ed045d8c3ea0f1b9935c2cc7bbae0c13b4c', 16),
+                    gmp_init('0xdcd37878ed273648ab10e134c81a3e2ec3e9cbd25c6af28ef65b096af0c0d2aa', 16),
+                    gmp_init('0x10ff2d88de5e6110996415b6dfb0d0aaa5e50390e617b410ac5a33db284a529a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdeb9c866f2f51bd0283ba5ae04e6d0bc1f0c6698099a62ac90ddd22346ec6a25', 16),
+                    gmp_init('0x84df836b52007080ae78fd9028701e2f49b3c79de87c38a575809344496c2f8a', 16),
+                    gmp_init('0xb3e15af5741867bb297c63ee1d027624032a217944f4e4231c232123573b00f9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd4fcd3e19ad0d214f9d282c94a5939ac30e3641870fabbd90e2634af4bd7442c', 16),
+                    gmp_init('0x49f03625913cd0878cc129cfff0e470d9fe6123b47fe6dafa98d70c753ee6ab9', 16),
+                    gmp_init('0x8c04c4c0acb412c4f5f325d4e35709d7a114c0900e9aa6aa12949cd066c0fc5e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x440f9ec3f26cc7ac0d119eaff66ace816519ca2370b4bb4b6b0f65a973af1549', 16),
+                    gmp_init('0xe9b750d16afc88c0f12ad63b1a3fc698d2694d0d96038f5198734e9a56039a55', 16),
+                    gmp_init('0x9167937d5aee9a3d1be1889ed070e98cc1b4e3702f60b43b20fd2b432afc28ba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc8b9c56dcf0fb7ff3e598e9647e1edc04f1e525d0185574f9198ed3193a6140f', 16),
+                    gmp_init('0xf00a771b339fbae5ded8b5e8cf861460d569bd4bfd6492e4a492bf4a538b7234', 16),
+                    gmp_init('0x73625e8f5d64704152503a9062f83f752058f4c464d25920f8d0d4e936663351', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x4704048397e00352e0bd33c52dc02e1721f59ebb39a84a8cadf5e3a2c7be5819', 16),
+                    gmp_init('0x8296041a1f45a48ddae9546982966e77cdd47db060858aa6bb0601873635e3c6', 16),
+                    gmp_init('0x36be1702c59c1d539537d83db87b03594e9c152d18fef74a5f6752c12168b483', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeba243bc48b53bd416a46ca2d7174ae1e25fa5f14da89211777c92adc9aecb60', 16),
+                    gmp_init('0xbd1152c0e2f0682e7ba60eee43c76e6de35e6222f1c79e5204aa43069d3efb19', 16),
+                    gmp_init('0x6ff5e41daeb372d70faa787aa52bdac935b7fd9f6029faff172735392bf289c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xafde84342bcfb16bcd87dcfa99b6806e97c1ba5db775d17a16352e47a3d8a069', 16),
+                    gmp_init('0xf2e1fc06496f5be4e83298c213365bf7e199c4597bbf9d6d678f85b64d2389f9', 16),
+                    gmp_init('0x937c98773d1de61f6ceb1c3e09068b0a43ee0bdcb6b770197cf01ffd583d8786', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd0cb7c0e66ae8801ae9ca8a21c87e4be553128a77687284e8e12d9db7c75029a', 16),
+                    gmp_init('0x1c4a98046c33edde53cd36c8befd31b7035ce23a18b6c774060dd1f326c332c9', 16),
+                    gmp_init('0xe50a3981b8ac1353f417fe6f89ef30862ef4748ab5ceb73b623c9c93855fb0f5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c7e641138adaabe3125f2f43f4eb0d43f50d2798059f428a2e76338bf8fd609', 16),
+                    gmp_init('0xd53ae33adad58f8ff7a300284f3b6087c3ca8b783a8ad749eef3e8d4707c2b4f', 16),
+                    gmp_init('0xdeaa2df0c5f41cb231c9a0237d7abd635b96f56fcf68e6fef81f45c1f32011c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe6397df4318ab8d87fdd3a7f78c9aab2b2480f55d09c2d16f29bc13b80483ba', 16),
+                    gmp_init('0xe529c60a4faa5eb263fba4c6a71512b000ec6dcf123a14c1aed62b9584db7501', 16),
+                    gmp_init('0x57bc0ce881d50db428e635e118ca470ec54ee1b1b4f4e922d9391efe1c00e287', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x774ba201f6976189b1a557b115b04075e78a41aa18b24b282aab407b472e450a', 16),
+                    gmp_init('0x9318285ad2ac918d75d5202c60e7da8450a39d0be7c26bd58ac6cf7c9cc189ab', 16),
+                    gmp_init('0xda480529dfe3e6275f11562923edf8a9ae2f2b29772353a73a0f2c7afc051eaa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf47b7cec69feb4f8f2606ca589fbf35984b3be7296b29a6cd98c0d796cb7b212', 16),
+                    gmp_init('0xa633441d0763273d7ce7f2560ae0b95d9f5d07b692762db7b1ef17dde0c0d551', 16),
+                    gmp_init('0x9dcd9cf1d87826390bed5196747d4b944efa60be05493c101f7b9f1958cb23af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbc5a53605456ba81e30425749857f1255f3d89f56a7847503ef9140cec7b7bc3', 16),
+                    gmp_init('0xd0d6efeae6a4b8ba4804e77260a002afa374b174b0bafb121b27db2857f36e95', 16),
+                    gmp_init('0x642f71edc105e5c446bef75cf35daa745ab027d78efab0bf001fe0a312c6ccbb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x29e97d2703ec1c243daffe88db8da0d3920eda50f02d52aea6f4b932b9efe075', 16),
+                    gmp_init('0x25b4beb4f30eb66ba90a955717b6c642cf5dc56a8b4c16a1162c195c24884741', 16),
+                    gmp_init('0xb92c618bd8be5d3d24ec4523cfb0a4a1da6abfdb314beb87551c97192a11cf82', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c4e584012e231ae2474244c3c512ff50cb06cfa7f802d50d1a3abdb331373f6', 16),
+                    gmp_init('0xc4dea460f17a89ad987fe392f176517d654ffaf213147eb014a76553891eb717', 16),
+                    gmp_init('0x8477b4995370d2a341d0c6b689848536986492986f08044db6db6154c67a3cb0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7b54e6649d6700eb14db27de46ee1fe5add887e5d1e5e96416e92bad9089a0a4', 16),
+                    gmp_init('0xed1bde2f18b9de918808261410ad95592d6de9079e74100636090aff3ed19924', 16),
+                    gmp_init('0x58823b44a08803981e1c40cce556e29ea08a16c7921a4e8d5a1e4527591410cb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfa9fe2a700c8a64334cca85c5473b9c25204f6cff160f0fddd438607a1cb5c5e', 16),
+                    gmp_init('0x29cf637d1fb1c64745f89d422a7f0eeba2b91a9107b7fd944fe5cb16c546d66f', 16),
+                    gmp_init('0x5ee02f77690dafd49369b5f0fcdd4c4fa0a5e9cfcf92a355d7e1a79f41a40ffe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9e8d2f4a7c142273544b21fa02adb5e80c2f0cac7e19d9e5e998cb6be7bc3f89', 16),
+                    gmp_init('0x3295ebe0e2574f65922f09e89f66f73fb2b3524f2d5e555e164edc01a43fcf61', 16),
+                    gmp_init('0x211817d65c424727a30fd007d88da16ccc64fc9a5d863ff3d90493601ad1676a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbd37fef3cd7811613dc4912a9fe4112edc53dad4a4b7a2e00702b91ce8d65da9', 16),
+                    gmp_init('0x78065d1ac2855e5f715b247d44141f70d47d119d72cb7241c0d89b359a5acea0', 16),
+                    gmp_init('0x9da9f92ac0a7be87ab10d2799feafdcc9f89d459337d78a9f30a6aa192c352ce', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xf3524d1d9933f27c7ce8dae5740feca310691954111ee9b77655d8672c8f0f95', 16),
+                    gmp_init('0xe30807b04d2902484ad04548f1de9010fc81f1933f57fb7745ab0f73531ec1f', 16),
+                    gmp_init('0x5427f1cff1e16ca65adaad9d119cd62903adf14aaf4f29fa7ed9622fc195a466', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6b2ab32b39ecb724ced4a101780fae62e500c5535211810bab5eb1b36cf18f8', 16),
+                    gmp_init('0x21022b0105daf18758018b206afe80bf0dd99f04d1bdfbca12c7ea34268e42ae', 16),
+                    gmp_init('0x48d7b4b9461a7ab60622529afe6e0c0bfbac3b0f9237c27227fab2876e179c61', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd5ebcf197eae2a5acc6e7c4bdfbe8cfbb5761196e2b7dae6da4dd90de8745f33', 16),
+                    gmp_init('0x3e73cdcbeb46046db6056e1cd78cec889a6c9adfed38d06a1ef435b778ac8b7f', 16),
+                    gmp_init('0xe82be9cdb711e0aa545ca4bb307d9cb91b665bb3176d3ca0fd3eecbd7c2311c5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4fad41068396f9bdff4b728227e87734a2ff0ca3f6cfb05e41108804197c8a5e', 16),
+                    gmp_init('0x4159eff6f62a0ed92ab53a23348cbef8b0d0491608590393d39b6659946658f2', 16),
+                    gmp_init('0xa5213f510834dcb9b787a4a44f4e636fef582cc994a21a2de54c9e94a33deeac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf381ab01e75b3a429801629bc2ace87338cce5c8a25cbcb487c7f2fefb2096e', 16),
+                    gmp_init('0xe78f0e5d43c4094f58d2aee01fdc00d25eaf9a462f7abd27c0cfccff22d9879c', 16),
+                    gmp_init('0xff4f9fa81e3b97bf93d6beaba0215827ac3b77a16271766a32feace3d5f168d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x94fa638a144542fd8e86f6ad3348aa027c6be6e0616049b0b789e8a090a36ab', 16),
+                    gmp_init('0xd05c31d0357bb8208bc8c82dd55e3f568dc28d45c2976cc8a608b12a4a67a455', 16),
+                    gmp_init('0x7252ac26cc79d40dbf393432b76dedff824c607e5a8c8c009b231f2f803cfd61', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbd24d20f1d77661cdf6f8a8ca5586d2897e13ca2afd1d4df585cefaa5cb99518', 16),
+                    gmp_init('0x3e6a5a2ed893eb7c7fa8640f66c2858b90d8a2018b2751c4dc07f4ad41743197', 16),
+                    gmp_init('0x687b51258108fd7237c6035ceac9cff01ea68d5e29e57ccb435b8ad7b691f405', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5a36a075db4436f84443af06e912f84dd8948f623923d2ea0ce43583862af8ff', 16),
+                    gmp_init('0x57a53db8f76b9d2867b71964447d246ddee4d4235f4c9c7fd6726a95fead9251', 16),
+                    gmp_init('0x1ef58cfa605a11be4fb8c708ede7bb514ec445d6c2008bd0f9894b032ec494c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x49bf435142787c4fdcc03fc7fa1a73473610645326a243861c9a3b4b9f7b202c', 16),
+                    gmp_init('0x92db84f46e58890385c06de2dafd4641265fd0480446fabd8566cd82fd7da2b5', 16),
+                    gmp_init('0x91da00d452f3e0a2c59414bcafc3ebc536de7fe7e4d7d710472c7801c0ed0e46', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x10c6e5d6b781b69f23045c3cc0b82ce90f784bfcdbfcb56ef0ae9c30d18d1325', 16),
+                    gmp_init('0x11aa6a6e993b930c94d53cc141d2cc0806c9391ee5e553016b8ed3cc01de4987', 16),
+                    gmp_init('0xdef23c155a4b1d0e5a240c6dbc9c81f89cfa77d9663ac5c0632938fa47f73b7a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3191362ea1b00b62392f9ef06379615fa890b148e63d73f27c41377b84dad3d', 16),
+                    gmp_init('0x13b77f1b2c5ab89a9e99a2bbeaf4a3b4e9732d2f4d5aca19641ef91e5a630e5e', 16),
+                    gmp_init('0x7719826389ed3ae5645dbf181953b51ab5eca1051f0f7e581e20f6273a7fa51b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaea2af3b78cfa69c4e1ac7ae5271813cd095a6994f02f0a55d71b398a2465dc3', 16),
+                    gmp_init('0xa8d0b4baca4d2f19d82e9f815b108a9d80774f024bd1bdf2f8a1f74599867116', 16),
+                    gmp_init('0xeeece49cbf7f0aaa24c6b888ab34fdb0faf8a7fd17939790be2668a8beab86fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa39ab7f354c03fb226e40454888526561120ee09d8d90366ecbd094e08db17e', 16),
+                    gmp_init('0x5fff4addba228055e700eb08e5083a17c7dbfeac008a5638ba9b91a336ce4342', 16),
+                    gmp_init('0x304e959cbfa96c1c0183ca5aa281e7d27bfa01ea67f3928ef82512614bf0d626', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb467e0f2754bfc78e5073d1a7e2c257eb0eeabf15be2e99703332e3cbec64881', 16),
+                    gmp_init('0x9f963bc9adb3ff3138e93f34dae442c72e7cd4d3a7272370830d53f4d84bc83', 16),
+                    gmp_init('0xdd858a0bb581e9182c53430863f221a7d44f533054012eafd2f4ba2c619f1060', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x59d4886e9f3fe58316605f8e69aeaf10333a6c3558309e097b7faf1f2ef03205', 16),
+                    gmp_init('0xd94ef37571466a56514ceff82020fc16934557146ef4ee57e6fa736efe5ec16f', 16),
+                    gmp_init('0x74b2605e130fc36e72a1a8d910ae040bec4b6c3d6a6c655e79e53fdb4f501e05', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x417ef678ac0748ade25b671f6e88fb12184034ac82de19e98ad2c2975aa879c2', 16),
+                    gmp_init('0x929619b0cc594b011fa11509b7c35a48107cbd7770f56b018efefb8c285e3f53', 16),
+                    gmp_init('0xff316913a88f90528bd8bcb8edbc890bf1d89b67824825c9b00612d270ef462', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6bb41817fe1bd57d3ebcc6ca945d6ab2ad12256a2c55bc05162f6a0ba4185924', 16),
+                    gmp_init('0x6722a904779ae3cf2c21f73bc31b2b2ec2e75c4784a55a7e746b596eee14cab2', 16),
+                    gmp_init('0x3b1d49b33bf7b406afb8f561a46eb650d6e442ec7cd15b2d15bfbd39523188b9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeb6ef5509b2826fa1e15394d0364aeb06f0332a5b9483e90851d8a78eecb72d0', 16),
+                    gmp_init('0xacdb3a8621f575a20726bf3b3165b52153d4d7ad1b0e172be6aba7ee2458e6c6', 16),
+                    gmp_init('0x6ff6d4920bbb5348853cc7f5c88269a9a377508c1215e2a9ee134f70b0ac43fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf5edf2de03c47e02dbfec3a03bd6cccb347b23ecebee81d4b9fdc6a42c7b562c', 16),
+                    gmp_init('0xe5a49b8b1d80c4be2bea59c79df6f9839b57714abc1b3f29c2ad70493bf03513', 16),
+                    gmp_init('0x505ef7adb35c55334fea0c2f1ac422838d122e7b908896fd9140fa50405fe9dd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6c7357ea19025f023a87258e7677864acec147348b0e8792ced3c19096637b1', 16),
+                    gmp_init('0xc10c01f0f2a9606666b69899ddd96dd68826fe885839b42193f30874d1acf2c4', 16),
+                    gmp_init('0x93c74ae1245e5c30e56b0302c7687592caa68c5d753f82e59c2fb6bb29bbd17f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4841e6f7f5e24bd4eb30dde929a8009c4a97e7bf400a2264d144604b51dfd889', 16),
+                    gmp_init('0x76cbac4532029ab3929a6e8056e140ce42f1f08ead241f317fc5f632b94e7659', 16),
+                    gmp_init('0xc177dc10299053221cbe2990dc806c3530617d1bccf50685dd5f5fe3deb09df3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5e16e41cd2402759d144f4ff93175edbf7e0c043d6d78a328121fc4ad4cb5b81', 16),
+                    gmp_init('0xc3ca8ab71ceff97e7a01ac2d088e0ac54dee953221a3a68e0fe5b902dfde4809', 16),
+                    gmp_init('0x6bdc547cd740f33c9b71e94157dfd4e63f0509d41ef13dccf5faa316ab8d5868', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd72f1a362c4e1f33c23a27e99d099f264fd87da5e6c9b37572dfe0a9f714243f', 16),
+                    gmp_init('0xbd4011638fef31534e9835cda9f576b43682be7c8c6d9e84389c89dfd73a5233', 16),
+                    gmp_init('0x6bf989707e61ef1ff3137da2e23dfb40e92c6d2ff9dc3ea014d4895ad9a4a9e5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf8fe44e6cc6b754c41976d2d4ce87b8d64295cc266599d59e321188ed262792', 16),
+                    gmp_init('0x8dae7bf3209b1e03837231bce2b12ecdcd850094f425a0cc1e5a748c2ed5ccff', 16),
+                    gmp_init('0xb0db06840c5707c94e8434edfd65b6613281a8b848c26b3683a24b7de1947df', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca61d0714d7e2de6b2853e4206d6c82a45e9a655bf5e5d30f09b7129cc7a9c30', 16),
+                    gmp_init('0xc0e88059bde3cae128aac2c1e72ff374f4a5066de99245304100de26cc3c6d93', 16),
+                    gmp_init('0x301322855a0a8601de5f1ebddd1f1c5e946158daf50bc09f37cbf38bbfe37428', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1531c06740252d42359101a78328009517aa2cc4e4be72b4e774a47fe6403f75', 16),
+                    gmp_init('0xc00ffce8d435e6cb5b1497e7dac00d104ce6aa68647529c2e40916664da2978', 16),
+                    gmp_init('0xa05c4ec1fbf33efca226546d237f0d39eb63af059770b38308e58ecf7c881097', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35cf5c1e524f10e6bb7db3b6efb9c2b8248850701af2e5725c02e45dbac63f96', 16),
+                    gmp_init('0x60fb9ecfbcb014be8250fedee02327e8eaa89b9f20352717b0bdb7aa4814f98a', 16),
+                    gmp_init('0xcb78613b242ea346ad9bdb39afe92daaa83703a6b25301c65d25b6781d3b314f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d0baa923f49fc21cdd2d9a15dc2ad6cca467f2686d3cc10005d5c2d1ac4c4eb', 16),
+                    gmp_init('0x5b9d08cb244bd89667f9546c12ee17ad41d23646e52a18ca307ce02cf0904a8b', 16),
+                    gmp_init('0xc72fdc7b1f4d783f7c22f1ecf94470ecbd64f007079455edac9e7c47d98e9950', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb0efa646e473b1fab49aad5dd507ac31a148876b87ce565154cba96baa90866b', 16),
+                    gmp_init('0x6a0d2147ab112e4272f87ada924bf2b581428340bb8fe2f470008a4406028af4', 16),
+                    gmp_init('0xca5e31a7267da764d5800b5291e6ee1ae3f069d739b57e3c0d3245b95a11011f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2431f7513dcdeceb0e1c5788bdf6445b3cb656012996ffa688c9cd8ac9a7bd04', 16),
+                    gmp_init('0x93be6a3c7ceda85fd66d806cc1a1df6f450b89f31a6e754a5055df599aedb8f1', 16),
+                    gmp_init('0xd128d78055963eac0ce707116460ab3a1ad0727e710f55364a5952211e93451a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xf1627ace7bdb692d57c53501b30e895d631f579c55dac61bb15bae14edbd7e55', 16),
+                    gmp_init('0x8975230976972ab34c9b6a286fb383e0162dcd57edaaea32afd88399a07face7', 16),
+                    gmp_init('0x7dd5f3758526f86e69f36b685bd8eec2ff8f6173cf30df920aad55b6752de3c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x21acd08359c3232f046018909bb91381847c027b87d0023f3b6d2a2deac69ef6', 16),
+                    gmp_init('0xbdbabcb3140b00e572a8293a9b2050c1b29692bb23fdf5d80221574ff08dfe47', 16),
+                    gmp_init('0x7618970e7556eae9e1b1fbfeb7d2bb71f3e0c71a4cb35d980730b0d864ed6a09', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48c0d1cfa3deed37baffe7370a70a4228be19a39e4f39675de9c839cec9c7642', 16),
+                    gmp_init('0x54b1425bbdb514307a9fd9fc69d4af24ec8aeb27fcd6f1cec36fe23ea75deabe', 16),
+                    gmp_init('0xc9b7f3e5e5ef156d75ae803a72ce63b8fccb044b6a6fa10eccb5f64a190bd1b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf8466da040f6909a36fe73d1632c9babe0c72eb09bbc3b24e7e7e3cf38a3b4f8', 16),
+                    gmp_init('0x4787419cb0e98cd0047b26566fa7fbb54acb76a45e587299df58755f952f4eda', 16),
+                    gmp_init('0x7c3f265913c92ba4b546a8d5788b1f7cd99dc03660a400d72b105f833a17fa29', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d7ebd1908434f78285fb1bc3c4a5468dcaae35900a57f3912322848ac038473', 16),
+                    gmp_init('0x4cc37a0ba63f092951bf07b62d657c7166276d87dce93eade9b5f2c829baf4ed', 16),
+                    gmp_init('0xb4c2c35e9e67bf473b5a0d5c86d06b80ba62418c65d28f6d1740b31292c9af64', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x114621c354c85f17184a99eaaddac8267725cda5e1a91d44014a2efb2bf8e84d', 16),
+                    gmp_init('0xeb9aaa9a486520371e2d1455e13256021fa579ed73f5815d39a2e1471ae1abc8', 16),
+                    gmp_init('0xfe1d97ba41ef895dddc5fc5ed221122adec9e99070396c14a29c65a1bb254ad3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x83b8e792cd8317afecb372d99da9cd059c5689042efd71145307376e02d054ee', 16),
+                    gmp_init('0x1896e691178c6985185a22e3aad63b9328b4ba0d6e87ea3bb1e9a1a503bbfd70', 16),
+                    gmp_init('0x34a005a26aef540b1eb1328dedc7c08770b3806b69f493490c13a6b1637a6760', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d03c034721f2d5b8872f1ac7f8a906c39ba3b66d351908f59042e84822eaa08', 16),
+                    gmp_init('0xe4d7ba2fe987abade8b11589296c9dafbd29669913a05844009341f44093e0d7', 16),
+                    gmp_init('0x928978aabdadde45dba5f6fcf4690c4a6163fb048760c8c213bac41ba766dceb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x47da5efd6b59bae33731b561734a9881378bed460fac5ce74e18a82cdf4b1904', 16),
+                    gmp_init('0x5d009a86e00c555620e24db0cb9ebc8e669e292dcb60997dda074964a657d808', 16),
+                    gmp_init('0xc3b741ab673110aefefbf1bd9257e99221bb480fcbb558e0b717205af52814a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7d4ac219468b431f65e810acc4c4ebbc89ea8b307e16bc80f3dda1cd0b93ff', 16),
+                    gmp_init('0x70eaafbb627477379da5a8ed75808931bf7da8c045f15049a9875ad255648435', 16),
+                    gmp_init('0xea948a723a26b810c2aba2432efe28d4958706deecbcaab308d738e1474b2ac3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2d7575d9daabced5552bfe71ab5a1432d00528813730a733dab0a5d7bf3213b7', 16),
+                    gmp_init('0xbcb1f6ee93db047099bf81a44d818bb3bb8c3e8b2c843a7e25458da2fc273cbb', 16),
+                    gmp_init('0xbd8cbeb7393076de9c5494283a23b90e32b91c06fd42b332aee32b1e7280e351', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcfa856ef5b03609a2df10587a962abd4b44185fc227b46ce8415fd28d0f393d1', 16),
+                    gmp_init('0x562a2eac347336ebed9e1a9d59f6e889fdccfd6bc4222a1b4cd21c5374917843', 16),
+                    gmp_init('0xcd653660237dca93e8c8f61520de7417240ee32b192c1f7ca19c47ac4d4591ab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce305862b15f40b8991dbe2d8033fa04f01eccbe7a961a14f28f080b4084d8dc', 16),
+                    gmp_init('0x443b6a658234f0a3511b98ab2b2d306f6f34d8873112ba7570afac61ba477c61', 16),
+                    gmp_init('0xe27e7038f71b457d6a53b8bee38284dfb16e23667cb8ea2d786b8f9c64324146', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x80cdc0c18061fee185e8e4fb02184c051bbaab7fde497f617b833122f283ce97', 16),
+                    gmp_init('0xa252498fa6389ea61f1c8972144dd998b6d733bbf2d0c8a49f6db70e1ed04aa', 16),
+                    gmp_init('0xfa1a8b9bbe123681969ce7ba38265a4d3c43d0e87804ee72187417f2d79bfc92', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8802148bcb84281d3e9123424911a0a374805989fcef89207f7c9e396564dd96', 16),
+                    gmp_init('0xbda6d4ce0ddfb6bb11f9b3468c91a24e2454c6222ed3b3467b93f0c58ac26bd1', 16),
+                    gmp_init('0x1bde57061a763047225329613a787fe1efe0e6b92c8e6d0ca6ccad44510ca042', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x2f68988223843a98bebf16f7a95f9d8f441b4f6686eef68ff8b890ca48ba561e', 16),
+                    gmp_init('0xdc126581534947f1c310bda678aa2a5ea5ea12b4b87f29cadfcfcb9ca1b46c96', 16),
+                    gmp_init('0x9234541e268c8605034f251d859cc04673f772026d0a4ea0f6afd2b5339da29', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdea8ce33a5c2ec3c64c5d6199da8cec0207c7b423b5f39b3b916e6853efab7a4', 16),
+                    gmp_init('0x7b5e386fdc6bfbfb75210b9f80fa18b5d73b6c061075edf637d16cc540c39fa0', 16),
+                    gmp_init('0xe852f8f1db953920016aa5f68a48d282033a0b7b1dab3c30dcd4359fb85bffba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xada6b5bb4a41cbfa6c853476588da0c4ebe14d05f69202853787a9497f902ecd', 16),
+                    gmp_init('0xb27b521653728e825f6e68e78cc683c69b508660060f70aff5079cd124e79bfa', 16),
+                    gmp_init('0xf751d6abfc2c598282afee1fe00861ec7e7e06ba512dd8d0e9a6c0b092088e20', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xef7d9c2509eec509a162f49c0b66e48aa704ca0a3c52c45c8f4a1fce52e5ed3a', 16),
+                    gmp_init('0xca5bb31540cacda202820be15fad7f92233a81732f27f2b79c03aa2f01e90d5', 16),
+                    gmp_init('0xefc592ab0a6f97d4184e9862ec8ffe276dbf7c731f3e40fe14300ee214a6effc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xffed68b1ff547a1d189a445f82055b0fb3e77e601dc8794f5049df76fcddc06a', 16),
+                    gmp_init('0xd06fa7046ce0db95b149279772e8ee27f0267baefb9db31c1b82f7648f3a33fb', 16),
+                    gmp_init('0xb9a615a5cfb2503211a985d6416f17223bfbf738ff3b8936f845fb715ecff116', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x37e0a64a5398d82cab9c29bc296e2fa20a3a7babeddbd57a2df498a82e1e9d5b', 16),
+                    gmp_init('0x4a157c91a1e4d6eee4fe03d5b63825b0b9faaf81039c6c82a88b6bcd8a57c59f', 16),
+                    gmp_init('0xc3a1f644cb638f537d6f74fc7b2c25be18681265678ece72e5c3709763a6d464', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf824fd54ad97db3e14e45f0d85a06a7da33eb1cac7078e927e1f93d0d61f4a22', 16),
+                    gmp_init('0x9aacc8a2653268cc32a02a2178bb537844e9ea1f52d5d326cf76df5dc70b41fd', 16),
+                    gmp_init('0x1bfadd417fe03713e10b939cb3ffd4150c708b5d8f1637838f903808e964e999', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6e9de692cd5674c5486992b62c024be2f3908b885b9e2d75bd531c9d1d166c4c', 16),
+                    gmp_init('0xc225e1b3916c1758bd5761101d03848585cb9a666fa6af39980cd340796f105e', 16),
+                    gmp_init('0xd69e1fd82fc7bf326a777f845aa835243671448b4a2e7ce76e4c9b02a5df2dcd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91e940fc6abb9ab005ceb98f99f7317bf39f80e2c8a5a81bc5bc0839618a30a1', 16),
+                    gmp_init('0xe7bb191216db5f99e3bb89f3fd44d3044bfeb7864d65b6571d4c429dbdcba446', 16),
+                    gmp_init('0x7a84d38cb653b5bc9efa38a282656148c19678f14f888e979481a2493676ade1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf14242c10e5a22a381604555f145423c8cfeda1f4acdb2407b59fc6827cbae5f', 16),
+                    gmp_init('0x69d6d1935ca5508e3c8b95123eb9c685b38333eedb7617c45b4fa93fb41cd36a', 16),
+                    gmp_init('0xafa5cc4e09b5f42363bf97feafd265765c97a2cef724830d693787da36e24f8b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4a1fdeb73de21e08435a0429efce924025349ea31e898f1ea97968e78184fe7', 16),
+                    gmp_init('0xff8fc011ba3b968c1c89a570e877188984b68e88e581b66629e87e341f48c4b7', 16),
+                    gmp_init('0xd5cb74954f45eae12308efe170f895f09c1c51421c2c720531dfcd6b5a1ffe10', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2617641e53cf408928b59a3d864a990b23a9a62dd0591bab2c4261a46c06ee7a', 16),
+                    gmp_init('0x8631c55e9e468877656e1e3e62b8e1d015935522b9af797cf0621f36c354dd37', 16),
+                    gmp_init('0x3c6151b83a0e7ab1196ba325a1f8c50ce59df2ef122a80549c2015b03e404548', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcc34e8843b7f7a4fb8915a780f2fc71d0906fc4fb624f7e8cb81f5d5fe6870e7', 16),
+                    gmp_init('0xab2cdee65602cccfeca9b85bb161abe6ca7bd193f80ec36ce23538404bb5021e', 16),
+                    gmp_init('0xb9d982ad59655e04a9bacb257cca2d2da959a2a848e4261d0835946e03d827f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7d87e7a2673b215b5fed983b55003d38e2760e535c02a74bdac6402f984b8be', 16),
+                    gmp_init('0x773ece8cbc6eb480e505d731d0d806134733b3e3a6e67b5d57f97832b0ea8037', 16),
+                    gmp_init('0x3f6c044b5eba06ac6bba2cd4421073a0b6e4801e19c80df81c710c80f5a87ba7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf57895c97156b15d3406c01063fb3a5f3d9df355bf8979bfaf549a79e3234ebb', 16),
+                    gmp_init('0xc14ff9dad6754d001ad3e1ed0adfe0609f6edfdeee319e3dcb94e0d7439e63af', 16),
+                    gmp_init('0xaab04635306c3075c9ff8056f362a7a89475ae0b2c67de0d043c64c1202b2517', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x7b7083900a14e26bd9c23c7417abdd39b7951c161f33cc58669020343639f911', 16),
+                    gmp_init('0xdf284826774900cbbe4249f3dc68c39c7d368fe713539cca46ca976f5b9e4895', 16),
+                    gmp_init('0xc1b1501e53cbe2834e371a68ca8cfb4218420ef5a9f1759b51887242152b5e80', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2aade9e58266da8be46b8db97569d40cbaed254d851a4fbaac382ae6fbc2818c', 16),
+                    gmp_init('0x9477be10d74b9f243e15e43a8bf3c4ed9e16567b5faca89156e14d1b29f100ed', 16),
+                    gmp_init('0x1186f9472cfa2f481670611b5e87642796efe68b484e22857cc418ba126ef661', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8db5dbc2875378ebd79dba8c284090d7c7430127384ddfbddecb45284f09ee1f', 16),
+                    gmp_init('0x66ee90da35e88aecefed8977bfa2a3b8f05740b3fb0bbba85aa71b1019aa027', 16),
+                    gmp_init('0xe2c0af1f66eec00e0d1570d35649fd3567f4492b1d33ea36006ccec4f543bbb9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7a757f2b0166736c3577fc239682c215792e30e91500b2964cf69b7eb1079685', 16),
+                    gmp_init('0xb5a397b1e5c0778e1f5827597f4d0a2adbd066580b1bd7428622c0e970d9e006', 16),
+                    gmp_init('0x9dd6e82a74a8313f79784fa85975d27739ab0edfb87909dd56a389d36c67e6aa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x34d333097bd62440e9b2decd2a6d79fdb1b393b124df3903ac8ce61fbf24f7d8', 16),
+                    gmp_init('0xddc116d5e2dab38b8a4c9e8d06e4dda225ebac14d461853e131dde9fd37abaaf', 16),
+                    gmp_init('0x938b1d9e886fae8da017535f68642659ed17e58138dca0692de1c7391efc1ff2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2875461cb4a03c4125a7d95ac68a70f40529eafe19ba78375c851313dde22fc5', 16),
+                    gmp_init('0x70ed850a9d45eded941450926f3deb11be09de9dcbd21a39cf991275e75e5de3', 16),
+                    gmp_init('0xf2fcfe2afe6c3245d39471d285b1b03d79386f9b8712111f33e4f924291b06cd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x461bcd93cdba71eebaa9ac9e3774a50bf5423faf2432847c141c739f3781babc', 16),
+                    gmp_init('0x47de611308653eabd63a10c049b661551b9f5117451d569417c5c97491712ac0', 16),
+                    gmp_init('0xa00ad18088bf6b7f720b4912477f3b3e5e198e0d347c2e3f371df19c312c1cee', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x99f82f467a4877c958598e3f9f4341f6fc4b4ecbf8da1d25df1f05258dc5f9d6', 16),
+                    gmp_init('0x418f39f3454a69c7c1261ccc4a3dea8c299949b5e2bb9bb9f9126ff8fbbc58c7', 16),
+                    gmp_init('0x27f92742f95e4e7dfad98b8e41610f171b6a5cc64b043aea54486c11db9576e5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc6ae22ec2c3286400110f2dbc882408c75abd0c67e5172310f1dbb4f241a7b0c', 16),
+                    gmp_init('0xcdb9f9ff74a86c35b6d53a9ee18fa1d60a40da227e403355af532215624d0cbd', 16),
+                    gmp_init('0x330410b8cdd79f6dbcfb84ff30b61935fcd1a99a89f2b69f653bb8818c2b4908', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc9f78bd211b35ad48cbeff89925acaef328d7a3d47a14b170108a48f5905deab', 16),
+                    gmp_init('0x834581f03bf5848019f3aadfc24c73f9aaff39e28da157dc8d71af71155b71d4', 16),
+                    gmp_init('0xc850850d46df51006d9e4e47c2e332eb84f9da338c4158bfbe70795607de551c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbca31d163be69e25172cc23181e781623ad010ab72e45645f6130ea054604a40', 16),
+                    gmp_init('0xc0b92ebd833f1b762f2e6dba8b87695e096125394e184549e1416f149935fcdd', 16),
+                    gmp_init('0xaf6110869440dab8ccd1a7b03810b15fa3a4e5c43366676104df6af053090bc2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x219e33c0f1bedf6a45296b9b33fc76656c021f3743252dc0bb860baba1b5749f', 16),
+                    gmp_init('0xb85588ab33bfb8a39ab65cdaab7fb0bb2c56d5299ceae1da391d354400627aaf', 16),
+                    gmp_init('0x1935a45d28b744940bb774f93aedc68bd13801ac53468a552ed046982d413863', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5fc5697d346f5e940e70a4f085712968fadd96469c48dc6655eb3447aa790a6a', 16),
+                    gmp_init('0xb90a7fa35782160b5f9ee25b34fe1c0d8478ac6693138d36b8fca39d10a04d8', 16),
+                    gmp_init('0x45148986dccfe11c9f7fbed61325f8171a7c1eb660e649d13e7e8b5119659011', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbcae481f6a4e99136a77c756b6273be1228e34562f26e2f9a5b90a38a73cbedc', 16),
+                    gmp_init('0xda1b163e98464e55d69be89adefb0b4902ce91b5d7fb9c8696e80442b9b5a69a', 16),
+                    gmp_init('0xe208c697d5e67a4c3f7720a130abbac286e72a6ea74c5ef684f6e94c0b857393', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa4c0304a050696ed1766bc735c11f4928e8b4de92d90e63525bac997629358a3', 16),
+                    gmp_init('0x13e14958107fb3bb38de4471b61e101e91874689c37ebbf495aaf5d0015a818b', 16),
+                    gmp_init('0xcd6ebf613b0e47ab49025ac6fdb2cbf4b7aa76dc94fa854650ee0f1ed537efc8', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x2e934ee2f484eec3a0353f823ce399f537f6a85b296df589672cf8a68bd84466', 16),
+                    gmp_init('0x46172c671b0f6e97e364778c4d7e67a5681514b0c7643eff6c80d39040007c37', 16),
+                    gmp_init('0x4339028ce76ab41a8baf32d1ac7ca6b8a22988fd92a475b49754e9d6862b391d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd68568fd0c1cfc475cbc3ca9e846dccae034076bf4e189c4ce7926ba80ac081a', 16),
+                    gmp_init('0x8a4b65c7efc17985223e159709cf06c07c27107905f633fe9d8c110a4f2986b4', 16),
+                    gmp_init('0x8eab81d34e48e759ceea57924343644acc85349de4c8e9305ca894efef079534', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6e00785d8075178b290363876ccd361eba0111409b64387ef719e6f180a32697', 16),
+                    gmp_init('0x913cb49a621a1a7010c413025bbcfd8edee16b9adfb0ca159989800ac1a06178', 16),
+                    gmp_init('0x2d9afc99113ebdb3696e884315eb6965869ccea797de0aa536660faf32157283', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc12362e51cda5c3a70ffb27caa9715b68d20fdbccbe2f18519aaaccb8493264', 16),
+                    gmp_init('0x1e708323d8104355824500062aa3f63fc97935eb9fb074580bdd3c7e5a213234', 16),
+                    gmp_init('0xd95bc7d82693193b0a2a206383f954a16f652789ada0bda5f34e2b86305096a2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91f098b910b750b18f09bfd03d3c03b6833f453a833e7613f53771699cc61dec', 16),
+                    gmp_init('0x91e38e20a6dd83628a2fd8ccfc9337daa460878fd5cdc6b7eb610d786ed8bc62', 16),
+                    gmp_init('0x3ff8aefc30924b8e2f5eb91393de1b6b074216a30e570674dd2749ecf5586ff8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x613281abd63f6f5acd0205d1ff0aa006050f98e1314572a2a2e845fb00e3fbcc', 16),
+                    gmp_init('0xcd3d8812152cb634d84fe120c2f9157e4c69e4e27652162d556cb68e8901db5', 16),
+                    gmp_init('0x6f21223b5f397a513f735820131a102b5c98981737eefe14bdfd7005e5842338', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd12a2b33b1e3d7eff482e1a1549d5427c13ca223352d01ccb24360d0a99f19f6', 16),
+                    gmp_init('0xeccebcb91dfce783e9d465162cdb85c482a59e13a89ac9d8610c5dc8b2982fe0', 16),
+                    gmp_init('0xe38e8398d2c0c35565990216a28863171298d8c6b6d0410ce15c33ca24608315', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbaddd594db81b7aa005f5a301cd96ad9a36b15d45c02e61471ee21ff5fe389e', 16),
+                    gmp_init('0xf888b57d3ef7dd2298bcd85b51b2930bd8a6f75855d929423f62b6daf9b613af', 16),
+                    gmp_init('0x59ae8188fd1771ead1a8601155b2323de6cbe62f1862c5e3fd7e4370606fa380', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6410d2be611d57bca4d089df72046e76d6bbe19f9e27bf3cea46696a9d41b056', 16),
+                    gmp_init('0x9d224d4be74dbe7dc445e7c28c7c7409ecb80b23235bab02d219da04c70f8259', 16),
+                    gmp_init('0xbd1a0f199c8689de0c2e1a6c1726e9dd300b3413b32f57af08f818f21a95fa32', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8deba44c8bdb8f393fbb36b178ccdb0c94ebc5769bbfc3035e107d3832460fdd', 16),
+                    gmp_init('0x262c1eacff166613d2c458cfb80bd6229b5e22b13a9fec96814ed71b8dc9d0d2', 16),
+                    gmp_init('0xcb3ff458c29b8895bb241e38550648aa10ccbd5038fe9023879790f49feaa6b0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe1bb26eae03ae5352ec09d62b08d7921b0c47a4c68dbf9ec46f230a1326b3c26', 16),
+                    gmp_init('0xaedbc38e6401191d3035fad27a186c6768e5ecdbecffaa5e23f2363ba8dda281', 16),
+                    gmp_init('0x96562a4b4451daa7df03109005726c6a485d8e6f4aee2275a75aa43c4c031f13', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaf3e0d81d0a67b71e312f4d0d8599160cbb9911faab4f7e03da06b0786d4b1f2', 16),
+                    gmp_init('0xbe2b115917e9674812e75f210f04844dab55f9b8aafaeec31ecba5c0f09b182', 16),
+                    gmp_init('0x286bdd8444b8a8fcdff4786db8396c9978cec29a0b41cfa0eea7317f6471a682', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x605f00ce18ae839c4747ba8a4c7e4cef3509f7e120d75800f4bbce1dd9cef6f4', 16),
+                    gmp_init('0x2decbbfb754f6e634c5f3ca3018ba9bc58f0c044333e2192589e6b998b8e435', 16),
+                    gmp_init('0x4d0b30c12cfcf94382aaef08bbcd0ad170270d60ba939f2a69877df01076fcb2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfb6db8a0a6559d3a1d37407e974e4b1fee9702b559807194a698947ff01f12f', 16),
+                    gmp_init('0x7e6f5bd12964685716b2d627789c399c65741953093ce8b9973908a2baf14049', 16),
+                    gmp_init('0x61972412fc132ab56a847982fb85fbe425ad8241ffd6c5d40035bbad6ff0266b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x472933691634b2ddbace94ecdef2c6014b4008b5ecdbb7e55c3a5c7d8b4330a', 16),
+                    gmp_init('0x5edcd68bf5528c98e6a08199d80dba3f5b64d924b8fd23bc32e5c2e6ecf55241', 16),
+                    gmp_init('0x4bcfb7b9c9d3d93e51ad2d17982d4e4d3e0950fb80e89724f571c21e15c9b9c7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x87535db34b4b4e1d87962450f2f88e72bb3195a7d39c520f961e39f3b340ab6', 16),
+                    gmp_init('0x9e9e4e98f0e4d60f405d08a8bf96001db5df9ce82905a03a84f417ae3b752e92', 16),
+                    gmp_init('0xd38109408861ceabca0e26f2b8607b316e612116460cae8a3485c006e62443f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x20056c107133c326a2d2183b31676080356a3aa639c282f157a22580081af155', 16),
+                    gmp_init('0x2b8945d3e4e12f19ef935ebba328912818aa88d5653d1920d93739dfa471d95', 16),
+                    gmp_init('0x3cb1e72d28cd2fca0b4a211e054207a9863169e1e1c34cd45a0e4ba35c6225b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd56e744989212f5a5dadf37cd229598033444f0638f169dd50acde4b955a6310', 16),
+                    gmp_init('0xbde9fd5913b5a9c742d2ed97211d9b84d43795407d1def579d9344fa8a50ab07', 16),
+                    gmp_init('0xb49d97853f48a008da30b40e9b299b867364890c2246da39f26b934db580f2b3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8646c6107976b7aee30c72216925666a7eb2e38e92c69fcf7a8e48d815530758', 16),
+                    gmp_init('0xfe7b207b83f74300989e558759605e72bac18d68c5485f2d36cd74e04c222adf', 16),
+                    gmp_init('0x5b7b3a37c6f84297a53624987b6c8354844008fec2256ddf9471a98516a46ec5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9dd61160c5d16e1aaee4903704418339b82a0272da04a7eafd22d3b60cb8ec5c', 16),
+                    gmp_init('0xcaa3be673b63488f50f937cc9c9637cb85d68cdea2be97d0bb2503579addab35', 16),
+                    gmp_init('0x9b15ed62b287dde4dcdf0b97091061042adfeb7cfc5649ae1cf9e7851b33cc87', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1bb7181b82ddc840e1cdd905d4b17100dc6a2279aa83764d8bc43c7717d9e762', 16),
+                    gmp_init('0x9b529a2bb458e1dbb27cbb0c2a8317e72f99f25fba5e38f7b1e26873fad449ac', 16),
+                    gmp_init('0x1047d79c2cb836fc0f3d29ceb871fd01ef512bcbbc107f1424b7b0e8f4d56aaf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf46f07b70c07134377b2cf028a388aeae568bc17621af6dc11f25efe228cd689', 16),
+                    gmp_init('0x92ed6db99c2ec0da7b38bfe18cede643a077976d353db80374ceffc4779ada88', 16),
+                    gmp_init('0xef59ee5ad61bc109554c6d89c27021952da91fe9348ae2bf8cbc01b6665c01c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb341990d10f3b799311e3aab78ed1b0636e7ae7c107281010e615a08d469bc45', 16),
+                    gmp_init('0x66066021c7cdf74de67972944732eb2778e83ee1fe9fd3e6ac07b7f83e88dcca', 16),
+                    gmp_init('0x4668728395d94f375a742dfac7f66bb66aeb03520d6bb1b1e5ae7bc3519887bf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x68f2d0e74a0438ce2302f5c7d11c8951815a994b84c1bf5ce72b81d1f0000df', 16),
+                    gmp_init('0xa497df7e4d3d70f619fc3f20e2a558af7b7519ff0e24e3c1ca4aac36859fcb12', 16),
+                    gmp_init('0x42c202a6b58e7f71f0f98a9777881d59a77e497b2dcc9329e94b48960e9bf856', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa7c0fa59af4c4959f621306f622e29ba07c52b9e6ebb894aa0774680daea8bcd', 16),
+                    gmp_init('0x7c830f47d9848476c0133ae9f0a186786276b5e69ac37da53c7983c687243475', 16),
+                    gmp_init('0x36016b1138f2b86a60ef408e9384a43c386223988a6723b3a0832e4be06eb3eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x171e6c7a8dffe61699ce33b203c3ae6f0738c49850fda049d7674f0fefced4fd', 16),
+                    gmp_init('0xf47bfe281f331a1f9799814e8b062a474664c38bc95369fc9eabfffd257b7a75', 16),
+                    gmp_init('0x947ec1c825ec72ecbb8b3c627cc286a69f91f30f56091f68ea85b7e4ab5b9d44', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdfd75b5d3c292200f4fde886953f2bd50e6d83be1dd43060a5a29048348eb7f6', 16),
+                    gmp_init('0x8f5f11246d9a960bf30a35ec4388cd268830b3d9aeaf3359f54dbb1c50665679', 16),
+                    gmp_init('0x9a79533750993cbd865870652e3a9ebe0cd819133e6a5c2a1775592a441759c4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x684d7ea954011a2c9df440e01e940a537f3a52bf46af9bb8ab8002799be26e5e', 16),
+                    gmp_init('0xa7174af385780525bd4c2f24afa823ca5410f15a2d4bb4186220680cfb56b7bf', 16),
+                    gmp_init('0x64bf1c1e051bafd0ef8c8118cc20a3347ae0bfb2250057bc92d7460d2ee0d88e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x553fae838dee17a707b82c5c373e04093dfe44de5358e9f0786c9a0ec4733424', 16),
+                    gmp_init('0x95423800441b4c632f938e252a0600985cb89674d03b7cb0f98cf3bcccb098dc', 16),
+                    gmp_init('0x60e27af84b0fff1ae959bb58c9a052aefc5db4e7cd2dc1c3a1c8b7d5e0d264cf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaf80ccc40add79558af9e9575a21d3b52aff63afef5baeaed9797db4f910540e', 16),
+                    gmp_init('0x3aa827709f553862bdab7630adc5128e5115151fa9cf53965577508e496ca40e', 16),
+                    gmp_init('0xc7ddea1930ad74e128f008d52ad2bc16416fcdf39e1b0cad93ceb3d87c9f94ab', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x4c3aaf6c6c00704e96eda89461d63fd2c97ee1e6786fc785e6afac7aa92f9b1', 16),
+                    gmp_init('0x14f1edaeb8e9c8d4797d164a3946c7ff50a7c8cd59139a4dbce354e6e4df09c3', 16),
+                    gmp_init('0x80119ced9a5ce83c4e31f8de1a38f89d5f9ff9f637dca86d116a4217f83e55d2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe70ee0b4b177d3fe727ecbd353c8a1f7df421872e6e25cc569e0059874d4370c', 16),
+                    gmp_init('0x1417b3c4765e1e773165b595603867b3af4a3d3d1f1ae9c404cee3edc205f947', 16),
+                    gmp_init('0xbf403ed22ed26a82a4ab40bcc03504f0456950c5748580409dd415cae09aac25', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8b0715ed2e7408dd4aeb92e29a27fffcf45f63c2b4865036c13fdd9ecb78f126', 16),
+                    gmp_init('0x877e5356508c6390778271ce9678b99018181d65ec6a18b77eaa35218b8e109c', 16),
+                    gmp_init('0xc78a43c82907f2eb90211dacc29e00337bc3f882dcb10eda7ea313057eba4581', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9261cf69d51d0b3d1c423be72f0b1f99bcbd7cc5487d0faa82bce088dc57f027', 16),
+                    gmp_init('0xdccbcf39482cf7ff6b54d5581949829174e5b1890b4783a480547de484cd35f3', 16),
+                    gmp_init('0x37ac1034ffebe835fe528fe560401fb79b9c886b27f7c8c334e2f49a97dc8976', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6099e226ec2be03c9af02f55da1d7ff86c1acb06adea94019fd656ddf4d8594a', 16),
+                    gmp_init('0x9125874f1d823acaf2a910006556fdccba781b8bf6da4a64b607ca9ff011e6f1', 16),
+                    gmp_init('0x930705b485835fca801870fb842c17255fe5ea60ad7a042881f287b5093c77e1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe6353a4a4e5f2df4d757c88023ab2e830b4881550a339addc551d7864af1d3f2', 16),
+                    gmp_init('0xb58f329a294181e9601eeb144238950ead5e751d7ccc00715911b05943d4db5e', 16),
+                    gmp_init('0xb2609d2f49bf07bd027cab87bee45a1fefd55a6088d12fa7aeb5e50139dca10b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf2cf781f0081a9d915df7e1c6fb0b9da83b90cb4f2213a5cf527d489dd5efbc0', 16),
+                    gmp_init('0x9f090488ca4cf0fd837244b3e3b9f091732ba94a1efc5dfbe130fd833bfefc22', 16),
+                    gmp_init('0x4cc7707a211cb7886cc00d60f36b2e8eeffd4e1c302af9509c7e0b0f8eb225d0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x290120a28ba49f3f57b385a850a0727e4d834a9c20abb4df79709c594e039a61', 16),
+                    gmp_init('0x4876c8db3c91c37b5fe5d5d1dfaf3a09bf29c7b72741ffcfd0f127bdf90c1f80', 16),
+                    gmp_init('0x69c090da6891fdd504c1658af0fdd68564d64dd4f74310dacfdbde52a4a905f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x388339f3c31d687ec3975a944f02caae36432bb1f53226a72c0676df78a9ad71', 16),
+                    gmp_init('0x85526ef9cb33595045041be9be7eadfcff182b52d6c82224cf09b973a98aec19', 16),
+                    gmp_init('0x89b5c36191e2ff291fbb4bece336cff4e960bf35548eedc42d608ee634f44749', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xff71339ff4433fe3ddfb4ab8a53cf0a0c1d1f0f372d149c146a32ad41d60399a', 16),
+                    gmp_init('0xaf996735c692d468adc3f757da884007f35592e207cd3f47a5e680405e3701a7', 16),
+                    gmp_init('0x9f6578e63036e8ef633a4a3245660515d968939f12383c36644d29fe7c608b59', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x446a22d8499fbc06711311553b268ad7cea48757b5c6078f36e9efbdd7aa3a94', 16),
+                    gmp_init('0xe575690fbb913d853c1c34ca0cc0b04fa7350a79ed672fbc2a7bfe8f88f9361b', 16),
+                    gmp_init('0x6b3a7d5b37530b1fd33da577e0de33c9d4d1fd9cc36ea2dc31be1a45f1b859cf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3512895ddc774bb560f60f16ce5c6b268ad6e01f851a58183a8a8053c4949966', 16),
+                    gmp_init('0x8c5f28938a1b15c3f9f9e9d0f88a4724486eb12a5d0f18e8b8108f5df31af53', 16),
+                    gmp_init('0xf556123fb9d97a848d23ba58785cbf36bbd08b722afe7dc02599c53588c3fbd3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6c62c0fc8c075c352b186cb0e2597bf3e9bb453776c9db695d0951bf6f82bd07', 16),
+                    gmp_init('0xa0cf112415335116a0efa400b65a7c3c3304fe2f049ad5d3828ba033d1c43b1b', 16),
+                    gmp_init('0x7a71506da4c2f2429246cfd9f7183a4a4e01abe5af33d885dde5b25404bd9f4e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc86f7e862cd8eb7ecc59c342775050e000958ac320e5feb9586e29cfb28cb562', 16),
+                    gmp_init('0x595b8a9e6e4db7d2f6eb5ce0796a38e4ee03987ad2857224a8e93220b711adf0', 16),
+                    gmp_init('0x2b3e555a56c9cae119cb0f70f0f3b798b35cbdfabb301c9d52e7f71fe5b0ef4f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb69aeead32c27bd2cb266cd15936973fcb7c64640baf20d9009b6efe60b195e9', 16),
+                    gmp_init('0xb46b13247550e63d15f59918a2c61e1edad602f51ba7996abac4c8282d7a4ed3', 16),
+                    gmp_init('0x2c9750b2c88179cf63aaf4c4c0bd8a72796a0e5c490119d25cfdd521fc5e87f8', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x7922a1ad7eff40514115efe1c650ab78efbb76d185ae3862c07f78d97072d04a', 16),
+                    gmp_init('0x6ae7e2977fc9ac91b6fcad2072807653fe1054350a505c38b61e8e7852d3a83c', 16),
+                    gmp_init('0xa0e242da24dddd13180eb11af464459a4bd6b2c575029379a21f052600775abe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1365519b2768dea5c51b17c82d08f52b263e36891f7b76b953e0d354ba4366e3', 16),
+                    gmp_init('0xff0a707dca8e733f36e7c8a969bbc7126fc920ec6040b16ac44b1df172eb9ba4', 16),
+                    gmp_init('0x55a107bf0fb1190bd875fef7a9e49f5ac5ae40b921b8b125671c60021d1e44e5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x56acb469178fe18f93d91c8ec83a8d1fc849613c8a7e1e779eef58c18195e64e', 16),
+                    gmp_init('0xd7399e14dc073b8fe24c3589843bc7ef2863504c3647d4b0b76cc450a597b255', 16),
+                    gmp_init('0x1c7c407fc571bb5f0e8cc7cc0bb8c91db3233ad27bec34016cf88997fc222934', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa75884279eca9395826207fae92b2207ea4a5b596be2840b357d3984bab9b23', 16),
+                    gmp_init('0xcb0b75e5a2975863e84ba0165889235242bfc50cb3336f3c7de2bcc3871e5b1', 16),
+                    gmp_init('0xe526b7eb639a62c72ed3dd50021788dc8b7184961c04c8e62aed3eab232390f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x45ae73ab4f366e5900f060781e60456c6fd4b9060222882d88ed95a345721f75', 16),
+                    gmp_init('0xd672cf97be6d7679f2eb0756bef022e32abe0509f216a9ce1dc3fa65bbe349ce', 16),
+                    gmp_init('0x35e7e0d3b82c8caaa4a7ada861170831a5df213ae1bf85a8a4e09ffc1b95b8bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2bdc4fd2411388f3859f532387ce646e67399a284dce85d4d15a3eaa5f086f6f', 16),
+                    gmp_init('0x202a61163e733e41ee91422add487cd09be3cec4c56c8eff360cb037f94c1912', 16),
+                    gmp_init('0xe4ab356f62c9ea62a5cda1de460ba265b9a28035b342b00a0421db91827a529f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8c29c7f4005f0320a1b721082bff35f19cdc7a2b89389b70e112ab48f6e54714', 16),
+                    gmp_init('0x8fd9c876dee0717f9c4a84428f64bc87f1dd80373de9b417c04c3da035e8c15e', 16),
+                    gmp_init('0xef05f9433b881b21ff1bb3a0819bac866b87c4887def43dfcaa75c53aefdf5fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x46e892e1bfd26469366089bce01a2840fe5e73d90269e2798a9e6d1b26ae0e2d', 16),
+                    gmp_init('0x47e4b7081a993e0ba8a9531fb73161ef829313565d83db72be5a8da39f97af6a', 16),
+                    gmp_init('0x577effba3365c881427f13ccb2012680950310531c44dc3e0ecd144e6ab77478', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d810cc4e93b7bc149f82b78891388a79e90fc66cd80d9e99a92797ce60d8560', 16),
+                    gmp_init('0x25cd8f0dd0504dd01c13bfaeb040fef39607b56b5fce7b085e7dd0a5d7fa57a1', 16),
+                    gmp_init('0xa0a2424010bd0c0fb7ed42d4e9761d4b14a1732648ede8d4711121137476d830', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1935ead9b0f387f59a6c86d54dd99acfa7a110eedca2c13251875c636f07049b', 16),
+                    gmp_init('0x47c3e27109ac5426b4177b311b51caf027fd55c452679cff8fdd779953d71750', 16),
+                    gmp_init('0x5ed8d9cee54595baf633de73585d8d348d588384b9784572583ebdbcc0babaec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfcc33d6d9695caeddffe454592381ded190b7333662fb91d48e66a2b1ff8936f', 16),
+                    gmp_init('0x1ada094711607c11915995e50df9f4a99cf6870b1a45d758681b3e7e0e794219', 16),
+                    gmp_init('0x224bda437b301e05fc959361d6d3df1346a548b0d6a2eeae1c5315464c4079fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf822a64badb0137549ae8886501357e87c2a6f7284070986ef2b7802ddb4a2b3', 16),
+                    gmp_init('0x96786203e5fbc14fd27ba7112412b29d6d33718cd6e24e2d148474f66a96abab', 16),
+                    gmp_init('0x40798bc48e55692e55e47e2339f3b1ae944e77c4add97920fec4e643acd59fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x174ce09a43a3369fc7b9300a74c3c6dcdfe0c561acbb6a3e1c08bb56cc8630cf', 16),
+                    gmp_init('0x6ba59208eff33cbfe472e483f543c26e52785742e5752dc2fbf945df058eeeff', 16),
+                    gmp_init('0x441fcb66afb4f73bfa92f5ba6dcc7f1cc54d2617a886bc0fa2f04fd2ab5b1a9a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x29edc70b44276f8bf105902bf1eed9376544224d94f1c21be4de80cc8d03a6de', 16),
+                    gmp_init('0xe3f33e0212d3dda654e80b07a291d9302678038eb3abde2fb3b3f98216cf058b', 16),
+                    gmp_init('0xb0a3b30db618810df778e5242903d0259538a8c5bc9de53653b34f3d61e8a4c4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5b85e970ca1425d19a436625902fa86bf84bae9316a68d6f802a19b78e57dd6c', 16),
+                    gmp_init('0x8756b4494c7f9479396b908c61c589c580434926bc30945eff73280ea2113534', 16),
+                    gmp_init('0x751cab9f92191c984821e9ea35aa7a3e4c5d914b8af2ff867292531e721c6369', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x57fa95a0ca4c66cdbf920eb7505989bbdd46a4f172f5fa9987274107151e03f4', 16),
+                    gmp_init('0x1fe4f0b3226992f8f9b4110d63675eebe8b7a72daa4f23347c20f5e73cb836b9', 16),
+                    gmp_init('0xa27b578872f705dc670b1c1e4a18b4c78a42a029bd715944104e298b97baba68', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x126a8ca0dd509b93759c5e97b4092574128ec04843451ac3ffae91fadff95a5f', 16),
+                    gmp_init('0x4a2ca5735961a7e2631bda73f245259c77eb8f0c421b8f22d54115059dc7b07f', 16),
+                    gmp_init('0xd3cadbfa0913a9b8603d6df0d7085996c0f182735ba06f17f8c224ec8c922cdb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8f336c5683019e80b9b9bdc757872645e1ffcf3d0112a7a0122c7baf5cd59f6d', 16),
+                    gmp_init('0x9e2d9806fc8e4523602320426ebad3398e1122e06682745080aea99df3b39151', 16),
+                    gmp_init('0x875e78d0ae62a911fd1c3cb3a39665ed366c9f55b26e5ff05076adc124e8d55e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc47e502eccbd3af4ab6d62930cfb80955a59bb8aa3fd55fc4fa68e855b6ddea4', 16),
+                    gmp_init('0xd1181c2946d3abf1613b56bca6c072f07cf810cc0befb5cfff0e61e26fc98ed9', 16),
+                    gmp_init('0x48f2bf5e791ab3d96f8010c199869201b682a0dbc662668e4c3b70effe1f9c7e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdfbb13cf8790c9adb356d2e28f49636c31cbf55dfd894a7c1fefcd949a202736', 16),
+                    gmp_init('0x595ac2c61c677fc0ffaad8fa1aba49b76d91857f445ca90dac902e54f9462b5', 16),
+                    gmp_init('0x343bd4095defe66a52c054b6ea8ce2f968cc634f2161bfa89f7b7a0b2f6d3f37', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x77479e641a4b421ae2ddf31c134a614544bdee7e063cff716f42f43462779f54', 16),
+                    gmp_init('0x4d9bf7bb8c10598d9567f3e59a12200df905a0455eb030f4a21163bf08e3cf7b', 16),
+                    gmp_init('0xc57a9ebf2a54036865cd5493b5ccc9a3581f99d9d8b102c823e2b5e3eef9580c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x714ce1842f3ee667b8b316b7544794f3836505926e4641a7598408740d9e703c', 16),
+                    gmp_init('0xa512f535647fab067c7851735ea74b832cace094ff91346647080e7312d38de3', 16),
+                    gmp_init('0x2639ddf9e4aa8c42feb108a11eae4348ebddc9336525b4a37545d001f0b5bc08', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3266af40392245e09eaed280315873c9699628dd863484164550c1793daac1e', 16),
+                    gmp_init('0x5b1496453b8998c87d197c3de28e4b257747d891085cc8ecca87ce81536c234b', 16),
+                    gmp_init('0x1f3852f2655f43db5d91259007491a31558b5be97e61a7a60f751a9741bf0303', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd06bae49a19987e595e32e03313bee6b4bbc1951d7de5780ca214cfb095f14bc', 16),
+                    gmp_init('0xc284aa023d74eadde4b08ed7b03e835d3f26569b5325c5c19a05a8697741eb29', 16),
+                    gmp_init('0xc76c23e863fcd3cd833edb8208e13040a93633bb94ad605927296e0b7622668d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb0952fedfe344c0fce5c5a81c53bc77e938ea3d80232708db9f7062876cfc2fe', 16),
+                    gmp_init('0x80cfd826facae68ab9cb6b59d757de5a7bf744bb48d43a88978350d0a0b4bac8', 16),
+                    gmp_init('0x4b18b024e859c3f8f02819152ce69dbcf5941bd90a339846a1af46663176e4d6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xffcac366cabc55c4f9a23e6810990ba91e4a0236f857590ca082109011b47b55', 16),
+                    gmp_init('0x47879267ca42c7b8681a1b4e321c1af58659a7970a9288184b8a4f88138558a0', 16),
+                    gmp_init('0x983ed996b571eaabad4adc6e0d6184c49f85b1873b3843be55844beab6f10aaa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf3c5bc2e93992c58a0fead534bc64397acc6be167e310022070bf59692dea1d3', 16),
+                    gmp_init('0x1e872c98e76721c4ace9b73cfa1aac83d36dda9555853d3b9c524d9c08f85dd5', 16),
+                    gmp_init('0x76f3aa2f1c69ef91690f9fb336d52482ab9e68189a623885cc62caeb8cfd1b8b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e7f795081eae40ee4bbf73e89c49a9de34cf953be5cbd6ccec32690af1235f3', 16),
+                    gmp_init('0x25dad78951b20f132de8e15aa97b153f78677a044c1a38cae9f23a0ddb0ad272', 16),
+                    gmp_init('0xfa630d516604e99a645e60124c62a0fdddddb09e4739accd9f2e2ee2c6526b3e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc1ad7d07d757fc0122adeb4df196071bf83c935e0a0f1dff64b1ca547a92931e', 16),
+                    gmp_init('0x35594e3d2d377033d49d9f2da6a9de812b04dcbfb67a66e0623bb1b1965b3217', 16),
+                    gmp_init('0xc3f12c36e2e0edb980daa69bccdcd7b2b765492356b71da0ecc2361f89a31c55', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf83a08f24ff85bb55fe76a83520364e8804f7998dd50fa279e14598733f793dc', 16),
+                    gmp_init('0x81037de95a623e3b8d0d59ecdf595ca585ce3724a0f1d1602617200fa83d6fe5', 16),
+                    gmp_init('0xce8c9e579ff7e62b8f34a8b6caed08b1203f5dcebe9b533bb3e9408a1e143654', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xd1fedbbcf73b1e4af59f0f13d2c976d68c21b57424d0a6d5ad1209b94068041c', 16),
+                    gmp_init('0xd3ed133f4283bf500a819cd983d1c201e3dc65ac7d1e49da212481f79fd9c2a6', 16),
+                    gmp_init('0x78f1f586e6a1b132c6da40358505b096f332ec96d647ff084182b925a31e86d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda8fa4a7573de6e79430f2b4ad43367fddbc191241a4fee80c2a14147cc9222f', 16),
+                    gmp_init('0x6e9c5782594dfd70e3becfc66f9b935514c696730447e93f27a5164fc950c774', 16),
+                    gmp_init('0x60bed1fd8c9d750765004772a686562d07deac236f69c26effb6366e240dbd7c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf4524a8493b4c58d6ca999d5ecdb012a6ce209c6d5a3992315415ae426f9c1cd', 16),
+                    gmp_init('0x2712bf26f8ed204f9f1aab7020dbe3cb374b38c20d765202ea323b939292b1a3', 16),
+                    gmp_init('0x17373076d44b4b4a00d9e5f57cae3283192a1a153440441a283efdcf1ed23e38', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5bc0b8a8707a81f6118e556d4ed3b7431c0419c808f9dcd0f715bf1a68dd4529', 16),
+                    gmp_init('0xab9fc80928bc6edc3ed0da159f791578aa112efe0e7ce80bac8fc9d3c59e5d9', 16),
+                    gmp_init('0x85d64f09ba78b0311f90c9d768c24fcb11e6fe82fc7aea4d0df45c11b895146c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x106a5e0b8b59a476491b8453871797dea49fc2d06f2f4b91ae87d5ca306933f9', 16),
+                    gmp_init('0x1142cb6d98afa26cdf312e181e5dbe32fe1f66d434ee94d2ebc7196caf9f9ff0', 16),
+                    gmp_init('0xd757fa6a29859ae8b7d0f03f23aaa42096c0e09031180d2356c0f2d2533120fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfbaf5af982e1a25dc209dcd228965ca2c4b8c106038e87229a3bbd8f49712140', 16),
+                    gmp_init('0xb1986459044601e28e0b6e85e51365f61e41655d1136bf2bf4cbf1b758617e4d', 16),
+                    gmp_init('0x951e0f82199953b4d27d1b87bd36e41f353ae36e4738a05e45f2e641c3fc4e1c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x54f75d6dae8817b6492f557d1e1c5783b1ae8c4ee2da35e49d5a7249d14664e0', 16),
+                    gmp_init('0x8fd8e30f9c8038d992752ae5b7ccd82e3cd93ee2cbe04689148bcdd948eeafd0', 16),
+                    gmp_init('0xddcc477bff393cbbde551e1a579e32e6d53ae542f209cac84d9168496ce1c0e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x417b753e04f16d60340aec913d80a92679faf0b62ae00ac4c2f5ebc79c208213', 16),
+                    gmp_init('0xda934bd580de8e7cdb1bc58a45d81ddba3a144b059f8c199422cd90de8ae7e58', 16),
+                    gmp_init('0xf548ba91c947a13c5e07e2d2597abecd245a299a5ed42330f05a2dff18f8547', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x411375fa80144b87f15a45ee65827df99b2637156d932bc703ef67eb099676b7', 16),
+                    gmp_init('0x7888fbd610d60f2d76b5d1908f84b9351f604afe136021a32d069efd9e575e0', 16),
+                    gmp_init('0x4d88e62229ab313d29d3ee13553b89a5ad1a0eb30b17987f4faa044c64e2cb63', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x31a2f37321b395f2d6125af7daad31a6644178efc179bb4682baed2b477cc59e', 16),
+                    gmp_init('0xa0679a27a62d13f6b0c334482a3c606440dec5a79bcb7f926e60abccc22eca58', 16),
+                    gmp_init('0x34ec04f0a8f5ee891a47567fc3ffc37cf5413a4cfd102e430a025e62ba706b32', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x432745ef2fe1d61b1e682feb5810dbdeac5478c60707c945a016de59cce9d974', 16),
+                    gmp_init('0x78cc6ec179d8b7f42e00c87f0b17eb1d946e2e2c33c468dc1fd074f7c4cbef39', 16),
+                    gmp_init('0xe8176b0c47b5ca8710b7a294e32cbc8ea1f9f7689f82f6b94794866c0654b622', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x38ca233f28889b86170a4fc4a718565983ef552c9da0c5fd28b00149ede60ba8', 16),
+                    gmp_init('0x98c1eb07dfe3ef10f4edf0984206fe1a8a280304529eaac41c9921f270c0acd6', 16),
+                    gmp_init('0x5d2cf1806333fd0aa6df4ea3a871a5266110b79b143585fd2cbeab1627087698', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xea0856629ccfabe680a9721d0d91d18fde6946111df84dc4d3e051b17c66ce5e', 16),
+                    gmp_init('0x3f84497ea6aef069a25a822051a6f31901e53fe8c98181983e1e222b9cd827d1', 16),
+                    gmp_init('0xb73d4952b4f6f0959f9e6850cd17d5ea985717d1f90fa0a0d635f90dff7b74e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3cb995172f78a8545e777bd71eb5117ac6976cd30b0e7914221c92467e7c71c1', 16),
+                    gmp_init('0x41b1aef95dfd29bc2fac48b8413b4afebe64ccb17fa45b87cd588f26ca0814e6', 16),
+                    gmp_init('0xa6bb6e051f081f7dc43a6ce18ff19937dc65c83448006a24174c672a9bfbc3fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x30906142a785b8acc17f420cf0bf14ef43f234dbcdbc2292663ce8bc10213b3e', 16),
+                    gmp_init('0x3cb1edad85c2600be94a695430440a066a5e48aaeb4d14a507bb4747c1fb5a77', 16),
+                    gmp_init('0xbc7efba34151242eef6a33ecf30e2cb6808822ff7c07e9d1b37dbd59322d79c2', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x63a9a5dbb038ce2565d510c8de8bc6d0317020689d2105496fe06ca02ba4abdb', 16),
+                    gmp_init('0x2da96870535a65e4328a87a1b287648c6ccec45af35af8d653ddd02b8d188e34', 16),
+                    gmp_init('0x52bb836a35b89b292dec67eae34761c2ed47fbe5236e057c1513b7a4759690fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3b73cc20f06a6503b7fc8e274693ca39e581c07c245b5b1d2a7854c52407047c', 16),
+                    gmp_init('0xfce6215aaeada2eca0af4c1d18da507e8d21e4149ec1261e8112ae227a2b7a8e', 16),
+                    gmp_init('0x289a22996fb54d55de6dbd33e14cbbd1b9b6cae46e2fdf1a8cc6f390a2dc13b4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3d47c3b9c43e2dde088dc35f082e9cde6d649a459dc4e23f9aef71f8173cd34b', 16),
+                    gmp_init('0x3ce0ed7f27ee3b86bccaccbe777c10149e9edd6c41029fc49be3ff361241c4b5', 16),
+                    gmp_init('0xdee1f2154c266900bfcee555074e30650105170603fe6d772861017434876133', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4cb56ed64b4f7059e77c845766d336f1cd1cd51f5dd949a1e8509968ff6933e9', 16),
+                    gmp_init('0xc5ad3ac8c4ac941e19e041d00ca2229dd265691006caeddf2d134ef3d3b6cb06', 16),
+                    gmp_init('0xb529c53e309ab8cfa4b41ba64d5e5fd033b4d14f5e4f5343a63ed6623a748cd3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x15cabead113cca2ff55eb02ea1b0b2dc4b8f386f21e2d8d2e44465fded188e97', 16),
+                    gmp_init('0x9002d8fbe6c4bd0e64cc0be1b7bbdca231698dc76aa03a9cbf58d1d707ff8f43', 16),
+                    gmp_init('0xb18fbabac22e305a64271a760afce4a23d2b27910bba486de80a5047bb08927d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5fcba9577d06dd713250e5541cc7e48e5060e8b7afaf1ca51fcc2519d85a08ae', 16),
+                    gmp_init('0x95d6ec2896ca92b5984794ee6b83c00143b7fcdb4eb9c258f773c2635fb946e6', 16),
+                    gmp_init('0x7675202e98272d93b7cdfde9b19c91312795c48f0edf50716c01afc9b6165429', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbdcd7548b32abfa8c28b2654c4a44c5c281f71cdaa1a9b63c4718e7b953c6ac', 16),
+                    gmp_init('0x1dae49722f7eab216146d9de9fc0def2aec9f96c1a0774d7582bf0866857affc', 16),
+                    gmp_init('0x1557ce5512200fd52fd78866b47382960ae8b9c0a024e682274c7322073e95b5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe5fbb2259037f0bfb675233a68b4647360116e2f2e21c0979571a41ffd7d36da', 16),
+                    gmp_init('0x7aa3783182a9fa0dc71f5aba26a86f473403e807a6be70cbfa069a9de5eec9f4', 16),
+                    gmp_init('0x217655eb0f428543a6aefe2ea6abcd827e437017d3d7d6f6dcbaf34b7a13c6fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4bed4333802224ac7d60889eff862ba00833d196ac0a2cad24b6a5043a3527c6', 16),
+                    gmp_init('0x3b030aab199a58cad9b3a0eb0862b7bb56f5963fd96c0ac74e54319187bbcd49', 16),
+                    gmp_init('0x38ff04bb4098769c2bd9dcb97ed255e0a1bfe1ce83fa09ebd31408297c0d0344', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc619e1c5b5f5f8bc7b2a14e3df90e0db8a94f16e2508a60909988be1c7d95517', 16),
+                    gmp_init('0xa29e9f3576270ac9725fcb159e5b33cb6763b9d737e6a5344cbf4c394d7e7514', 16),
+                    gmp_init('0x61454bad68a47105bb9c05e2304fb7603c20e09971c349ca728d965e0811aec6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d19530d9459e021c6781fa9c9c6a39e1a20043ae51443910b9e99142069e275', 16),
+                    gmp_init('0xaf3e722603780bfc4fa7ad4a6f6ca5ef61a5f43df52c64efa84070c34daf22b', 16),
+                    gmp_init('0xf52597ccfaf9583219c8b1df6c6e2f342584f2ca095437af12a9ac3d3a70d30d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda1f42d923df668ab12d4f3fb2e399e1c38489c36fabdc27b56d06a1e4bfc5ae', 16),
+                    gmp_init('0xf255ec5834b720a37aecde01c04b7162bb11f109b3d3380b94ab82862e5742af', 16),
+                    gmp_init('0x9f9698124e2518c940fedb84ee42253da25452582d2ef31d5f93866b0e8ea8ab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x785fb622ff4576b409d8961ba3838d7cba206e1a5a394790a608acebf3b0e3dc', 16),
+                    gmp_init('0xa353260db0f9e86ae2882ea8b2d072fb4f90541633b8b2f8d12d2ea018df3b45', 16),
+                    gmp_init('0xbe08016dc0a6cc56f98074545c3437b7c6019981c2d070d564f8fed4fcf46ee8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x371f33c3221b34f8280b35d03d85a58d5c4ca0811382878818de2f21f3f9134a', 16),
+                    gmp_init('0xa6a606c1b416e1ef6e3032ca57b24b6a106eb4c0766058ec8458bec6622c626a', 16),
+                    gmp_init('0x76db57a3316c700fc5a57176252813fd1fe4cce20c2ae9d3099685eb931898fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x391323355f38bbe37b3222dd9b21c945304f1132f74211c88b5d257d1ec3056e', 16),
+                    gmp_init('0xa68b29e21c3db7aff467b6ed239c240226b3d549048da989144a21e8f8e6184c', 16),
+                    gmp_init('0x19ba06ea95868f2372c54ec4944b9a8a9725759f3fd90185ab470731284a43e3', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xd33c5187a6f68081f02cb454aa2baa548bf182df6fdfc0985a7177e5e70c3e0b', 16),
+                    gmp_init('0x98637fc41a4c41275ef9048973d90f1e10de0117fd21b53aa1ca5b5feccce39e', 16),
+                    gmp_init('0x136ef08515b03c69b10c9bc246b23ea1ce07daec3179d48c013f33f699ce7201', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae57addba2bcc47aca49a5a83bb4eb3d3998a58a09e63bc16ec668175d97059', 16),
+                    gmp_init('0x7be1c6791db1cc3cfb10e745d09580e78b226e59bef58a7d57c7cdb0c7ae2cb5', 16),
+                    gmp_init('0xd927e19a72edd91eb1082f9e9c7381e3e949f3cd59e74dc203b2b7b7e35ef57c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d44baffba8c722b4916b1d168a0e3fbd2c474bb267f49d0ff7c52f2d5fb6359', 16),
+                    gmp_init('0x6787732f6483dd4e67a0ea15f67be49ca6d5f3e4cc61d97e03ccbd96f2e2ef9', 16),
+                    gmp_init('0x56f9be113668ce9dcfa4a9d276b139d1c7187c027890a8f9d01e739fcabf0d9e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x916e77cc5396ca44d203919a57490bb9bd97d61da207aa2249bd677d7a6f1459', 16),
+                    gmp_init('0x5d23f7b199e911161f3702bba293c0faa2db40551f120798cf36097974123835', 16),
+                    gmp_init('0xfa466ceab3641d587849f31cef33fe5f15836467a140931bad8194574bfeb83', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x33ecfbefc1ec783db1d67ea6f46fe74ce8fc89b3ca6ba68233c529dbea97d7c0', 16),
+                    gmp_init('0xa35f8d4f6adabd45e92b825c4562bb4aa044a80b047bc377db5272089794eb52', 16),
+                    gmp_init('0xfa29a69893ca61ad611cfd362769cb4d4adeba4cbf5317660baa382fc24c54c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8ac1e47cc3f7809b6d58b40b4abc66d0e6e4886d40b461dff39eb5dcaf855043', 16),
+                    gmp_init('0x1e324fcb08d0859c482fc969522d11aedce22f0b4403689bec11f4cc0ca11ea5', 16),
+                    gmp_init('0xb58abaf143b98b05cf550af298a320bed5b5427c2f743598474cc06957b39cfe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x63839a8d5fa30b79470208e31d430ee3b27379138771e7bdd5db034382356580', 16),
+                    gmp_init('0xd9229623dcb48c2d72abd1d35653af4e926c337f0e8538eca3ce3792abab6166', 16),
+                    gmp_init('0x22fa3b250a110bb5786b20158e91ec3e5f69c349bc51ebbfc87abd020825d42d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c75cd805fcdb93f2f79c28281f91c5dcde28627e533f533630005370dbc54df', 16),
+                    gmp_init('0xfb80494c90c43c90e280db29131b2ff2a5aacdd4378d87a32345624e5c09c192', 16),
+                    gmp_init('0x2dc11d48bcff039d9815196495d2b27b67f247c0e6b4a0751e356768af967d70', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x62b8d7f2c6acf888b4d66c6c86c2337a979e4180efe8c9e4f12eef2e2e06f6d1', 16),
+                    gmp_init('0x3d01cfa5f28b64bde6c0e0b3b0b222b2ca2f7cf124c5973ccc318996b709a619', 16),
+                    gmp_init('0xc0a65cc40013eca19ee4b6a41a4a2e26c73ba5675a6ba19de250fb48b7163ac0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x32f9b5a31ffd2cd916bee0f39e013e905d9de23aafbfabb367e9894f4b9b969', 16),
+                    gmp_init('0xa4104720a186a77adc0a996526a1fdd1c95db263ab37aaf951f58afe42462702', 16),
+                    gmp_init('0xc992a594732408ab05cd258fbc7014fa822f0267cc688151edc334ab99c94e52', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xee869295046a335a11cf6e1e211a1b4eaf6d8f3ca23eeb5c944407519829ca25', 16),
+                    gmp_init('0xcabd218e55f0704bc12c2299600f3c54a076d0559e71f5c94aafcdf728478e41', 16),
+                    gmp_init('0xb81450af466a4b09c3145455007fc51d3dc1e375f0f8b98f45f14f9c2e9e8ad1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9833eb48d611d149c06ce555f094d047388702d895719e6bb14961a2a2eecc6c', 16),
+                    gmp_init('0x25c63883f7dc769f22be57fe1c2572d1308206ccba54fded90bcefdf89385dba', 16),
+                    gmp_init('0x1832a92ea7d26e0178de4900cdbaa7cece771aad04565d2c0d31252b68de2850', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x26db4eaefc934a90ab361b9ac66f09887e91887be0d2437b30e7dede23f2bb15', 16),
+                    gmp_init('0x9a5a0ccdfa0a5de674a10d612200098ac9281c438ab433df51e92f0d49218f21', 16),
+                    gmp_init('0x89ab0d529a21c80797e1c93efd78288c79bf8dba1ef14b501bad29c4bbb28266', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcdeb53b095681e257604960a141fde9ef6de6425aaf5b70306ab54660d0427c0', 16),
+                    gmp_init('0xcbbf85e9b489be3d29cd77c091c4d96c8e7e1fecb6da0c5710be9baeb48c8446', 16),
+                    gmp_init('0xf70af95eebb30d8aa4e4eaff8afe95ba08faa11760f914a3662c618de63ab498', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd1bb0564c2f03907c966ab06e3e29365b9e88611aa4c19cf3bdb8ebac4b2e27d', 16),
+                    gmp_init('0xdfb0af2bf464f61d4b993057348ca0279d36982b3979470141330c0a876679ad', 16),
+                    gmp_init('0x727c3554337375080b4b8019cf820eca80e9b65d1521ca9f093fdbd5b70bd101', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x59b011e0b4bcba0d5a8ca7952eb5326b7f6e262b5724ce1e0574b3f6f751ae11', 16),
+                    gmp_init('0xe89679c7d58d1c42a461c25000f4bce1d470a121bb0218631bad65f0d8c189c5', 16),
+                    gmp_init('0x80c4c6ffaea60aa00dd90879ee867d659a0a21d5e9d8f6784362819b81755293', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x24965723196e0e1300e51eb9ede6d723a8a00655f34cfd9b1d502d2ff3108621', 16),
+                    gmp_init('0x49b270757e645ae054ec5cc5500b59984a32f7f131d05bbe3411ec78e8df0d6e', 16),
+                    gmp_init('0x724213a4ee490c9a9bda721f6e1a2f8fb9579ab5ef9624d97a94f5b909a60bfd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2030cfaf82228803a48ece27f3a9d483afa6e410314e473b1bc06c9f711fb6f4', 16),
+                    gmp_init('0x2757aaaf4c32128580b94f1e0faf0aec1fcf100a38ef19b8adbf5ab7909fb538', 16),
+                    gmp_init('0x9fe685d5aa70d258b4638da4b6f6b9bafc0770b2a2651f16340199acc460f872', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe73391d4911c4f6d2cb7eaa1e8614bf704c90e3675e4aeccb04a507656579502', 16),
+                    gmp_init('0x710bb14e86a59e80ac9515b6d839f3337f27e162dab7c2d5fc287eb26d202778', 16),
+                    gmp_init('0xb519b66d3d41ca16e779ff6c312d35b278e1bc04611c58941586e1fb2e905937', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x591f3ec31fe9a2a9ea82e2b86597c6819dcedb197e8ad56f407c999e66f3df68', 16),
+                    gmp_init('0xc11f5ccac1ea789b983c902763c3533bb0bb06436908a531cb3c12285ad3f782', 16),
+                    gmp_init('0x466c44d0f1df05071b3013bb2af0201ef3f2fe90fd2acbb9118b4f7ae6c3c03e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x535bc80cd021ff3b83fbc292b35538a2cf7411525bd97ef87eab25809beca2f7', 16),
+                    gmp_init('0x22e6051c9ea1ef2e48ca93787bbe7d50edff71d4ddfd82ef24b135e355ab13f2', 16),
+                    gmp_init('0xec7921bde2858fc6e259062057f8831385ef7148d6378dde1c6f69ecc7a0c8d9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x994b9dcd4000f367ea89c3f6e070b35565f90706d2fd71b4397967e3756406d8', 16),
+                    gmp_init('0x64ed26542826e104c24594f9dd8ffada7837c427623bd4a394dd2c3f4849a5cd', 16),
+                    gmp_init('0x2b59077c5f6fd2b92fe1165b8ec901583b6eba4e65181fe302e6e72f09d6f55f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb8ed73e0e6e87d5b00ee08e4c08844b5410975751f9927837754271783b76100', 16),
+                    gmp_init('0xe21d90f88cb4174a5b4814ba5b8b2392272dc3500dc53416fdec565d9c9f7c56', 16),
+                    gmp_init('0x7f6af7fd772f85fb8233989bdae1a39e932ee472cbfa07a4fc2d8039ff6e040e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7dfc15918d7f3278494ae7d41c01068a1d09b8abead62acc3bab0642d3fc611c', 16),
+                    gmp_init('0xe3781ccd2afcb8fd894c3e92ff715113df0261bad33c179aec8bd6a3efa4db3', 16),
+                    gmp_init('0xfd9e247e356b46354684fb3384150ec42b42e8adda977c5bf504582816e0e000', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c282c9124fa5b5d8ca803ecff66c6bbd65f54914b9475250610737bfaeda2a1', 16),
+                    gmp_init('0x62bba44efb8b50bdf0fea14fff3d3ff385d6ca790afd57be05fc9d5747c0c368', 16),
+                    gmp_init('0xc46e71139aee2d3990b393c5b41d87e10f0b2098c771815cb48fa20211171d3f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x684b99b19cc1d1f2ef6cc88e26f59fcb1eb2b600e071f427ed481aad512bfdc6', 16),
+                    gmp_init('0xc90c25428ee89a6d9ecf185c0d1caf3a766514ccb04b6b45fa7a9424504c8c3', 16),
+                    gmp_init('0x792ff4f50024ad2a5a5550a9fe00f12bf78b436899f4ca738253854cc716f466', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x36edf45dca13dc3b281690d7a21a0bb6409f1882c9f0995cfdbde11bd18d968b', 16),
+                    gmp_init('0xf1aa8b25f991238404502c450697c807da4e20f24b10d0e6ef9533d1145dbd4b', 16),
+                    gmp_init('0xc1625314ff918f30df5fec8ee6159f5b15668558ac9de9a43c50c1f09cc724bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4396a9d54d5df64f4eec39f84274c27dd612220f759c8139ca38334533bd1cf2', 16),
+                    gmp_init('0xc5e34f520b81f35eea33c1f4cbef9bf8c6e5921ff4f3b9351362e466fbfe00c1', 16),
+                    gmp_init('0x608570d6ab88a2ba9cc058184a56ffa00868df13e42081ae45c35291b8269fe0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc000a6adf7c15a8e5899c20831a959d7537e2450b4f05fc962444c39cd31baf2', 16),
+                    gmp_init('0x521dcab525eb3ce0d51bb9dcb51886284da1e54b59d3b20423003f1e28377add', 16),
+                    gmp_init('0x1f55a9ae4917f52e7577fccfc2d9f6ef73236fd370f07fbec0957aaebfee0c6b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf34d61d517da8dba3acd2fc0aeeafc3cee2579a88e64c20ba313b0078aa18fde', 16),
+                    gmp_init('0x31546c7cb43433d331f28c35a514d941926f1b94e8c565295abd3a4fb37249e6', 16),
+                    gmp_init('0x74f0dcbbfb4f0cac1b0f74f19efff791090ad4b6cd50239b498682400ae3779c', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xee7129d1a8add19fee2e8d6fc7746c6a728f334def1feb5d664de5d5938964eb', 16),
+                    gmp_init('0x1000368b04dc120252d86c9dcafd341d473b80f5258664eaae7b59101a6f84a1', 16),
+                    gmp_init('0xf41629171c6a97901a95c9a0ac07fc08e72d2ac289822bbc5311104f7770d828', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf0f2e7c9a21bdf9d858d6c3d72710545b85e9af5960ca9ee09e8efd3561b9958', 16),
+                    gmp_init('0xc42b620cf736d96f1ea5b2dfd81749affd9388c887db84e153b4211b44647043', 16),
+                    gmp_init('0x7239ad0897f84a6408455f258d5a0be7655a655e517bc2aac3e764e291f82f16', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2466bd488c91edb0fade287a3ea1bfa01d42aa7203619f59de28fb22a2e01f15', 16),
+                    gmp_init('0x2429f6ea512c6c04322f47d2aa806fcb2bfa6e3082984016aa24aa9195bf2c69', 16),
+                    gmp_init('0x91e5e985b2e3450ff322da136eb970e0756e11efdfba981f2426df1c388925c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdb155f1698f9b936b7edf61493698409190c104689241150608566bb5792a2d8', 16),
+                    gmp_init('0xfa44fb38adfbbef8e34ac3d16ae3e5a56070704e2463384313e751be4c5a9bf9', 16),
+                    gmp_init('0x2b6c31efb6640d149064961f345ce0efeea287c4f3da67a8f1955b72645f5771', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2fa37957844ee487a3a6650229c76c3d9d5c3cbbbb25cfbce82e707116a68b36', 16),
+                    gmp_init('0x4c73ec14bfcc913a6c1bdc283a426861026c41b43452961204c4ddef59a26f9a', 16),
+                    gmp_init('0xead637b7fc3c9f728874bbaf5510a52a4cdea84aa9d69ec9ab703340cb25969b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x78befa97dee92866146a05540a03d5fa365afc0151b0f318506dcc5f3583eda8', 16),
+                    gmp_init('0xee9bff01b7e11da16941415487018d8ed2ffbb445378c756a796bfab802378af', 16),
+                    gmp_init('0x84248e08e7bb8abbf0fd379c280f58c105ecd2174bb4b70642449f38e5d4f2ad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd28c8c561777ab7f19a426a428993efa7acd87a7e6ab71d30834b6ebd4a5b503', 16),
+                    gmp_init('0x51af2f8c72c0dfb24ac22c85031ce1c71c31a996fdf043eb743eab3b68e177ce', 16),
+                    gmp_init('0x76e52433307bf175fa3f3e7072f89d30342ccd19ee480624cc0b7d534def23a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7d84bbf2e14045e800a0f9c98ad20d46b5bab70bf373bef434f9b40ebce52889', 16),
+                    gmp_init('0xf9aa0fac4f50aec3e58982f65af29750eebbbb623194b7f8d1e23ccb23448569', 16),
+                    gmp_init('0x949c6ad3b48025a332577eb20f71d832b8daa29a46f14bef3dfd2796fe68dcd4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe24c21bef26b51d87dbe7588355b33b88f9ce682965261122855202272c26b65', 16),
+                    gmp_init('0x18248c85b6d14547cd16ccde5cd68dfd9a235b3a14e78128c9bad629fb9a122b', 16),
+                    gmp_init('0x9d3734bec8a25c64bf9e3176e83bf6e2de38f2a6e232759152bb560e43a08fe7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x628a690a9ffbdc0fc66f479c0c4cac2e6ea7c8a0e755e54b2ed0f00b2e07491b', 16),
+                    gmp_init('0x50d1645a88089ecc6652fa0b38f920b8a92d96c0bb705ee8febfb84eb826c9d4', 16),
+                    gmp_init('0x55755376a59e6c4e777b867e7550565c0e08f10e88af950ded043b4a04850bc3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6ccda391db63fc66a71ef0ef0e8fe3b0f8ab9894ea722d112e998d31262fb985', 16),
+                    gmp_init('0xffc0a8a0238fbed5fdf33800852c97fe9ef9c2413d03c784accec723e1e8bf8', 16),
+                    gmp_init('0x44b6427f0cbfc622c9be3f168b9b7784294b5350309d9c2c6ba7ab2485e0c28b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x68e98a9395b7e8d79d07fa690ade64a86787c74cbbd8828f16f4ca68c4ac3ddd', 16),
+                    gmp_init('0x677d89ee8c5bdac035024e549595b366c4f3c608e9b80b958f1faa28988f6046', 16),
+                    gmp_init('0x7041bbb84d45120d2f814cf8ee019755fb6828641f07749ab6d12a54682cae9e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3f9e8ad05e6504851757985e863729074af43e5f6329c5a38795e4fc2a614d32', 16),
+                    gmp_init('0x8e8ca165b84705353e80bae4d12606b407f3cfcd76a7b47d084ccd215f8a8ccb', 16),
+                    gmp_init('0xc91a4e91cf1e0b17956f7e1fc6e315603cc70d4b414cdcbe4840ad11f95e23fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x873ec7e1f848ccbfa4196cc6951dfcc5e0854f759031bc4e55a895edc2618bcb', 16),
+                    gmp_init('0x1a8ae96aec83286208ada406127d911058beda9b4d8ccb6cc07e7778a08d2c78', 16),
+                    gmp_init('0xd9a2ef51c2ec76c112a728ae03245c647e1f335f5f804c9e8cebdfb3eb33cb3d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7ff748ee87ec5c8948b25b9f9960133a0508fd22f9a7831be7e37466bea1f332', 16),
+                    gmp_init('0x9342fa7cfd09b43508ae4cc06efcedaa5a1460d8a7ab3edda20df9411cd092d3', 16),
+                    gmp_init('0x4fc4acbfece375d291b377c6b6a50e3d2d972fd7b35c1d7fe74a4a449a95c042', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x3456b83f97743f803af6c72e54955d5b89a3b2b03f09667d800a1add4c07ec23', 16),
+                    gmp_init('0x91f99dc0291389968c2abccbcf2cb33096790703eea70475ff66a9b9cd994ed9', 16),
+                    gmp_init('0xeb6c58a8814c2b2f655cc16259500fa0afdcae659bbe2658ce8414b54c12c0cf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda049041be701191ec16fae16aceb53295fb4f6414a15685b1ed368d297b2c3a', 16),
+                    gmp_init('0xd2039a57ea5b1f8660a05f666756d30f5c1a6ded125d1eeb3345bba94c9e4c31', 16),
+                    gmp_init('0x26d90345635b4d594e0807188666d4ada844e20499da7db3e1c89e1537008be5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3f684f0fea0531aa9dc08763c1d385517f82fe7a7d5ac669fb8467a8adc49ba3', 16),
+                    gmp_init('0x63eac045574d3c88c75c76c8ec694ad098da660bd50b9924c8a4783dfdbc985c', 16),
+                    gmp_init('0xb12629a30b34f5cfc30aa41e064b8e78d4adb84070dfa238b54d062216e6f892', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfaa177f5dd57441eb70fa2ce8afcf8ae5c7e4d6df7bc418b6a99531b5b60d7b1', 16),
+                    gmp_init('0xd3cc0810f3289d5dcaacd1e078b351f46c3705d57722191f633bfb0c28425cc3', 16),
+                    gmp_init('0xf98b0fb0af74d4c06d091c7ce08eb54933be7baff5d1d66e74516b19e3786b12', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x46a517887f6226a60386006dfab6f57c1736a1afce7c1cd78d4f9bbbcede2900', 16),
+                    gmp_init('0xe54c6f8032ba3e19634e773059f9beeabbc28088ca3fb381d36697b9d893e029', 16),
+                    gmp_init('0xbc32ea7c0f38597bbb138d99374c8a20aefbc8782073f3c31712be2fc0afc3e7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xffe02e5bdf2d376b7bf501a2ff961553dc363ce0524901b1ec691a91a3064f18', 16),
+                    gmp_init('0x50596014b094ca2884b917d4f362d22be78a154eff8aa47b2ab35092d6979cc3', 16),
+                    gmp_init('0x151d4d45553b37e955d31ba3cb0d5c6cd6b91d1aa0d0bbedf1048274ff874f3f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc9e8352390fc8827ec3766f33f2616bfe49b9ad1e71496fe7368a5833d523c6', 16),
+                    gmp_init('0x754276588390e09415a7c7ec216b52e76215d2f6e7f90d3620c2ed532a1e03af', 16),
+                    gmp_init('0xff8c85bfd33afd2ddb211ce67e06e160f6d7af964b7715a0baed7710cd30715b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb095156f54809acdebb79e07dd90a9730147a5b38a3c6a8cd05944e6ef06faf3', 16),
+                    gmp_init('0x3a2cae2ed7a7dee010f60a27644cba4794a3c932c412d191baeebdc3987acf1d', 16),
+                    gmp_init('0x508cfb3d16ab71a221983c0962d9727b6dcd4c177cf535c830409e69212c333d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2bf1f034eeb9f6ef6f2eb9071b3f8be98075d78fd81e34b0c986dd3ad6fe454b', 16),
+                    gmp_init('0x56f852f6ebfee869b2a146e0c1a52776b1764a2cecb14a61a07131397060c856', 16),
+                    gmp_init('0x2550a2107eb2de43125f8f603b49b70a0d98d49c375a9a9a1ceaf3b606789db4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd120a8b155129256418f588e99b2e635cda8d32e8fa60d5c3ac647ba8aebc562', 16),
+                    gmp_init('0xc77989a640a58243d836902a13f61b3dc4245cf1b8ed781c7d085777fef25e11', 16),
+                    gmp_init('0xe3530705f6ec7bdc6b7e131c689b7cc222a082ece554832e5885f41bb305e166', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7a9fd36d856bb9aa01b7712622566e5513f21b0107c9480441c62a690221529b', 16),
+                    gmp_init('0x4bbf7bf574d79232de78051be127ac262e1ac95c33416a692c567604719461e6', 16),
+                    gmp_init('0x824cacebeb651ec42906e482d9e3f3e602ebaf4feab2542fcc7154188a555a6e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe813694fbe9176efbd8dcb0db02f3228e26a91a046b60c7a8fdc1d56f798c103', 16),
+                    gmp_init('0xb4ac3547f190b12fbb1b1a2992c6aabf5298085b47eec521d6146c8d8e8f73a7', 16),
+                    gmp_init('0x27e0a644978ca3564e3e5c36f98aa04ccc015658e8860187a271cc46985fe10e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb1979de7b632bb31e1e977dbd1194a7ad626265cfb1a76a8f66984fd3861faba', 16),
+                    gmp_init('0x538fb4e90aece67feb716efc19b97aa051efb6eaa1602c596905ced9900e8c98', 16),
+                    gmp_init('0x533469f08ef5072dc2f3c42112a49a02cb296eafd8a29db74f4c0a2ea8aa1ec6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x87f85e2b96219886ba05fb8a55eb84ac37329152681f289f1a6f96606f4829a0', 16),
+                    gmp_init('0x9699ba1283974e6d963d23eeab0c6422ce39f6e564d4ffbdd7b23a57b6024f02', 16),
+                    gmp_init('0xb9b7c11370be2ea1ae8ef0502847a8aaa32011558975c2e579b4d355b252350f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd8d24b8bd9a6cb7f51b919066818689c8b148ca03fccfc805745ee36585aae15', 16),
+                    gmp_init('0x6b17112da1ffe0fac7c3a0af52e340011c1e083c9f350c04605315f64c593635', 16),
+                    gmp_init('0x42b464f5699250e2df58e6193b6fda97a2b97264e7cb7a41f797c960cec12b6b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xbc2839d8ad52b03d45ce18e5ff22626176650bbda9c85e5c4c8797590f98304f', 16),
+                    gmp_init('0xeba3a207516feabb229d6b74227eca8d9bed1cf4d26fa0d9f2dcb7c4650baccd', 16),
+                    gmp_init('0x3330b5fdb715d08fbc343450eed3403ca79e80bd25fca20a0a5c14a7b623c42f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x76c97bd783429ca8d5cb589cde45e9d758419be5e58aa82c2eaf7370d8a62fd0', 16),
+                    gmp_init('0x57643f4b125fd414995714bd999692c59cbe3532b7a3cf3dd5509def95f424', 16),
+                    gmp_init('0xc2115fc4f9ee28bd80d68ff86f0c1397cc167d10085f5e90b33629ff399611cc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x211ac81f2453a2940c92c39972da7943119de6c04e6a8bc2a6fbaf0048d91448', 16),
+                    gmp_init('0x2a1304aa6c93fde7a3728d2fe28fb68247bd07ca2abd33c27dbb91db8129bd4', 16),
+                    gmp_init('0xaf9f197f411d511f482860458ed1932588c53320ada3662156bfb911b3faa536', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8cebd5e1b00f1ed8ab54782d434928d1c7393fd1727dde626407bce63433343d', 16),
+                    gmp_init('0x6b8d64985053270131d6095b05653d011e658ec13ebcd7df09522616fdb8523f', 16),
+                    gmp_init('0xa889df2c784a36fd7f2fa73780b7db520d4caafdbd27431eeb65aef859357616', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5cffa73fdf45156fb467ad48b7efba3d5689dda34c490eff6893a0370bae110f', 16),
+                    gmp_init('0x504c9ac8c7bf41d3f3cbbbac097d8200cc6fa1ae3a99f8c1db40b8c390affba9', 16),
+                    gmp_init('0x8426625fea217ffd50a3bdb8edcceb0633a64e253b8c3dd18c0f6a46f0732679', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa754e6fde702cf0bd680c11d5190e8bf74f030af376b1ccce6a2fa8b9f39dc2', 16),
+                    gmp_init('0x15aae4b1eef760086841d4a727d9ae6953950e69f4e9532726832940eb89f7d2', 16),
+                    gmp_init('0xe0c9eb1f66e052925bf9e619de7059dd35be45844ba10dccd892f3375f09b780', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc5fac3d1ddad0f543bde33556923b24af6226d8676a6cb46995b2827a2b619b', 16),
+                    gmp_init('0xf9b743b264c7c76527135c1c805df7d70eff6f24e324f0d8de5a790ecacb947c', 16),
+                    gmp_init('0xbd72d70488cb6203b610b3d8583453a3ea71267d74faa8274d5d62d2148187bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9b205ae65ef155b0575a27789d079873ac695b66c6dee522a1a3bd57cee19991', 16),
+                    gmp_init('0xcfb308601ca03cc93e8e4e44c806035978e1040bf7f4006a0cb1bdf43c3f9e8e', 16),
+                    gmp_init('0x8061252e582cd32535e5f0e726f44437b561a6b15ddce76ae5ac6ec575e10f04', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeac54eff9a1ca130ede18ef6f80c6041a0a1807c62425d425a463634027da944', 16),
+                    gmp_init('0xd6b94fc3ab7357d03414030652b6f28395bd6f70dae9629e731ac89947db93e8', 16),
+                    gmp_init('0xa83a813c27ae7c3602ac417aab4c6c157a99a51e2d924f11f00b9ade524a5cec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcfe126f37e17086a6204c6e9e71f57d106db16622f329a0daad5d603b77094f7', 16),
+                    gmp_init('0x9c34313fa43f75e7d5a27c1645401d61b711d3f125d05e21a872ec83a749763', 16),
+                    gmp_init('0x7a9b622fe369fa55ddc53b012011cc01ffde45fd51ad3544b5cb33eacafa0bb8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc73e90cbcb268955114a56e45d89de2f354c0c0ce350a0212dd3b57dea2d19', 16),
+                    gmp_init('0xb6b8aaa045f834235e2cdd95251ce1e2267472caab1726a6ab89b5e5290fecaa', 16),
+                    gmp_init('0x65520a1815d3059e4459ab75a027ecf7fcd5e850580cc3591bd8ec040cfffab8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x45e171e60db0771f8cb49107a9a2379675c9185efa888923d8c7d52ff3790b5', 16),
+                    gmp_init('0x6b5b3caa8b0ad7df19429e7e9ec47bdd1bdcb5c3ac45b734c12057f72c38d19b', 16),
+                    gmp_init('0x5bb1207a0f9e34b588d94b631ae1ce9b50deef9cc9349d5a2e8cb364f9368bae', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x34e673533675b314e48b2532bd96a2687217efa8cc84911c7530af7b944008fb', 16),
+                    gmp_init('0xef757a75ee134b33a552366cd2b4ec4ded5518fe4c7a12c1ec6fc28406ecf136', 16),
+                    gmp_init('0xb7f89cdf42c4356cb1b994cc268746682baf817b2ea56eaf8fcd9df599d31a59', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x71a92fefd0664a1884ffe3273265644fd0aa6add4061c32db6c4e53bdaf155b1', 16),
+                    gmp_init('0x783e68891172ec92f869fb562a46dfc00054ce094f10019f9f60f85cb600f212', 16),
+                    gmp_init('0xfaea664bbb446ede306eb86e58c9570fadf5c802b0472be1b110b421e378ec6f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d55038756efa4d8a716dcdf851146e70bc28b440421ce37a59a3f0a0f51f58', 16),
+                    gmp_init('0xdae29295a74dc8e33ed2ea335152630a91de31050c50ea4976409361ac5395c2', 16),
+                    gmp_init('0xd0ef259eccae91cc8cc1c305eae2409f929f3084deaed0f74d941c208e465e29', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xf348889bacaa13d4bc7a185508f1a881f8c0999f74f70b5ada1cc31dad599fb6', 16),
+                    gmp_init('0x3fe318b5d17f31aee2a8e31ddb6634d4be9d3b0e16e00e305c8531ab54c335a7', 16),
+                    gmp_init('0x5f4c8d8a84af5e346148b399120e37c4cce4beac00d70cb51fe32087b8470ddb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x449d95c52bf497548104ceba5cbf9db7454ffc4ff9a465d85d4436c843d926bc', 16),
+                    gmp_init('0xd4da82701279c28b6a77dda8e7859491068e761fcfc84bec59d158df8b715eb6', 16),
+                    gmp_init('0xee7c53709ef0a102c0718998bf689492d7b384d881b35b3d890dd682687d4022', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48b3727c0fd9c34a1f66804679bcade0139df3c644f180e632ac28a6dde35084', 16),
+                    gmp_init('0xaeef50f3a43ce2247e0f77d5cd7ef34c124aa15ffed019d8783af5b3fd3e8c55', 16),
+                    gmp_init('0x15d7eac0b969d2cf0dbadfb4c8505a2048541bb5dad6629f45ae015c505eef40', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf18a55819e991b8def43313dd9a250cedb9fe398554408ba74b005d1c39cb23f', 16),
+                    gmp_init('0x59f54b9753bde1b6de2147afd193c33aa746cd40c9d9ee1eec55e3d17d426a8', 16),
+                    gmp_init('0xc1648fb60ba2f711a8a7f943ff71d513642796a1843f0ae18ed9a2eccafb23d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x60e894e50a940147231f400a54cc41e796acfd7c7b82905d4a0682a215cd0c88', 16),
+                    gmp_init('0xe1d36473f9993c7e0b1bc70bb9ac1965ad8f47cd89ae8e00eb4efeb566357fe6', 16),
+                    gmp_init('0x64bdd2c0eab0e3e1e155188efeb9136ac5566a9f6d99d064dc6915df5886b7d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd75a36b0152bb4c441688c2a78e23a6b8a43200dcac70755e775fbf4448112b6', 16),
+                    gmp_init('0xef84702fafff8cdeeb581471e2cf0b4279b512077af447bd61ac9059354ba450', 16),
+                    gmp_init('0x4deef165e598a0baed0eb9aeb2aa836d096c0471d8a3b9f50b8ea3cc671944a2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf73b1dec5733710415289ee0d21b8b069a29cdb37a84a835031b094fefb74874', 16),
+                    gmp_init('0xf6bf082e3332fa7124cad0ee2c5e3f19ad2245864069aaa88f6012f464d0e05d', 16),
+                    gmp_init('0x84f8cf6dc4b4f097dffdcaded7921a158ce6af75ae840d01b805b5accaded95d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfafa365fe2115cafb79d1b01103a815709a4e85f37c98957b9b963b9c74203dd', 16),
+                    gmp_init('0x323720b8595fda984f89624f2c00664d6c6ef8328eded225a15da6fb1c046cc2', 16),
+                    gmp_init('0xdbb93a43d3c3bef4b5d6051e5d65d179fee9c86b805c1f7774c79b7eed364832', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa287a6593741eab39d8857cdb217af8e6d19a8d8e8c08872749047af14449f89', 16),
+                    gmp_init('0x888ef74e9f4a8f061e83f1687a7602a1c0a5eb6466fbe34bd6e32a546f66ab2f', 16),
+                    gmp_init('0x44cafe3d81599b5aab30b324dcdb42515338d445503d03d86e24b2b3a3f0be33', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3e4b03c1b1d299fe4e1da1880a63d8908e4e6a8a59d2e2b9b534ad5769f903b8', 16),
+                    gmp_init('0xd09906dcacfc375c0111022dc2b4288e735a9dc3034e8a4abe6a6a09a5663081', 16),
+                    gmp_init('0x83fd77b551cdf4385837de4cd2ed9e24bcb1994d8f6f43301470e66fd9a00076', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x966272ff2079834c95c0b21bfbcf873ff7a762370d3ce84f2f4c95797a0b4b5d', 16),
+                    gmp_init('0xf03fd3afa08a7712132dac86e8839df97019a5cc9d905e9d12d7907743980954', 16),
+                    gmp_init('0x88b4d697b72b5b39caf7ee6d3cae441a51a0fa00809ac0485fa8e7932ef74615', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7ccf8d4ad0f3bddba4c1e8f66deef91d4262f25bf1a3ca91f1f4de85dec5696a', 16),
+                    gmp_init('0xdbae2acee317cfc9bf57e928b9d07bcb4472da53b64080dfb21493daa91f2c91', 16),
+                    gmp_init('0xcc8fdd64b1975fe7a700b3e0907b1bff77f92ba6644408fc8895e4ce7651d761', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x438d2b7184c48e06bb06de9fba8107aae32e73127fd1b47fa7b718bb8311aff8', 16),
+                    gmp_init('0xe27d443ee13ecdfcfa39552a0eae10d16822b604261950657275f24afc38a7d9', 16),
+                    gmp_init('0x64a07130814f7d4493e7d765f04cfe3b6033fd58146c403cc14df8acfe754e1a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x921b00136165056e3f0bd87e9a71f6b7de4cb6c58ecb973d59939e7e473f8abc', 16),
+                    gmp_init('0x86164c42d6353134a603ba563da3dfb60e863bd30db7561fc0c29811690514ca', 16),
+                    gmp_init('0xe6b3c1d1b2bda4e307f5bcab3a5de1bda6060dc938c1f651ee832da5527e2b1b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf9695a355e73b22732f2a7eef1da3e8f2ebfabf2dd7c28f3e0a27d358591cd27', 16),
+                    gmp_init('0xc99202a85c15a37674ef5f759488b3c4b37a8788dde71628efbb76a60367b654', 16),
+                    gmp_init('0x4c2a27f8cb7586a7518d5c953dc3cb52c10ca24c2756d3dd11ceb08efb8209b9', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x769a098e71cec60bcae3a254fe2e8701a915a0bf74f9e063958c0ada23182700', 16),
+                    gmp_init('0x816f0b67d9cc10a4474b5ee7b8226feb52e7db6a24600eca4c7f1362af00324a', 16),
+                    gmp_init('0x75373c5bab729a11c9eee8e08c617e09700f65f03df1c9880337b63cc39b3747', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfd32db6e252e7d12102fb2baebc7e48be2fcf89b1835f70420e3d798282f64aa', 16),
+                    gmp_init('0x4253741a73cd12b434198201d5a6d9ca5d29dbd85401953f781cfc19ac3c90f8', 16),
+                    gmp_init('0xfb3e771d5b90d7070619f8ef04999bce12c9aa6e1f107f671bbc174ca23a1623', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf2cb5370fa40d3d14bc7917c8286c4d89dcb89a186bcb4ec029bc9a86b289037', 16),
+                    gmp_init('0x3532088b1b6c7e387b44e0bce5e1ad9197ac5c54f679b7f74bfc527bf7acbc15', 16),
+                    gmp_init('0x17f974dc85515e6a017c76b682a97120a895b13ef64283df1f212b19ca4533c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5aa87d6220a355423630a8071d3ce6c464c5c26ec80922e2bc576e7d8281b082', 16),
+                    gmp_init('0x3bbaafb819c4378ccdb88569182b7b9822b07c896790e0920b4af70255b20f6', 16),
+                    gmp_init('0x705b2bd388b87e0fc8e194a89a4c63ab69aa0e50306beae38259ecc7307ff931', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xba8f5abc9d0354ca562171348c0e0b1b18b931afe565f2ef91271064efce8674', 16),
+                    gmp_init('0x6d0b219a1bb54aa4171c0122a9cdbb52d9fed4849a0f991690e9a81fe523c700', 16),
+                    gmp_init('0x7a50f93a41d0c853f4104598cb5558d4f97460e8b8f93e5aa2a816b5c98f3aec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x826d3187f9eb8c4b4eaca13d8f566495ced260486b8cb10a68de9bd49ff01273', 16),
+                    gmp_init('0xe3273804ba399635c040ed3d348fc9ecd631f17b6ebe5d222f3b16b141a76726', 16),
+                    gmp_init('0x82f9c29a58bfea3dc4bff2f8b74baa4df9463db0d1e2577f397b3bcbf94421c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf8d145180fd2768bdc2e83d8223d1264438cfdb9b17f942725e581d2c4aad37', 16),
+                    gmp_init('0x66c1d94f73bf547a1bf6f625e9349ce1d3b3144665a075306748461e1371de61', 16),
+                    gmp_init('0x7cb3d5fb74edf7c81d8f45676a0eb65bb07a5824d4b40886572bf0090704b282', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae2a33cb4dec6abf864c8bda9806bb7830d924f0516763c36bd237e3deb91358', 16),
+                    gmp_init('0x2c5647a81c43866547f2317d5aaf0e5dc784cdf03eb81e0d0ed8874fb6c044ae', 16),
+                    gmp_init('0x6dc3536bc7de931506ab5b08cbf3a67fdfefa2ce5cd117ea54a6a1e90fde8a30', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd37f945cef3b92f5a3233793d6f740043eefa612efdab3a83083e29fa5dd70cd', 16),
+                    gmp_init('0x5f3096dd04de858b4ac1530df393b63baa7b2ed0b8dc227397e5337c6784c5c0', 16),
+                    gmp_init('0x647432616563f3bd78e03c880f8017ff5229266598dc02c1b283c39d351399bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x945d3d369184711d6c0c485e0ffdb6645dd8057e7855d4cc1682e6fc8430c938', 16),
+                    gmp_init('0xbd50c68bda446600455e3a5c13f9020011722e34078558a07ed5a4b6d7987a63', 16),
+                    gmp_init('0x49f1b331edd1f8c29f788770fb8471212298c4e3fc2be4d63a714f7b516b746d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1870a1f5d375c0a38506104c73fc71c4991f0cac8bc84e987b8c94d9f68e60bc', 16),
+                    gmp_init('0x785307487750d39854ad3a44f1a95fb0d44e1b6939beee810a176231aa6ed36c', 16),
+                    gmp_init('0xa825dc346d87dddc52909f8a13e667cd3b0a211f29704ce415d2da5f3e9716af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8f44631b8f69c4eed746725112d09ab2f91afb9a3a5176ebf07d9d96d402a633', 16),
+                    gmp_init('0x5cd4318a308d4ea3302dd7ca0f37f590dc888c39283609ea87ffa3f369af459b', 16),
+                    gmp_init('0x33000aa40a944f8fdd9cea160d8ba1d72a84cd82d4888c0681f9e2e58a870dc2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x813ac6d24d2592d0620bf8a831f2294741ef7a4a1ca1d879d389d6938e8b412f', 16),
+                    gmp_init('0x282b3717b4e2c0ed76dbbbe7c2a142574509ba51f5f880de23f7c90b61795728', 16),
+                    gmp_init('0x579390ea21b79ab9172a5196ea347ada87db68c4a2f35feebd31c49973085630', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x898e5d55ae8e7beb1615596f1b6258beb775af600ee6f2e8f928c36488c36620', 16),
+                    gmp_init('0x1b51fd2c96037d73cf20a23648b7ce99b9244da212d18b0c4d16cfad05ac8907', 16),
+                    gmp_init('0x27f784a784e7227e182bd8dadc84ed118b35d829a44e4be7d5e3135e5c121ea1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd634a37c8c96693b2b74728c3cb11141aa2e5a691a6cb895015f6782e50afea6', 16),
+                    gmp_init('0x97d5456c3369e40fe9fa62e6cf5e604edda8c1083f063e5463f9cd858efde98b', 16),
+                    gmp_init('0x9797319a13e1662ca3af4d1526407ee1100712747633a6804bac31305593e67c', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x280c62577b82a3025bb98431916b9da494a7b3cf6ddae31fc1affd92ec1894b0', 16),
+                    gmp_init('0x1bc85ee1ea9fae518123d39ed602c6ff59cea14be992653ef5b96831104216f8', 16),
+                    gmp_init('0x231bcb9b9e3e21f2d5dc8956fadc9e9e4d4cb6dc24a68005a5ac5799acb3cbdb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x440ac4dd5b7788000cf61a98d038c550be6e060ad09a66c613a83871ea3cfa57', 16),
+                    gmp_init('0xc614737a131fe9885f324abb15d821b40282a46cd4fd136447c6bfc7c921fc57', 16),
+                    gmp_init('0x43dfedf4a220456f31c3edd97bd4228465ef072d7aae8286a03f6be3073b7e54', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c57a3f8366a30c0d581909a3ae53fd1e29b4f17d06f1c976715146a341ea955', 16),
+                    gmp_init('0x76cdcccf7b4804347d7df34cc396b9e5bbef16896eca8f015de8ddf05794ccfc', 16),
+                    gmp_init('0x4ad916f22a936dcf29d59cd566c66ef908753a67dc1eb065856eb9c9beaba04c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa69e91d5e8df4f46ae01d903e3b4cd4a35870479944fececcac3b1e2a962f1dd', 16),
+                    gmp_init('0xb26558f345a3eac74b97ff72c869c3151076a28365e26f41cd298bbcad43959f', 16),
+                    gmp_init('0x835bc791c9fa20318c24c04b797fe7db9eab881095701f03cd4d614f143f4833', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x737c31784e95f9a78655d0df794a7403ed13a68dc1baa23d0aa5ed55b9ef90f2', 16),
+                    gmp_init('0xa537b1ff0fee81fd25339cef31319c2285573ad4e6b1827db3c3579017a651d', 16),
+                    gmp_init('0x8b3faf0151fcfeadebda2b303a104565380e6fe419313a22649c5c4af2f405fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6ba58920b71e0970932953078593619c205303ca6d6eac5ba165cff101f72f87', 16),
+                    gmp_init('0xd980cafb5ed803dba993c52faeff1ef22ade54305d69c5519c5ddbc5417fd4a9', 16),
+                    gmp_init('0x7707076f5be7e76eb8a4709f3e3cf96b159e173b0f0bb11857d1aa5893c8c13b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8e40135004be1f5368405a32ca580df4eca038aa6c48e64bb8a63eb74b163f03', 16),
+                    gmp_init('0x1566d0766d72561a2b6e35a413f55fc8898da1038f16487b172f2a4368acd09e', 16),
+                    gmp_init('0x8a6a6feef08484508db4fbaff20cb8ab5bff8e91f91b1fdd440f94be084c8763', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xac8a5cb5507ab5b9070ea44a68b40f9bfc50d23f0fa6b5d8282531e73e830bbf', 16),
+                    gmp_init('0x79c87bf1050c3f08c2b917fa4af7117e44907a0528b72e8bab8ed1346ae25ec', 16),
+                    gmp_init('0x7ae88c97dbe58bb0b7bc9438c84a9cfc8938cbba09ca5a10e52114da2ba90c9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa881d7cd42e5681a510b1c02f74d9fcd4999333b733c0fc13025434dc64a5d26', 16),
+                    gmp_init('0xc95ba6c5cb8a029671818b05224ded18e1e162cf7d55156e2ee6de0b8bb256ce', 16),
+                    gmp_init('0x87b80513e0fca771b72e942fa8355c5fd47ef5f310840cbda62cf712c2cc4bb6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcaeaa6453a754344c503f1eced2048e826b4be2e72a3629748d254254806e2c2', 16),
+                    gmp_init('0x6fd75a8fbbb4e90c144cf8622af2816133214e963040ea95c99bc6909e434687', 16),
+                    gmp_init('0xf0005722b70e6c38bb79e5a99e4333eb5fa50e4cdafe00da16d6349567aa2a73', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd96f229d1e3ec6b4bbfa6134943b9247042f9464e95683e857dee62389520ecb', 16),
+                    gmp_init('0xf67ce2fa91fb007f399ddf24b25c20d43a3be3338af1ffee1df1289b7bc1793', 16),
+                    gmp_init('0xd0099e869434f934532328c7e9147a6e4a4c6df17aff988900cdefdb6593b19c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b8aab8fa3076059467b4f23f4a28f3aa5ad4b52e8a02711bf27f46e9e5a4859', 16),
+                    gmp_init('0xa3caf5c3aa59f73c45458b9a8c77d23d257116da2dbcf89fd2c2beba4be9479a', 16),
+                    gmp_init('0xdb3173b370c1241d6a7c6224bc4314a90c3d42ceb53c28e09e3d3f418e87ab00', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6820e599438de76b5dc1e883c2cbd1340aa42ffe698306bf607ff510005b2016', 16),
+                    gmp_init('0x34d3f35f70ed31c44f4f75200b4738626c6eb679c0b1fc388fc4fde43bff628d', 16),
+                    gmp_init('0xc33b8c1c13a82ddac6ee7be9120f52b8d7023984f83e0e541f41f565f7c3a69e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2afe9192c378e6cc25b8d0c7a0ac96a43a17b1e25daaf65994a0a975c3b6f518', 16),
+                    gmp_init('0xe2472897cabfa21c1b7894697eb6ce487bbb9d41890d0ad57e16320b58d8917c', 16),
+                    gmp_init('0x37bc538765d887d371bd90f5e122b041606d521a90233c0ca32b9f0a6676665f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xadd20ff5fbbe1fe696947ec4cae0242693ee4bd3ff92dfa5f15d4af2d68979a2', 16),
+                    gmp_init('0xadd1c034eda063d9de8c9a36237cbb6918eaadcbb7d51511207198c09c49971b', 16),
+                    gmp_init('0x59844246324778b6afe5b1ce374e3fe724dd85a1a379da094e7b9dde0eddb21e', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa907e4ed39e60f4f7dc8e472d3bab748361f9b99da1b60c092011f7e1f1dda1a', 16),
+                    gmp_init('0x9b9e3f870293b3df10cca5695477e3f3ac83ab4e117f7ba06518529a432891c7', 16),
+                    gmp_init('0xde874f3bae1c8e2ffcbf82a644735f66ff9f3e34f6a90050b2a0b0b6f17bd0bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9572615c4fe30c49c140ca6834e0744d72d21fb15dbe2db626a4cd6b4fc83a4a', 16),
+                    gmp_init('0xe855847aef3bd161da590a7719c4d796bb76064e19e8310d2e99c9449d24473f', 16),
+                    gmp_init('0xf084476df3c931cd177da88a9176e81e5dc42c618a184e23282e21a5ab092cdf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x73575a8cdb77deff3289d6b8ed1f6e8e680bba3d99c3a46cc79b48cf686777b9', 16),
+                    gmp_init('0x43ef012fb3bed747857b4793113403a41cdbe351920f83ed2c6879ee7d659a6d', 16),
+                    gmp_init('0x1072e6fad5dab6aa5f135252b18377784f73a5faeb33919dd80bd3d1b013fe0c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8f6a77a91db3eff0c0e9fde8952fc1c7328fe2dde42f8445546a7031b870462b', 16),
+                    gmp_init('0x4229c64beacb18f9bcad620fc73947774c5664bc289549b4b754b1ae0c60100f', 16),
+                    gmp_init('0x33455788bed71bfac19e74e9cbc86025fee86ff1f49e0e9f0c1374c2432e75ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf0931563e955997fdc929f1e8bb84d2ddc13599ad0d8a5cafc295ae1f850d9a8', 16),
+                    gmp_init('0x9d560735a41af2386f038eff994fa29720feccea89e72b078a4d2c337aae7502', 16),
+                    gmp_init('0xbdf6dd7e6e6f62ce99386edb3b76b66bfd2b93a428ee4a93ad5a2198cb5f1b26', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x89b4d4c566c655d404856cb052b03e957b2a88ddd1ea123bb34c17f98c9cadae', 16),
+                    gmp_init('0x1fbb474bb6717bf1312cd5e03eacea2502ac60a784bb3bc4e72af92fc2260378', 16),
+                    gmp_init('0xc82bd9cd57ab66460e8597169a5c4141bd444ebe61ca4f466e2ecd5246b2298e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d1760420ae150a22364a44330e690153dd93753bb684f98701c0accd0c1de7', 16),
+                    gmp_init('0x62593b6d63daf1aabdd716f2d77887320f5657a39b236d94383aa69d44413028', 16),
+                    gmp_init('0x9323cacd889c113383572944c5ccd657a60657242f5d45cce7a384622bbf1c38', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc1b0d308ca494389d8e9b5eb86770f6663160b8e38c758d6a9c387cb70afd3e8', 16),
+                    gmp_init('0x5f91482fac03b70715eca1038c6e82eaf36aa5cb6dd3c93f78e5617e5b446cf0', 16),
+                    gmp_init('0xbb7ca11ca1e26bbcc8fc40c9edeba3fd8d93a74eff344df7199e2e1fbfc8b850', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x11c5484646234fbe40db0380adfb8c6f47e0605b733c5bee20a8b8fde755b771', 16),
+                    gmp_init('0xe246c0231cd92e4eed3eac4c3580c8f193f6d077f09cfe135b537dfc732d44e5', 16),
+                    gmp_init('0x7bf291f1b541e50f7a5b4c5ce70cad6382f7d774b3ba79455598c69bc8d6a1c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9ff7a48551d54f79c9fae963862a50b1cb8506c39b548cecb26b5dd3252b7f74', 16),
+                    gmp_init('0xc35d2b6a43fce6960294cdfd1cac19524d3d4094193e6fca685500f324db904f', 16),
+                    gmp_init('0xda7ddef46dcf74de6652b89c16fa590a60126a5164b54c150720da3ff5d2631b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9e8a0ddb250dfe1f98f83ec18909befe31d8f46032539608e8b98e78c8762042', 16),
+                    gmp_init('0xe37a75c6dc71b8262d630b50f23b0566cb00999b204800efcbdedc58d8799c9d', 16),
+                    gmp_init('0x1ebc798eec99e6ec48f595a0ed8389a00bb35a053cf47be004f91651ca1354c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x242e47353b1ce760ca45a3829d4252634e87f6e4e9ec401b9cbb840e6475b814', 16),
+                    gmp_init('0x14a04d485712a43e830f8821151c8dec3e5728b30cd863a7610009d6b1522a53', 16),
+                    gmp_init('0x4e7f1c69889a47c17fc420bc9e118c203a791aee3fa316e708942732c6693d73', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd924482c0e02a90e06c185c40d455a62b0c41e58206df9012fe8e8b2f3784a', 16),
+                    gmp_init('0xd463f82962ddaea6e73d1be0a79306ade4d0bcb25c55d86a1066665fb379df0e', 16),
+                    gmp_init('0x973c69b65ed2877099a7e9229d1702872a734bec1ef9e9ae3427a0524ff2a63c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa72406f11027f9b2140637b6e81a6763236c9f3d3ae683027d0aa95c9cc402b3', 16),
+                    gmp_init('0x4667f354a35e7d194732ce63bb621cc88d10ebf74a0f6d2e76458d41d531a5e6', 16),
+                    gmp_init('0xb959942360031e4ed66f9c658f67ca486159806a40a22964a22603eceeaa4306', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd0387f20b9795635ed372cb3208a6db7c687cfb426aef77ed3cdbfe4c953597e', 16),
+                    gmp_init('0x855af2238dd8d41b931fe35728ab534270a7a887b5a59c765c48af0aa4123831', 16),
+                    gmp_init('0x8eb66e0545f543342280b622610321f1bc7a0406295a1e0699975be731075ea', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x493ab4829f51458bec3659f4d3f450fa57e1696e05bd194740e4bb8da42b6171', 16),
+                    gmp_init('0xde9cbf01155ec28ffea69e55f8a9eae753852429a17d75bdc47f8df74e4a980a', 16),
+                    gmp_init('0x8a22b1756730677f37ef7e678da1b8834ce71f8a5e5188dd800c918368406150', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfc754fb97ee413b10a95ab25182e1596f33f920df260171195e169a20be5da5', 16),
+                    gmp_init('0x392991d6c85206feeedaa9964850410fcd71c5c3f020c4dd88a04af0573a0592', 16),
+                    gmp_init('0x9b1d2c32ab7482cb56262045996feea668bef628a4145dd90a4014b15b26f5bf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x74d6c9c896c37104952250170496ec76f18a7319319bf62cf38a650cd71d2946', 16),
+                    gmp_init('0x34f25bfe7f37fcd40c4d3901c9dc59a99dafd43492d2ec135ab00d53db0a04e3', 16),
+                    gmp_init('0x38d3c9f6e06c860064c4e57230d0ce6bf8f8e3b6e9472d274418e53dc35f69e5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd4708ac0d8b42a772972b0a7db87130077f3a15de25900365be30a0c64287487', 16),
+                    gmp_init('0xfa8cd11448cc23cedb8b0184175c2b0377cbf2001c65891f0a71c65e5c5eaaeb', 16),
+                    gmp_init('0xf02a43d2b3decb12ccb22b7c3fadd0792f3ada04344dc254c2d26d2d15103bd6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5573a30dfd72998a6ca67d41bc8146e887ab2f6ebe03022a94f3c63eafd6bdb4', 16),
+                    gmp_init('0xc60167d86fa518f75a3c0db740d82e2210b3fb297846945b6e3b0c67340702e0', 16),
+                    gmp_init('0xc95a3e6609844646ac7c4cc3e78575d65768bf49a31b1f40c03c69c8748c614c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x26a786049c341bc038fcefcbd5f16d26e8b9ba43225be3290da69e6c1cf3f4a1', 16),
+                    gmp_init('0xd0a96b5beb4303c9ea8dbead4ad83b3da7c221314c14b2a26824edb0e25b5930', 16),
+                    gmp_init('0x7910f340e0ba9773e1f045605a095a6cea3bc1d9c961078dce6c2803bbdc0b2d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57a3c4b3f9cd658eb1a7cca94f028b7914db4f8ac04461959750b720a8962b94', 16),
+                    gmp_init('0x104ecf8a2cafcc5fefbfb5e95025083a27c4cc64d988c1c295f7cd457b74116b', 16),
+                    gmp_init('0xd5725de955bc66ee9737d07ebe946cde0892482d3d4d2062689b0645d5268cde', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x72bcb109d147dbbcd27de5eae0a68a33b97753af37252577cf905d5ffac9fb60', 16),
+                    gmp_init('0xeb2b06332a3b4cd7713fb5e9d37d832de1f400f29ef3e49919ca5abeb0f68fb7', 16),
+                    gmp_init('0x4de58e5ddea199d1ea7887a16720614a1dbfb6d8d3d02906349610c051edc177', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8dd8cb54373b5ebba8fa51dc16674e867672d83096f1f1b339ecb056d3baede2', 16),
+                    gmp_init('0x8efca57ed37fa37c9f9661f5ab2b1a1a68f4d7fed1bd8afdaafb5cc830bd2787', 16),
+                    gmp_init('0x8025ae613be9a3d6f5b1c3f44eb5daefbc21aa036b63b5714db5d80c4693c4b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb1b761085695e9c3bc5762553dcde201414a5b52836ed9c3bc3d589e5e6f6e0b', 16),
+                    gmp_init('0x7de6a8087369384b78f5291b254c2e2d2abba2df51445fe5a7b29e433cce0af9', 16),
+                    gmp_init('0xd6d84a124bd8cc402610575672c45e25d30824568ce21b4f029f09d1617d1be6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x454883c53a2879c4bb2e7519cbb3383df98844d5f24e733569b170fbb2c6838c', 16),
+                    gmp_init('0xae9de91b7adb47c185a5ff3e12eeb776e1ea77ade07c9676bb5135933cc995cd', 16),
+                    gmp_init('0x3e73960a876fe12b7c4056700fc0a4bda104f3d4083a8fbd2ee7ab73446eca48', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xedc0f25e6c2178bc23bd217611da573dc5e0e5decc21df881d2872d1234dc7b4', 16),
+                    gmp_init('0x3cfa4def49a3a484aeede1bd6fc042d8505a91c089ec1dd5bd3fb0ae26ce0622', 16),
+                    gmp_init('0x93aad9eabbd518e345b7f51209e203e027e5e3a43361a1ca57f99057bbadc15e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x72ae39ba93cf4430819c9932df4f8a6258ac4b5523d6495ad0180fad480b423f', 16),
+                    gmp_init('0xbf64133c0204b408da1fef674211041afb0d726e429f70acf46ecae073fa25dd', 16),
+                    gmp_init('0xeb3369c607ea01ba5bc19081a4eb69067122dab9e8d97c3a5bf7d56755d0dd07', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7df64d1afbee6730aec1e90f920c8e615ef0b86fb4fb02eb4a9acec1ba0accf5', 16),
+                    gmp_init('0x63eb1149641d3928713c626bea67b13639f5e1eee3c033463686310e93a1a749', 16),
+                    gmp_init('0x6418926f7ff4506fcb563415b0e767fc3eabafa816a5bf76face609e68081fb6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x21f0e57bdfc611280f8a946013babec17ecb22f9ad29cdf7a2862718f9d4e8d0', 16),
+                    gmp_init('0x18655462bc4d352fe287506d7a216589be52a3d2f59bc0842837b806b3c839a1', 16),
+                    gmp_init('0x511c5d9a6de62890239c28d55ca4cb4bbf191dac6be1aefd2d4beb1c54268e92', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x618eb9cbd74611b9ab3a6772799032bba154931901bfd1e2cb88b48ed5a645c0', 16),
+                    gmp_init('0x798326d87133a9cc4d2d8ac7b983d5cc5b13ef3edca740cd91058b07f07dcbf0', 16),
+                    gmp_init('0x833de5068fb90221b8bd829143ae0092b06eb96edba3f2685363eaaa22b1c6a7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1aa42cc1207a22bc1e3bb927f4c81b7c90978cbcc881408b73557b4276b4637d', 16),
+                    gmp_init('0xab4ef30044efb15b1d9ca5c1637cec992822e301b4868d5b6547789a5451972', 16),
+                    gmp_init('0xe23b813ac1ec3491baba367a230bed0440b2256c8881b840044c2da1a30ea813', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdf88083fa4d583b830d9aa02cf529865307053e41fe4f9b40331b182ce1ccae8', 16),
+                    gmp_init('0x61b01a79f21327fa5a3695ccf1625d08d5e0d5560d60ca59c7fb3c91eda344e8', 16),
+                    gmp_init('0xe6ad6fe8c60296a92ebbf446bdcaaa247bf4c9e641076394a5ec5aa08dc76d0a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5ba10ecd80b52c859d62c8c5e9cb4eb398075cbfef5471428ebe5734fd3bb071', 16),
+                    gmp_init('0x817f0b31c596fd9ba6b0a030dea22924d58c2ac267306fb73ae1dafb0140e6d5', 16),
+                    gmp_init('0x5ce04844837ba1a49ad204e379c8e57a672e1567b82b75dc1713d2136def6df9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe16e4ac6a73c0e6a477d0fe530ce5ae3ebe8a735c461281187315c73e0ee6c1d', 16),
+                    gmp_init('0x374d5389584cb796a6219bb4b94b39ca6163fd1e43732dfb704fc64a870dfa6', 16),
+                    gmp_init('0x24861299d87fa24546a2d1f9075005fbe291736d4635d133956405deead9e423', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfe055070594267ee9f63c5920690df80c5aeb2597268411cbe1e674756661997', 16),
+                    gmp_init('0x4c6feeef843fb2d07355e80271d0b2b8b8e24792a2d3984134f0bc98afa278ab', 16),
+                    gmp_init('0xfc684b056b59d2adc93a642e5ddbe93cbaf8f431c2d9f46ba659f1a7efcde5a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5b16567e030c460fb3d9cf7b59d7da5cd7d854e7ec1d85c93b162088d40bde99', 16),
+                    gmp_init('0xd5844a7aafeb0b881d3dc49b104adfb8bf339bda3c832ef3e3a8290e3f6fc673', 16),
+                    gmp_init('0x7120e507925023a508bd4da82f01d41af86f2f7f4a416552eca274b29a0f6905', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1181c9963112a7763defc71b3a465d77aea33e67d57f618b5ede6d0e8cc0b9ce', 16),
+                    gmp_init('0x6a40208094b8552776070d721ce0e530bf51d93e334ad2380c73f899aa56f279', 16),
+                    gmp_init('0x8c926fa396719ac5122b95273c0a40c1dabc7dfde25173535ecef57b83464eec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe1c1422f1a115f67bdec74bf30748400ab24398aa1322563c6bf2ac8673ec7', 16),
+                    gmp_init('0xd5304616612ecfa3d8d8e550d8c3220919f84295f5dc4da5a18b25e824d1705b', 16),
+                    gmp_init('0x42421ea537a107af70a4379489617c80aa13992ed12ed5421ab9c9c21c22b4ed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3002a4a65e72bf149ab0285148d58d9756be5b262b2b5730a23dc7fff3542e4e', 16),
+                    gmp_init('0xac4051bfd4480c3eb1fa495e71760624598b34808690c6de4e18020691b1dae8', 16),
+                    gmp_init('0x2655edfbf34457d02a74924369c91d5d197d551a98f75a9b18886277d5aab2a1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x76374bfbd38a73e115dcf2b2fa53f15bc48fbd29c78bb2b6902f13efd992cdb4', 16),
+                    gmp_init('0xea7f2b2364658f36bff5d56bd26757e335a80a6b1528033363c86e804c25e149', 16),
+                    gmp_init('0x89e78751d193482e58810e9d54e36a85a92188950cba784fe51d9dcce06df39c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1a9929834321c5e1f2d847f05f4abec4514603f2f9a830b3a45361456e0d3750', 16),
+                    gmp_init('0xf90a6de5d90bbff9f26d4392c16f34cb9e1562e58bdd0e71ba7897366b4cd067', 16),
+                    gmp_init('0x7bb8fccf5c5188e6136d31754f1ec4796147088c44a4dbbef3ede6ffc3c49955', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x80a73500f04ff93579fe967bef7cbd6903649c9e2d21919af89cb62a17480b5d', 16),
+                    gmp_init('0xdc31729bdfdf3e98b4266978cd0ee46b4929a02f3fa109e7330c485f035529fa', 16),
+                    gmp_init('0x9bcbf2693521e1e324d95c2c0682586c756bb9cdfb6a1efc9f474943c5f175e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x60c157350a27db75b8d43cacc4aff49a2fe2597eef75a35ccf2bfd3f32500438', 16),
+                    gmp_init('0x810bb4feb9e49250ef69c005134c8648702fc17bb355814aeb8987a74fc86d7d', 16),
+                    gmp_init('0xb5a4226414f7dbda13b2a3d8802d28276e020caa69e16b1b68993af4e21f386f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa1c592ca90adeed578b39d385e06df17e7d65f4630a2a81707d8f6693178dfc8', 16),
+                    gmp_init('0xbf1f9fd1d6ae6142404b942b0ad8ef68ff25242cd5c7fd5e8d38cd618a648a25', 16),
+                    gmp_init('0x94addfc837b457942eb656037140155becf67ca94ee41f73847d1413fdfc0a1f', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc762a9c8ae1b2f7434ff8da70fe105e0d4f188594989f193de0dbdbf5f60cb9a', 16),
+                    gmp_init('0x1eddaf51836859e1369f1ae8d9ab02e4123b6f151d9b796e297a38fa5613d9bc', 16),
+                    gmp_init('0xcb433ab3f67815707e398dc7910cc4ec6ea115360060fc73c35b53dce02e2c72', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x49db3dd17a3284fd06b1197890890600f6a6d7d219bd4969b603f9214a285d1c', 16),
+                    gmp_init('0x458dfe87d0f838f311b652a8737db8ae930dfc27d97af888882951fce505dc3b', 16),
+                    gmp_init('0x2175549f32eddba86d2a062507602c65b504468b4fb006aeba713e698806dd6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x95f112d0039b81f37acbebe38a2f97b3a7543ee3c561918d36984da4dc88eb00', 16),
+                    gmp_init('0x889c4999af4b37b85aab55822cc57915e59c3a8e7c518360da394f6677f78168', 16),
+                    gmp_init('0x9f3c00119f778d48370f5bfd85b3eca7813439fa3913d93b8c7a343dfb0bc021', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5f27b546ad438bd772de55e5e79b4c5ac0f1076a8f6b21664bb919f19a366deb', 16),
+                    gmp_init('0x20a1f7919532c25e9f9e7168d3bafdb2a461c1754b21f6f078dca80bdc250c59', 16),
+                    gmp_init('0xc7c8c32355f904c74a9e864e30312529e6a83377bc1c779347bb06071245c871', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x28bf861e54cdb18b395350cbd334c46471663d8782e92e0000804eefd50af596', 16),
+                    gmp_init('0xdad52e2b0d83bc392033b693253438368487d46a0be870232c98dc22b4a99128', 16),
+                    gmp_init('0xf54d429dfc4d327e075e575380b3e8752d369e51daec2b980db2145bd678b9f9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa8788433e25011d497b97fe3fb076a31cb0f9e4cc3164c92314d6cc17edd274b', 16),
+                    gmp_init('0xfeaaf54b4d05625d64e45f12efcb0d8536562d042cee4e225e2fca38c2aa56b8', 16),
+                    gmp_init('0x2b2036f4e43d50d186397aad8c7bfda1e68a8490dfcc8bf5024fb88619643b8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfaa9658311ca46a1eb2bb7f3f32bcf19b3dca39d727139ce30309c75cc209f2f', 16),
+                    gmp_init('0x5f2b453cc3ee59604e7561b2ec565a4eff9376c21f1ac2b891e5d357413def76', 16),
+                    gmp_init('0x82c241089c8c44473e2e69bd42eb01e95c128c5aa106f52c9705e3416ce5d98a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb11e1cd45b6b882bbe2a2479861ee23f0163ba50ecd589ad47718117bd7c8234', 16),
+                    gmp_init('0x8ae9ebf0e5578ee218e13124a22400a99304b68f3c1edd9a9188b1fe842012', 16),
+                    gmp_init('0xe44396ada41dbd0b3f63fc44d1c99d5ce61125a0a1343d5cf8edef8a56829f0a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x80e818955cae16bc7d3f1b41e95edd9c79fb7f68139eef4232a1199ee8364d42', 16),
+                    gmp_init('0x3d652e07e6d1f44b010ec82f6f3cfcd506190ba8d30bed8aa0a42a36b903b7c', 16),
+                    gmp_init('0x77feda3d3644d44132321b5f866f161338b9c7ab32b98811bc0fdd065969a51e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d4a5d4d617e8518b6974d7248b7f6ae670e730874687990aa1e431bf8860329', 16),
+                    gmp_init('0xb46a587bf65a37e9252fc1d7d7cbab717132c828e5e638687a3ec350d4b33614', 16),
+                    gmp_init('0xa721910fa35949ae6d39a79db73a16f098b46879c9de65e1554e31e04f341fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x807d94ab61fb3832c1de362e555bf04407e6f8fccfdbb2bae564f5e58d12b461', 16),
+                    gmp_init('0xcfa0834d9619a7a52745891bd049cca13522a8646e2ff8b71ee03fc234132b20', 16),
+                    gmp_init('0x25079b7a9b4e2068e9de97fbc29f5b65333b42c39fd1999b208a6748c1b9f0db', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82b0d308d9bc86db044b5388d78ba631d18d40f05ef6e26b8a4312d3aaa5e0b0', 16),
+                    gmp_init('0x2526289ed17e71b1f46e066a927a70ea74d4ab38983650a2e2f30c8969fcb093', 16),
+                    gmp_init('0xd5b089bc47c1e627bbafa336a2116b3077483fa7f97b57a2e197b55b7efdf333', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xafec46ba2650d6e64aec42015bed46e335cc4e454e3e52a37ff56b2124fe2eba', 16),
+                    gmp_init('0x66a5242e73afd1735031aa372881facc946eb038cf278a94319e80610d8a772c', 16),
+                    gmp_init('0xc7bbd9e10acc511aa103dfc10c44106bffbd7195c692f8ba41b01fd782136565', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27f7339e394b00c63db2ec289c847a812e7c11d6f873e3e4b8174d6e0cdb626e', 16),
+                    gmp_init('0x10aca52aa5bbf48935f16a0cde741aad6fb2120831aaeec1a4bf3fa5ed8fbf07', 16),
+                    gmp_init('0x6d9a9bbb5f4f9b9c947bd6dee4b53e990b40fba497a5709f0bd4d1bceb233a47', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb9068f1730f3eb6e378a273a489726e4da1ef27789bf46f792e12827fb3392df', 16),
+                    gmp_init('0xfd4b758e9faf77126dd679a658269f2487d2005bd59b00740966a1ccf2cd40a4', 16),
+                    gmp_init('0x964d56182b715d0475b9911597182ed4dfc3b9a454c09928959a5be752b62232', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa0a9130ada4284055578c0997c2bd278cf7431be9c463640afa2195db08b50fb', 16),
+                    gmp_init('0x82e0e5f755ec8f43fdb24bcd0a6b0d42b4efa51fe360db1b692d02b26e04199e', 16),
+                    gmp_init('0x9fd33972ffadea022a4c4ed6f72f8c9737884242e943286b43c454ad4ebf5d34', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x78d8ac7fe5b0ecce505dbc2dd9fa6248d7960ac880f9cdbc6c42fb3e03eb0fdd', 16),
+                    gmp_init('0x76b15f530a978d37f1cb204e8f124ebafeffeebb1082567a09ace7568229b541', 16),
+                    gmp_init('0xe60851a31b1e4e75786a0df722a59dfcd3c856938532ed9d1f3037f736300ed3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa056d822819ed1666bb047e71d22e3c21b2c86e8c91c0b4b2014d1112120dc5d', 16),
+                    gmp_init('0x7f030e34d924c841dc32afaa01aa24997286460ff1b99c0db89d51fc4a7b7f3b', 16),
+                    gmp_init('0x1e4b8f7528787c4f7eccb2b5564ad748b7d437787e62d98d3026c71911f45854', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4b00d4a5d99da39a606a81c866b46fed9de19bb05a93a68bd803f366d8097759', 16),
+                    gmp_init('0x267c4c1120997cdc9d458e6d5072da4831ac6c59862a7db12f30f44fac07b670', 16),
+                    gmp_init('0xffa6958b07e8b9921a2dd1af166e178ce41eb1e86ec377c43b34fe9645b0ab0d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe0722efb92f9d9cf15ae75264af6aeefb712aba0587a6bfacadf572549b3dbe8', 16),
+                    gmp_init('0x74c75b5b5452044b15851f97c5381a0a39a053f4ed3f3d336afac757bf700c2e', 16),
+                    gmp_init('0x4188c58994d2bae890d142f2260fdf28e5e74d77030f49c015010e88fe8dcf9c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5632f1100a0be522e3b6c4d355f3559d3bd4acc1b4120ea6260f2579a7aa55e3', 16),
+                    gmp_init('0x69e399e825a1580deed121242ed3bfb50b10d0e8771f327155b48d7750102c1a', 16),
+                    gmp_init('0xd0bef617b370ec44a8ab720b10e94ac7167be806873a06505fe9346aedc84211', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6c0005af146aedbb0865799e9d1664e5557205aa68d6ff3f1d19e4fd19aa4c78', 16),
+                    gmp_init('0x282ee4f0d8df8d7c2acd2fa9aef908a534f021a68e3178bc477dbb4ed2b66c73', 16),
+                    gmp_init('0x7e09db1caf30205bfbd01965f719fe3ff6a9d9678149956d420c07c44e180608', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x65dc3247a8720ca0b9a16f74a00529b707cca22b841eb3d1a327715bbef5be28', 16),
+                    gmp_init('0xd09134253ee2b56943af5d2b4fc53eb6ba13de473e3ab9f0063ad79fc10d77c4', 16),
+                    gmp_init('0x914b0313d86f07c8927757a01009eaf5a9f4d1b95bcce864084b924f63d27275', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9806285c2c97edd9e29e5c195a52ee01424f3a6e076bbe340590b495af26d4aa', 16),
+                    gmp_init('0xe2759ee2c4e946657a42659791d910a3d2bb1b1357672edd5094e15159f8a8a', 16),
+                    gmp_init('0x65b9f4ca64e3fb0ac7d05855ecafd296d582ddf4fe6e4c85b104245f213700e7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48268a93985eb3acb83bc7215c187857f7194fff1981ee8a65babb3bbbb7e5f0', 16),
+                    gmp_init('0xe3b68971c4e9e5198dadefd49195907953fa2c3754fda81927965eb32f8a1d65', 16),
+                    gmp_init('0x70d28dfda227278dfe8e3d2df489a4404d4c7290ff0563cc8dd5e9d5ed0c08c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d163464fda5b40851765ac6b7f2d50dead3af1e89cb8e04f2d66a853f6caffc', 16),
+                    gmp_init('0xd94008d7c979b84451382ebb0a376430d3cbf47f727518c13aed4fa7f2fef8e3', 16),
+                    gmp_init('0x5aab3070367e1d03c019ce03dca654c98ced247a550bd9f102db097c411ab65', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdca2e347282152d7ca03c4d724f2160db349c1d7e9f3f48baeae21e8aeba424d', 16),
+                    gmp_init('0xd97f0cc5fe10d9c155015588335e85c69673669a61eccf092b00caeab0be1b1e', 16),
+                    gmp_init('0x2628262b42679592af45901c9f888b6747bd2132ff314e6c94f84083c10df1a1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1429777a5f34c2fba432c3b4850056ec223cee8af46350e80c9879e3d230d56f', 16),
+                    gmp_init('0xc60b6022089a8c26bcccedb3504ee91699714a886232234d12367290f75783af', 16),
+                    gmp_init('0x15640b8f00f929eb6c136755063dfd88e85b98f7abccb952d62c2a19815afa76', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf52f8908f53e65724c877802f86d7f2f877e05e517d75abaf68388868d00a1e4', 16),
+                    gmp_init('0x6410a59c9329b46d70409f8e95c370eb637f4d791f7c4725df70fd2d06204c2a', 16),
+                    gmp_init('0x8ff17179c43afc76f9b667e7850bd426a0c3e932358d0db8f67bfeb3e4436cc1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4cf8926505ff4a1b1602db976445837bef649fd02ebf4426cabdb3051ba45608', 16),
+                    gmp_init('0xcfa08e507ac8674e8535d745c88e398e702b86169b5c598824df61e1b6055046', 16),
+                    gmp_init('0x7434482f53a80440c3e2031c354a796c406d6ae5410ca44a2353f3eac982f873', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xad553488fe76937a9f30173d675e590607f43f3e67706040bbf060998b069c85', 16),
+                    gmp_init('0x533d887a348d252f08690e2d16f543aa6a3891da4d6ef59488a4d85edef9c7b7', 16),
+                    gmp_init('0xf16e598a0b294823909cd24a147a18cb71ceafad3d8c330c937186f1d574fce1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x52e616759ab3bfab3181fe63130097dac676dd1b149b7ae681f584f776dc008d', 16),
+                    gmp_init('0x3e164e477ff1c32f5e4a8707471c28048262160fedeb4aae313922948014636f', 16),
+                    gmp_init('0x6fbd403206c750d10ff2898523e3e83df6a7713517b713f8344d236d7505c1db', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7031bc3ad7a369ec58997b4e01936c0675b73e7cf606f0c127f566c3b8153f4d', 16),
+                    gmp_init('0x66d30852b1c152fd0c378e577cff9ec87866411830149176afab96accea54621', 16),
+                    gmp_init('0xa73b5a1769060094dbf579c21c48dcd104d7c14ccfb544386fb623dfbb05e5b8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb4c78b85e4a88d25801c4b59eae1c84b24badc1a7d61fc39f4cddb9fc2d2ee8b', 16),
+                    gmp_init('0x1c1be835570086e9f91deaad7824a8492f42c1bbc6aa2ecec1c01200f484a99e', 16),
+                    gmp_init('0xc0cc682fbdf857c78880f7f240d8c27f90814c5af2a162a0d8e488be232a03c1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcf90963ebdd914ddde6874182123a73cd0f37e4c0d5b39a7cd85ea0afeaa0d53', 16),
+                    gmp_init('0xbf1109ce29f7441f894b5211847c7da85cf12b5c7506dac6db305e50a93ea3ac', 16),
+                    gmp_init('0x88b935d00e2d2a516a939ef8ea1954914f8233e2ca4fd5ce9f813bdab28efd66', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x56268bd4848332b96139c8828c2bf2b394afe1ea2a75d7feca07014afdbd9745', 16),
+                    gmp_init('0xac593d6f6c53b8fdfa4c61ad0ba0664d02bc7a9732e76b934d1c19ddd5256582', 16),
+                    gmp_init('0xa9b91e12af9bb2cefb666ce1f0a16d0279b7e647b4a1cb0a01499a2657c978c5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x857ff9f134d68bc6fe8879590ea39834389bbdaebd6a32181af9b8a6fff12c1f', 16),
+                    gmp_init('0xe533a2253d5f66e4112103b924c77f24156170d8dacf9dcfcd522f99d1df589', 16),
+                    gmp_init('0xf4aa8425223eaf34b2af16053ef60244de856c4cd1a3b3b01051375d8d152d91', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfde48868d6e76e956be138a40a9ed135e9adba96d81b937611c3e138d2b5a74d', 16),
+                    gmp_init('0x55c3b6a5bd8c93655c2c1a35e34c668d92203bc9bd83fbb10068f957a4dcfd21', 16),
+                    gmp_init('0x1b215fca5edcc75b8f61bcf87a7d4d2e10e85842ef890cb16dbc6971679690f8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x742f597208f53ebd500b8d933c23e14955045a78e1410a3aefcc07689e8eeeb5', 16),
+                    gmp_init('0xfdf8ed4f8d196ab843f2a3259c0349dc4e5e4ebd1c2117aab20806b6d0e98a2c', 16),
+                    gmp_init('0xe41fa673d1c4439178fa1c47e57ca48b528b084dd0352172618db8fdca1c3409', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b3e50fd635dd95aabc68d928fe761c92347ca61e8fa2a23f5f30c57982feef6', 16),
+                    gmp_init('0xa1bba75ecfa811025767a320434c720d3a305a1f3c209cc2d73986d86f058ceb', 16),
+                    gmp_init('0xb831d6a8b429f1b772a1cb669da526fd13a30e34fac3749fcd5c29937251e8dd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3b2f126d9fc1f59143657203866eae00942b46bdc492dac1f4ee6206f752ce09', 16),
+                    gmp_init('0xb145ece101504c66bcac1cdf0d879f29801a4be95e51cf36cc19610ec749ba3f', 16),
+                    gmp_init('0xd903a7dbe727b555765107d8c56dff592e92872c6fe874790f5403ddd205694e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf81211eaa399ce3132aa03db897a4ee668c1c3c1fae4e785264e408452a5a7e8', 16),
+                    gmp_init('0xecb0879d54725ec7406b1b4078a4450d2c74cfdd31b0e100d9a8792494fcb0ae', 16),
+                    gmp_init('0xb7abb68dddb38c95ea06ef61e776f61a04bbaac7db1af3c994baeaa3750c7efd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb33680bbbba41a5b51f2d568edf4a3dcaa060d1e3760defd11457d3b629f6e25', 16),
+                    gmp_init('0x2a4f2a125719501c960942099ea8486aff7a115e3007013e104403a577a62394', 16),
+                    gmp_init('0xb5b18c54bb72156be9b1fd5db49ec13d90b634933ee86b175e755493c259ce22', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xedbea9194ecad4aea24f69cd9c0e00c20b64a558a23841f03674dde37c5eaebf', 16),
+                    gmp_init('0xf8cd69f27181cef6bffd2f88c33cb515491d1dec74d9ca829e76aa009d8910c6', 16),
+                    gmp_init('0xb7dcd59107cb929c599d410eb0de3df963f802e9f5e163af1f12e576c44487b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e3be280e7fb38ce56a566442f2f4b175402327666acbd8724a3c1f9a9e94d0', 16),
+                    gmp_init('0x7d1bcff69162df4c7df729ecbb3a516eb930bc8e0f4d74987924e66e39a61bed', 16),
+                    gmp_init('0xc70d71ecdbcc76ff7c392d7590f413e58ba6cd58e0c56b9e558506ad581096fb', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xb1bf00bec2f89c6077987661de0b4c0a8d247e4bf17edc922dedfb6af2ca3dc6', 16),
+                    gmp_init('0xaaef31ec793517b9ac23298f67bccd1d42729396f9b981da099623463f196539', 16),
+                    gmp_init('0x86feb92b6480ca333698dbc13355473c725cbcfdc29e410d083abd65dd434613', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd0b1247aa554c9ac52d19fdf565cb8a7018f3d364bb453af20753de9d8d1436b', 16),
+                    gmp_init('0x7ad271f671022598e6613309ccc2cfed3197f71bee41e7556bfe1d1fa64e02d6', 16),
+                    gmp_init('0x89ed04204acc9ba6ffda64f419a209b83ba3b27a6f30cf465b4cd771fdb09bd9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1945c0ea17c845d278cea2ccd5eef3ee1e78ef291db051809e09fb91d97276f7', 16),
+                    gmp_init('0x4be90643c65416d83acefffa964bc6330d670f46647a55ff8ccf75587468f20e', 16),
+                    gmp_init('0xf3c78f21af0a5637bb86d8094a82fb771c0d0e5827bc5c8c3a8b1cb7b73d56d6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa951e03bf97756c4f36ac2de5767526baf6961b911f711ad8e6c6a8f22765d1e', 16),
+                    gmp_init('0x8eeb173b6b075335b126a1e0d352e3b6c7bf658b6197f282cc7be785d124910b', 16),
+                    gmp_init('0xc6d6b1e767c1ae75cad8804621be5c680bb0f638b6c94ceff0e90ffc00e78b13', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e7647bd9739150e1615f45247cd95f3772ee6a630f54afa3ee9ae4f39be1961', 16),
+                    gmp_init('0x7648ecb12e64b6822a06e5c02c21208ff46bcdd9047a1a668a7bdda2343d3441', 16),
+                    gmp_init('0x4d82514ee262eabde062d696224e177d184fa7d040c66240a0a6f0d95aeb791e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x116072f9fba56d946932fcead240c35271d73d2c283f7a88bacc93f9de27cc99', 16),
+                    gmp_init('0xc2d5d9ba29dbd4f6f2029f9dea4a6f0fc9e58def85cd7eacdb3b451ad578c822', 16),
+                    gmp_init('0xd6926dc5e14b8bfc7eaf9307a2ee977a7dad3275ecf8375bfe46a86e2213a5d9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x36eaaac27a740bd2fd9689f21097a15fb519ac887f16ef24201d6a3d33f27e74', 16),
+                    gmp_init('0x9a3d01c5196776f29da4c95711e5de59368f3a7ee53ac8b0673d998625aeaff4', 16),
+                    gmp_init('0xd659a496af30a51dd06dd2165fc49b009cb9c1471ec9fc300b82a569c5d594e4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x87b2062d2f96c1c1d494aeb031d5e5b18e2751cd9fe16bf68dfe8e0922c425c2', 16),
+                    gmp_init('0xc315f54a0a7981caec944660448923920d5fcfede1c998b0ad4e86d21fee30b8', 16),
+                    gmp_init('0xa2961734a2326ed070a91d0266c86e853ebb5daadc7207764713755cd21f1132', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x255e2f5c94e63d165dcce0b5df24a3abbbea1a127de7b843daeec1256c0487b5', 16),
+                    gmp_init('0x64aacc769a0041381dcbc3732a4813a8122f6e1c8f4c9748f1ce469e9b2c7ec9', 16),
+                    gmp_init('0x4a29894cdbee70e75adc991e0f35697b8ae5b31c760c51323cdd44e972725015', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e3699da7106289f5fe8da3bd4d59e17fd42056cf568a08925a21706b8bfe56b', 16),
+                    gmp_init('0x937186b28a239e5a15ef8cf85e1a6314ffeda1bbc480f097e9942bba279191b', 16),
+                    gmp_init('0x979daeb65bab67572d62c5343c94916759938cda281d1a327862c5990154c289', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8b2ebc75f5e2340964416724fe1c3e6d908e6611a9e15ebe903d2940ac2e1360', 16),
+                    gmp_init('0xd59be4614c00047de0f11a5a0e77b504f9ae5fd6cde268a97d1d1ab703e877a7', 16),
+                    gmp_init('0x3cab50f318d5715a4cc41042cd8c575132ed3f3acec23ce1ad379d36e217d7dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x325146ade6e77860bb9bf56c44a13d2c0464f786810c32a9d44ca718b902d1a8', 16),
+                    gmp_init('0x3d02e79f5999b57c9345b1428edcda5072e03cff63615102fa2ab40be5911d31', 16),
+                    gmp_init('0xecd6c921b2b24aca1dd669690f59b2bdacdd86989b7880b4c84e865b65930a5e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe57ac73e43d8ca11a8a4d31799fc211b2908b03a829cf05c56b502b9cd54576', 16),
+                    gmp_init('0x91cc363b8bbb15a49fa4432aa3010fa77b87a165fe9ac4216025fc6f7e55f135', 16),
+                    gmp_init('0x759af6b0392ac088a12f7ce4c50c28d23240474bc1d98292ab74b0484f652710', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce380e4706400a1a236ffcc011625bd9def25c51e65e879c27e3b6db2c66f2a5', 16),
+                    gmp_init('0x7c6ff7ca4c1c9e3cd2dc39e6a3367cf3d5fc966818a6e8687311a2c7f07d055b', 16),
+                    gmp_init('0x4e9c6b820078ef1929029060a68048330dd32ff87837ba4a5a38f1d3bd7a925', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc81b92841f7fb8837fc169ec9c8d143c33b7df5927a27f66fef05a8cced12fdd', 16),
+                    gmp_init('0xcb93a0a84f3e8ca329c46ce4787bc903964d4ff330914a045299d620f8861d5b', 16),
+                    gmp_init('0xfa05aea426b42de8e444b0537d43edd9a2155062da366008208b233222d162ee', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x12dbeb96c6dd91b897cf5651c4a9f69f2f8fdb9a34b327ebc3f338edfbffecbf', 16),
+                    gmp_init('0xf66f3bbeedaa8213c4e8dcc3afc3ab11ed7c9638cfe6222ae2274365b59c79fb', 16),
+                    gmp_init('0xc3ec2291bb0e123b0e94daedfaccd0a2b197b6a433b372738821f0439e217a0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c7a77dd2cc63cbd49aaff170aa965758b9423a64c191829d59e063fcc26a887', 16),
+                    gmp_init('0xddcc36b839633f523694bc06ec1ab232f3bc952580f3c9d9373d511bd89b83ec', 16),
+                    gmp_init('0xfc8b5179b330a02d896f3437c85398655fe139713af429332bfc6da3b50a11c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbb109379999dc1c8afb2e23b84cbc83701357391a77150368bceebc5702011ef', 16),
+                    gmp_init('0x2e21c81a7d409fa8de5903bbe720dbad8f69b45b8fa484f650813d730ae5ba1f', 16),
+                    gmp_init('0x2778e174ca928d4884decda86a891e594ebf6cc3f8aeb68ae13fae26b2b944ab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35dd8774c4cc02736dcd3d76988f53c3be577a402c4b43f59132a2440dda408f', 16),
+                    gmp_init('0x952d69887fc71bae778297af90fb6495f19d5f1d75a20699ff3e319d3a40d3b0', 16),
+                    gmp_init('0xf7f77b4a327b177619e7d8f271d625cd12596e273c02fb7dfbd6bf01df3d4730', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x98ce3a78b17d2c24b0b4fdbf7fc41c0b246903f472dccd61c49343d5ddc81e11', 16),
+                    gmp_init('0x700d9ebb551a75ecd3ad0553262f97217379e33c389b809f0d9c3671c8d7b4ba', 16),
+                    gmp_init('0xd69703e447537750124b65dceb4fc9d86f5e2596c2202a3ff00e90c1bd4a2bd9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7b538e23a529bf2a666a2435bf3c4758b4e786e27d53779fe167f803279e3e72', 16),
+                    gmp_init('0xfa00b4b06e5ffad5a56f3375bec60eccdd0843f09ac641f7ba69aba95577e281', 16),
+                    gmp_init('0x21330a3167c34960d8ea39e240eab20a55daca237fb9df212d1f14e7c7171192', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa5ccf14acc05dadd1a48afb82fb2f8e1eaea85ad88a22d3dfc5aa7fd624cee30', 16),
+                    gmp_init('0x6d4b2119377e0f55a29542f755b44aafe009e16a9541a924896c9eea18b3e263', 16),
+                    gmp_init('0xa876cc8d3c47aa816aa5796b19c0ec98a6e263d2cfe6cba8443ff29918ecf5b5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x776e70c15130cf35c9e096607b80f8be50ebb75bb9ad2c96f79b65ebd080644d', 16),
+                    gmp_init('0x62abf71993778c7c0dd50afc1c48e466497817de3e8e12f7166ba8e5712f4672', 16),
+                    gmp_init('0x5e380f4b922d433310392bcef6450ca822041ddd94a601ccedbb9f30f99fdf5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x995687391f70d80808361d72e4819fbd966b6776839edaf9a127f0d958ba274c', 16),
+                    gmp_init('0x62c8896a11599b98379758fb1749475630ccdba977b8200b6096b00fb1bb00db', 16),
+                    gmp_init('0xacf8c3546e77074cd0e9aa1c77e3c3d4ec0fe44562cca85c92848718dea761fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe1a1dc6a8d5dd011da4f59dec15cca5e93e75fa976920deb304b8cfa46bd558b', 16),
+                    gmp_init('0x8d6277146f7432102f5b5a4af989390e5a49c25a52d9862f3c999f8024cdd0c4', 16),
+                    gmp_init('0xa5d9b54a9bc1758436e8bfda9b010f76af35fcf51d6b8fdb49ff97678e5d5b52', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb2e821c7bebd7fab63a2dd2d11896fcd397cca27608875f5869037ebe5c9545b', 16),
+                    gmp_init('0xffaad4f316426a30a720ea7c58b465eb452159c10cea6f87db2f06b3d4b49dc1', 16),
+                    gmp_init('0x7441d6540088b1baa6bb2d1cc44495068c34ff369efc748176062bdc2aeffa87', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb3886343e96e967b7cd6c754ef68247b6cb0aba25f1b6ed5375aeba1cfa2e5be', 16),
+                    gmp_init('0xa17ffe1e4fc471e99b4bb999fc47f034d68bdb56d8219e9bb2c09f1fa3676dd0', 16),
+                    gmp_init('0xd1330bcfc8a0e245f98ead3e3816ce4ab7f76eb604040cca8633c59a51f25654', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdaa84b62a66854fbc1cbbb462d0c6fb22c200235deac6e71c472440e77423897', 16),
+                    gmp_init('0x87260d5b3d93b0f9c18f81df3eafe5c46b9109e23ff5628eb940d9305ac89645', 16),
+                    gmp_init('0x9fbfb7f56d759c745bde82c6010e79f4a35805b09c781f205c9407752e5d0219', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x943b491b06df31cac16116336119084dc6cc7a7ba579c175c768c7eb05c85a31', 16),
+                    gmp_init('0x140517a33ba50b6f00ddcdbd182b0e275f441c3a87dd97cd7321b67d7405d3b0', 16),
+                    gmp_init('0x97f70aa867bf438ed3a5bdf25bf4c5705af673bae691e020bec240c451f8647e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x275a3c725cdf8e14c6225c884eb633a2ffe64baf12c55bb0066a0bbc6d5f855d', 16),
+                    gmp_init('0x5b09938d032ef6b1eb3400a9a59a6b74881e9d9e9b46b4ceb443c6cc97b61875', 16),
+                    gmp_init('0xd97858baf32f5702620efc4449e7ed34426b978223a3e3ebfe81326d3a0bad47', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x4a6ca92fe5c5a42b97019a499678e531e1ca5e2a4ce39d88127e6bd82c4082e1', 16),
+                    gmp_init('0xe9c47132bec756a7518052d761a857c1c16defa6d5102ae0bd84ae068f01cb87', 16),
+                    gmp_init('0xf4903ba3bb4b56ec795250c07873b5a23ea007f0ba26c8f6c56091a01c237f3f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1037701e902140d2b51c0ce34966ef62cf97b2f246c5202ddc5b04312325fba3', 16),
+                    gmp_init('0xa84554bfb44ac0a5433dd199963181707210e53dd7508c702a0d4bdfa3e580bd', 16),
+                    gmp_init('0x544f5616f97109fbde5a116aa7f37dad9c32527c8fdd7f7d57cb449571b8c67d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf3c7072e87920c66d95065baf657d1aeab4712467a32eb4403b64e45606507a9', 16),
+                    gmp_init('0x9d4f2b0c82d0913d71aaf156607ae13a2e4808355b37667d59bb7303274ff382', 16),
+                    gmp_init('0x5a2b2f1767bdd82656b584ff1c6997c7fbf8ceb0ad23142d5f933616f852e490', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf47eb9989a95996a64ab631931658d5ccaf1f31297d086431eed03d52f4ea889', 16),
+                    gmp_init('0x8b85c810ca1cfe72951e10f1e008b55db75e292ffce0e4aa428fecf914f2590', 16),
+                    gmp_init('0x36bff827fe9873106b4d3715f61437a0f8ddcc8577e6710ab4c5125ccdeff2ea', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdeb42489c812b43168c445fef3a1303810c9fec63cdbea29330691e9d58c8d1f', 16),
+                    gmp_init('0xca4840a5028f919ed35123cb5803366b55abed9d78338f458a8eece1f883cb16', 16),
+                    gmp_init('0x30ea6265f982a55ab167bed86af8edd44ca6c36f6a48bb861c98f4800403bbf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35ac9ea1a50c5470003e8b1d5cc1745fc21de3f749fc9d8c98c06044edeec4e1', 16),
+                    gmp_init('0x1daa8ca9d4b74b129115aa8762af47f69ac734a617b46d58c2d5b8a7f5c995c3', 16),
+                    gmp_init('0xd43dc6918f76a93ec82654d03eb81eb1aee164ad9dae6d5010d0eaf0bacd2cd4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd247b66305dfd5c979c56b9e0b81d09a73f78da3371479cce70a8073e503fb05', 16),
+                    gmp_init('0xdd04d40130468de396513828edb55653d3acec3e18f39946ad04d07524df7c95', 16),
+                    gmp_init('0x57e216d0d314f3e497b47e281a47a426e12c273076e24a7af1a8293c2955bb70', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b9c4975e4ce5a283814b17998a2d970393ea365daaaf18c5ba2b592a8025855', 16),
+                    gmp_init('0xea0551148f5472156988af2ed46d90a1c43f120a04f9c6eff78039f2df9dc45e', 16),
+                    gmp_init('0xe0e19e05ebdbb1ec96a42a95410fec35f9cfce17ddc95e46c3ba85d2a7fff24c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf44625cd49a9769cb550dd36fb6038f4d2d2d10929b18a920ff16da19dff721e', 16),
+                    gmp_init('0x56d786a5f5166f0ca0f4214c6d9402f80483164d67da2f8fc5330649a1781d51', 16),
+                    gmp_init('0xfdef8506771d9b42169f096e7486dc1960858b168a0c41ab6adc26729a0e3c23', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf4c485b6f404ef8b7b122fe6bdb582eef3d00ffbec08d042562c962d645ceadb', 16),
+                    gmp_init('0x41ee147e5592f88d6b42da27c1b0eaa36098a49272e3e6e0c724d0485115f86b', 16),
+                    gmp_init('0x43a0fff6a5f7b0f08dcab2e03df1696111018bc0f9b6632297ec8e63fb435566', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c6c2f69910848704fca41c21e433f75550fff11925de206cd7dc103535887f5', 16),
+                    gmp_init('0xd948753c2abcb30077ca0cf001a1acedfccc997e01d43e7292986c588626ef61', 16),
+                    gmp_init('0x8d65e5a6c16bb80380fe6539fa2b0399ad30ecc3d2054cfcac1fe320adef04b9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3e52ab902eccf9bdfc5c0cfc31b98e1033d8e79fbb958f0540137730394b36fa', 16),
+                    gmp_init('0xa3a5b73bfe75f56684901f3df3bc763591f668a110438c64a1b8ed2c03714bc4', 16),
+                    gmp_init('0xdef960b94634ea2ca8b2293482b3c5fe890df6484b662b9413a958b48a7601c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7b7f26348c59df7a71a7f5daef1ed93c912f3273ec95d6d5cdd9da31724d2789', 16),
+                    gmp_init('0x79b036875a4c35b28dafcc9a73aae864f9765fa10d9b19b25a18c8d6713a1f8e', 16),
+                    gmp_init('0x13b44922ebf6103a1823b3bef50e4c6822ab2ef64075d790a7cf0c8568741feb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x44a588e251f5559eda15fcef8c650ba5a09060fe4181014f4854a6ed75ff7197', 16),
+                    gmp_init('0x5595e32aaa5624467f358ae2d941ee6ec78da15352034729ac6019bb9ea04b3b', 16),
+                    gmp_init('0x66cdaa8d65cbae802ecc4e329747b837eca6dfc0fea15a1a81e52088c5ab8268', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c6a74981402572c48250df371ea51bad7af409613de1156be177d2c8d85cc69', 16),
+                    gmp_init('0x75d3dcc84d30656c0aa240114310b4f353bbb1f1084bccf25a3a2a5968a678ff', 16),
+                    gmp_init('0xb44eb8047e5d0bc527c140081c603fa7f4705ee83a4ec8488f2bc90b9386c970', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x58a9a2cb627ae6af182ae08d105be0686ffc6b3e75852b5d891836a012958859', 16),
+                    gmp_init('0xaa8e76096e143b01ef57dda284ce3880c439af886a2f96c269a2721f14098c4e', 16),
+                    gmp_init('0x74e5b2ac04328532a263260409caf51d0e3b81b95cf1cc8a2b45daa41498ec0b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x49dc6d0cbeb1007f3d6c72f0dd325176e41c5db3147d39903d77ab3b10b4a9b0', 16),
+                    gmp_init('0x12faf753e782d561f1d5909747c4926205ab0a38afc1ea96bf35607954947d50', 16),
+                    gmp_init('0xf1460b6a26fb52697466a5dd7d59b1579d5c2f967a91fda6cc7279ea3f652654', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb36203cea39df0528597d52506e01477c8b99ce91024a585907933ee3a15518', 16),
+                    gmp_init('0x75ad39e6a6225113856dd928fe19a30e592b7e18cf51b1617d36ec7a1ed2f978', 16),
+                    gmp_init('0x6628db234af3903c60fc22b52cc3aea2657692d9e14ea4c5825f4b8f1bcbb56f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4ba7da75ee03947652c9781f9f742e41c9be42462a69ce0439841c42e3fb2d5', 16),
+                    gmp_init('0xad223fdbd9f680d2bd839b6f901d39c917b08c5090143e98adede2b7fd34a1d7', 16),
+                    gmp_init('0x6bfc7d4018f4531533935d73411689cff154f02a5a37a79f0787af2b414bf05d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xad2877ff9a1de454a4ddfafe744917401aa5215fc39a4f6d5611ea08ec4e8b16', 16),
+                    gmp_init('0xe3cf4ba2292e3f4ea0f83dc4784662da3e2a02abefd690a9cc86105937d501e1', 16),
+                    gmp_init('0x66ece2387fc5b61a06565d0a9d815711caf8ee62f5084332056bb62bf001a574', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x700aae1ca6586a4b3c642cda12d4dc2d547ad408dd7181aa769befc205b096cf', 16),
+                    gmp_init('0x1143f29bd9736ff082703da2bbf5f357bda9c549c8d201965e407400082b1177', 16),
+                    gmp_init('0xd5aa7b6d68905416a993278f0d77cc24af638a6d43411f5df118c5e76f159e88', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x873380348d4d8241ef2b04946fa2f74da9955852bff201e802a1c2fa3b96893c', 16),
+                    gmp_init('0xcf8778e8e8b6bc3395ae306cb1ff672ddde9cad48169532d91b5fcf81cb92567', 16),
+                    gmp_init('0xf4015a2c8e3438fafd90f33d97d4aa74563dd3495229ebe672fad2bfb8314788', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xde940e77466272339cc83295893768a59e6f2cd9424f7e27ec62eb6c7ce01d03', 16),
+                    gmp_init('0x2a97d1bb63313040069b3ecadd374e5d21000cbc50f48a91f1572b9cacd19574', 16),
+                    gmp_init('0x92b6f52573ef7c0d7d3f29ebe716fee31523c7e8a1ee61efe21d4db2f9ae95ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x951ca6331046adc896851a76660d32535ce5439e1cf3df3ef71e16a98a349475', 16),
+                    gmp_init('0xdba09e19107140af618dbd0b6a70b15bed8dee7be860b09a631a0ed8ce5165b6', 16),
+                    gmp_init('0xbfe1a9deb25940145c680fd1561690566c3524e29f50cc17e24c115aae3124e1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9f0493f52de6777794a5982e5d88ae7e5551fe690fabc2f48cffb6c047eec6aa', 16),
+                    gmp_init('0x8facc8212c93a28b3f5acb0885a4d296da48dc16129efb59c47cb87a66ab478d', 16),
+                    gmp_init('0xf0c887054177aca5138cc5b3e4e66e550a1abb0304d3fb3899ef4921a407c633', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d4265cfc390e8afd5e29760b638c23db2e703d552a7314c02a8c291436b8dd', 16),
+                    gmp_init('0xa88a238678d0c8aa106a8fe027ba111aa20e3f12d0619772ca28b77dae4d710f', 16),
+                    gmp_init('0x2add3ed536c4a85b4c3c72dc15fc890e4c555fd627264c0fac66499d3fb2fd0b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbd233bdd42dc6465f264505a6bed10b4d57c9cd2c7e7e83a2339c0422535efd4', 16),
+                    gmp_init('0x38fd5fbc86a67d4c93a8b8cf3e1512d9b9c3fd7e76cd76786c4dfcb425546dde', 16),
+                    gmp_init('0x2f28be0fd05231bac5a3e306a492e602b8c95fee8454281704d939a8a9adc95d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeef2632ba4ed21d5b9ae97dec5ad1923dfee3abb0434ab0255365725da1593d6', 16),
+                    gmp_init('0xcc2850aec972243c3bb6d7cf4d0dfcc6fc7e97b4a65ee79136289bd15770eb59', 16),
+                    gmp_init('0xecb26b54eea94859efec18a83f30c78900a6dc6b4b5d8ec35b130117503664f7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7918e7a21e6ab928a789513ed015f1c7402651f2ac81e0bedc4a3e4856997020', 16),
+                    gmp_init('0xb921a6c409951ee26bfa28f9a9169d7bb66629b1cb9eb2b53eb6b4e89f0f225f', 16),
+                    gmp_init('0x26f8f1722761cc14a6fdcb2ca4260a7f616fb159296a0c69a440300f04b6de06', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6533e3c01a3b66d2fd110c43eca4dca7829258e72fea8212d8d4ca08d4222e0a', 16),
+                    gmp_init('0x8119eb24cb4b1eb24426056a561dcb408204c6ba4b8d4127efde4f18eb7283fe', 16),
+                    gmp_init('0xa39b3f319219852fe9684f22e42f98f49fc73474d1d7489873bebc50d629c608', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xae3d63904e54ad260bcececda385ee6620c35bb507c99178c07a734098268e64', 16),
+                    gmp_init('0xbde712062a80f1e2f17c9054540af57cd2fda4ab97a4cfe846cb8e73e7d463c8', 16),
+                    gmp_init('0xb9631a681d76729dbe207fb88ed270f07b7f28bab28fb56e23a04af0d21c4186', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x367df2310271aff98c1ea4d59c9d007c7f38d4ed6cab66e01fc7577fac1de897', 16),
+                    gmp_init('0x7fc990bb061160733f948d9a3ca2f86925fdf2ac3d50332f7802116be6f485f5', 16),
+                    gmp_init('0x5cd4c29769659cdc6ffc34a5b78dce8f11abd6e797b21ccef538edfe64b98078', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x924c1f2a0c6772ee9ea35cd5daae9c572bb59aafd250933664bcf6ce18cd1910', 16),
+                    gmp_init('0x60b502b97ad681af7d8f964f954fa91982a1333fd02293be9589ae82f81b0164', 16),
+                    gmp_init('0x2c33b9d09c3fa8ae73de4da9602fd118fde3eea4c91050b6b3029e129cfbc7ad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9f2a6d056435117740148448c8dfa248b7432a5bf7d726aacfa09f420dc23434', 16),
+                    gmp_init('0xe63bf94c82ef533b00174162d8061f7aed89767f85810bcaea3b0b347bc37532', 16),
+                    gmp_init('0x1df2d2936ba8eb6c4a053a73970d61610816456a03443c9cc4c5fb0ec3225b2c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8fc49a5fa1c5e6cee6cabd7c92768a159c10e8f2cde9067b1ce92a2e8415e065', 16),
+                    gmp_init('0xe695239b7d93af052dba1ad1f8bc069537bb225394fc243d7d7b42a032ca2eef', 16),
+                    gmp_init('0x35e37f06397742a9cb5f431972387e760125b088d87569297063472b01471dbd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb11f3d2aaca12240551b103a5f52843bdf9a0f3227cfb957ed8805794631cf73', 16),
+                    gmp_init('0x98eb555c23e1e2306cbf4947a9b8e23599622bb2255c7f93612ac822f628a05a', 16),
+                    gmp_init('0xe07260612a3729eb8644bda8da5a255e205a7895fd3570a440de62b0f8bbaad1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9da8f09aa1f444c442677b54e9f23d436c744a3f6b63432df6f382e4b55221ab', 16),
+                    gmp_init('0x58cb7b857d0824b92e73292e73ce534e9e56dff8ac2063e8b0b843ef75085ad9', 16),
+                    gmp_init('0x492377f3c7b6294ee136f5a162bdeb1a0e0118b23770015a8000848b1b867c5a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x106bffc32c945eede4843e17897eeb672f5e7334bb3c29c3242f07872b5be271', 16),
+                    gmp_init('0x6faf7d04d8bf1ff86d0f61917baad22c97aea561b2ca64047afdb0840b991431', 16),
+                    gmp_init('0x7056feacabac0bcd5cb01f4dd8da4e200211bfa534086c5d8887a9053c108eb2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xea600166c595907de513f2abc5a37cf6a4a5d0af86ecb0e511c259fe8d816eb1', 16),
+                    gmp_init('0xd477357871ccb0684db9a77cc742ab97604ffb7935aa384424d31133934787fd', 16),
+                    gmp_init('0xc21dafe3cc3b5f1b468d2fee75044110085859497846a71341087bca65ffe19e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfc8fcab830f0dd792a579ae6f8f3852e5d5dc62c2d2a776d278a3a9a66459050', 16),
+                    gmp_init('0x98bea0a56139b05391f872919170f85364501ae5dd051e5216b15472cdda6621', 16),
+                    gmp_init('0xc3c5f842340f15a2bb2408120a5db3c8ec319b98ff274345cd0b2a5c526476f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf358ff87fcaaf353b62daa0907ea142db26677fe8ede3dae50dc67376d81d12c', 16),
+                    gmp_init('0xec3d5d95d0ef80e131886bddbe6a814e4a8de2c7b846d9c3e904edaa92e2941a', 16),
+                    gmp_init('0xe7edef74ca7fcfe256b663f2d5e900f0c5b9981fed910b268e11ab34c3d54efe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe3167deedcd3a51ec61ed68316f80e477e8055ba4e6748231fe3e00fb4f22644', 16),
+                    gmp_init('0xa8c400f3c39eb7941582802718b4dca5bc980c7d8ec8af7a1fab81aa76240bcd', 16),
+                    gmp_init('0x6ee396116468d0359d9e5d38383b92ccb51cee575037df7efa681f99548efaae', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa46b53addca4d640accf703604961a2453c4d54ccaed0ba6fd8730f31c9c0bb9', 16),
+                    gmp_init('0x61c55a20baf66649ad049adc84c1526925f83b338fbf5d6e789a79afae94c245', 16),
+                    gmp_init('0x429220324af920b81e592f31dd0d782b850233acae3da4680c46d901d58c7a73', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc5643f3d130674f26e4a56dba4ecb6b53a96092b1e850bbd6a98f31c32521992', 16),
+                    gmp_init('0xeaa5ef83475a878872d7c4ffcc93ab73c7c1e8b130572e391856bdeeb3cf317b', 16),
+                    gmp_init('0xfd063e559801e02b154b3b7a44747165b872ec8922c5830fd7ec617a451b28ad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55ab3f82064b9ad811f6ea7443365112ebfd5a00dbaadae05439c4b7cc05a5e2', 16),
+                    gmp_init('0x35db6bea2e0bc81adea0cc1f462b736f5b3a74060380fa7823070daad44e15d', 16),
+                    gmp_init('0x5cdf254fa2f23f7065448e638c0e2f4ea6e368e0c5735b5efa05d8c4a78ef3f3', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xaa88ddd8a356ad175a03b5e09b23ce235a60f0b1f543f447a8721a383e6a55d9', 16),
+                    gmp_init('0x1b082694ea928049a4aeb742eb01f9b6584e5f7d027fd88fe3998ff06805287', 16),
+                    gmp_init('0x17ce0894fa733a444538116b8fdc9dc1b0b8167b1dff6ba8739cb1612f46034f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6fea1067de0e541ab6eb587ad36ea86e936e04999ad46f9f9b0c0a6c56afbf', 16),
+                    gmp_init('0x11092bdd01dc5ceb2ad6ffe233338e5ece10a3843bda6c72f121ea5d9fc498fb', 16),
+                    gmp_init('0xc3c43b38bb33b70a22238b03dfc1d196b521f437101f3bec32fe7e79ed498689', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x85a5fec90bb9e7ecff808a27b44f30a1b539c934c6e347972ca69e76ffe42403', 16),
+                    gmp_init('0xf7a6602c879b513115b9ccb96625290efdc1d1eec0d82eb12e3ae73902d0d7b3', 16),
+                    gmp_init('0xf23ea37bf999814e200a64e371226434f719aa97bf1943fd3a1bb152380ca3e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe48a94019ffbf1f1e4ea0188b09b003a6b4ba056840df7af755197ad4af6356d', 16),
+                    gmp_init('0x88b71ca53cb6e945d3ca87b6c9aeeaa0a0043194630397ba42c30be71b36c7a', 16),
+                    gmp_init('0x8edb921e2f38f321c107e9d628227b0bc6cd506effcdb0ca18c23676843b81d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x68df19db343abbc057f3da239f757f8f17fd0d4d814e63922d918fd737c7420a', 16),
+                    gmp_init('0x35e6b7684f47d18eac2473f09ff92aae13e23ca2eaca9c26dd2591ec23b406dc', 16),
+                    gmp_init('0x343cdaa82021417bdaa73a56905c863714d6b278aba9ac2f5cb1509a685231d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x33ca2be5f07be710d3a83bb29171c5c7c7ae6cbdffa9f63ac5d8008f3b600a7', 16),
+                    gmp_init('0x3af242fd8ca08bca1ba9dfa23cdf5b1fed2338d7392a014db38484589defaf2', 16),
+                    gmp_init('0x36136d144a658822f6b83d5bf78a81fc87797a76139c7e669e3444d1d73c7460', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7ec10a3c36137f5de2d5aafa5533bc093e2e11d68a0da83c0488999de678da05', 16),
+                    gmp_init('0xe2c599b0a058fcfaa946ba8a32bb5656bb91f82acc48a1167ecfcfa9b908147c', 16),
+                    gmp_init('0xe4c494ee5147f7e389dcc1b8e5bfad4fc0e382e718d79c902b3466b40b7c9e6e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x68b50732ff021bbd87e1ca57527c74516b4debe5f85ff02cefb35a9af5142d11', 16),
+                    gmp_init('0x11c5d541e02c6235a71945cefc32b8c9048a6db491301b04eb4ad291e4bedba8', 16),
+                    gmp_init('0xda5fcf51dffe1c152820aa110e16350e4cc22456b696158d65fb76ed389a65b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x126e34470ebdf9687320ce3276afb26a46504a18e66cbad09ae667d62afacb80', 16),
+                    gmp_init('0xff8b4d1ea10e43a6351060a96521f31b364e93990352952a24dcdb6632421914', 16),
+                    gmp_init('0x4671957210c79200de50bd5caac5a89b9c49edecd75d02672360d71e8f9677d8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x733cbb9d63712171934f7182c9c58eff4ae5a1933614db94ea34fca611faced7', 16),
+                    gmp_init('0x1475e2f0b03f8fe6b5803761b0f48674f4f8745f4fdaf529b98c0a70e8944bfc', 16),
+                    gmp_init('0x71cf505ee71977beb6145c390fa03cbe4536c9f20a1be0a89c9430192c923106', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3cbe46111eabfe0c13654f1fab696fc749f1b2a52dc43f417743158d42216c1b', 16),
+                    gmp_init('0x7f54c1f311c85c2d4343717aa0641d928f39c960f9acb985c5fe9a1f100d86fc', 16),
+                    gmp_init('0x79615b0c37676bfa66da7e42ab32c489144e006db6dd3f8026853d746df41bc9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcbf351feaa609f4d4467d9aaf41ed9d3ea33b294642c7c62400c7f05f644f579', 16),
+                    gmp_init('0xcbc58a39a7e57dd658a1eb4a47058e6e27ebfed94b3140eaa265a95ae40cbcb5', 16),
+                    gmp_init('0xb8982c956b73c29d735b1ecfd5e5b57ca7b44a8436ecac6b2d0bd02b21b9b395', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf16692b89e23a22e3c9b10161e19ae46673f7e6055f70138e38f09ed76705518', 16),
+                    gmp_init('0xb5203ee79895b5406f239f9de739b1b58e410c3de8bb2b5f8a6cbf17d97bd274', 16),
+                    gmp_init('0x5d8c9db05e86bd74557233d4c4e790a7eaf03ca04325b49e17e3ab187eec0c29', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x58e4fa148e0cc6a1d3b3b0e6f342b2452d0886494aaeb3bef44cc9f62d35dd2d', 16),
+                    gmp_init('0x7143836e1326e2488bf628e329d13ad170af1c05774f411235197e2a5139f29b', 16),
+                    gmp_init('0xce173f7e906f3553ff4d996052213e26105b8aff34ff129d29a36b3b5748cea1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xed2e7684d2fba4ad7d7bc954b87aed79555c3aec93c420d9aca146ec07c2ed86', 16),
+                    gmp_init('0x3d45e83abf7899632fb65289b3d768e86c423226d3967435a08a13dc27b5ad14', 16),
+                    gmp_init('0x98e3c6922e7a8033b4790585f61fdf36d4c237ec3810dbc2b2fa1d4bfa188272', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x17eb6c27cee1b70d499eb2cc41191972a1e87383660a59cc2aaa705698fb54a1', 16),
+                    gmp_init('0x48453d390b60894433884248d09b8490afbf7adf91ec763de1faa4eb4a74035b', 16),
+                    gmp_init('0xd873a69efb44a54dd5a9ea8ee66eca46616ac57abeae7a5c718cfa9ba03d9009', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4bd4b9e7fb08dfc2ac0564368bf0d995b81fb5fa6bf034c3f2e166e691f3839e', 16),
+                    gmp_init('0x824a3cd8e6ae73c9eba0ca030425a9a78332e729cd10bad37c5a863b741b0e1a', 16),
+                    gmp_init('0x149a717a79b5372bb181e944f6a52ed57e7006ebce610123485440dfdf06f578', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf97e6ffd3e2551ffc9b03b7c34b406cbc28b18084ce0a0760280f2f88c719b5', 16),
+                    gmp_init('0x458d11edf2b2e603bffe643e244709e0cddcb7af4e85ed39eb70d8bc20dd9a7c', 16),
+                    gmp_init('0xc567018891fafaa26314a4ab46881989a1a98249d26c5115dc47734d7eece6dd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb714dd85f24c98f193bd298648007f0270e5e3264a2d5894f2787925b626e4dd', 16),
+                    gmp_init('0xadd2dc472d844cedb573838bd0271a378c99c3f15b61792fd899b5b14127bccd', 16),
+                    gmp_init('0x3d433078c867fba8b288ee4f724da594fba5ee86b3ec57889e029c464af59d77', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd43ff466d74abd82c71e9c510cff2f4c580db291d3f8c893ec46fc135652f0bc', 16),
+                    gmp_init('0x55839f8c5693f06352afa574b7b5ba04add9f1f0df1610aa695aaad4d9f8c5c4', 16),
+                    gmp_init('0x459d31b61a7ce9d07fb2ebeac25c732ebd0ebdd51b867289a54f19cecd4708fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xace2c4ac6e95462f79385ec169aee04a2e5c729d298244b6d19836a0e73f645b', 16),
+                    gmp_init('0x767f7951b60185ce28b5b6f16cae306cf7c621cf9fcc70c36cda3af66cc79e5', 16),
+                    gmp_init('0x6b47a6a82657ea30fe3e54434a47976c15658ba55789d8a14cade652561e6258', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x97fbcfacba7af9a0755f2442fac0c6adb517aa3abc165fc8412ce28aea6d1a39', 16),
+                    gmp_init('0x3b9d8285d227bfb20b0e2fa4c12b52649577532a182a54bd239345be2a05ffd2', 16),
+                    gmp_init('0x513c6740d9897132b36af7ca06e1b3144211d8f96dff27f6956ec62c4b0d5a3e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27edc619171983d84b22a4f9f0c4e14a397463ca39d1c838ba73cd67884b3f83', 16),
+                    gmp_init('0x9ab9fc2b48997a80d467031072ca701d9472ba32bd338a3aefbddbc224a5c775', 16),
+                    gmp_init('0x1946b046a040a272eb8160167b12d66dc91fba7b0e4a41397260bf8c782b661f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc9826a3a5c315a9e311899a42b0fcc61ae00ecfcea5afad3da5b2b00b40a3205', 16),
+                    gmp_init('0xf053f1bd02cc9316082dcba655cd7dabf4f3549b71b845935d39696ed2b3e5d5', 16),
+                    gmp_init('0xb61bc4c5beda1c7c8ce5981735a117e2a64a074b38cb69af1bfb9b9e5bf99945', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d493c1faca854301c89d0e4dce80c2d243d245ce9a3767fa80d66183c64f427', 16),
+                    gmp_init('0xdac193208d1fb4f4e655e257452bfccab906d3c86b53557600cc83b918364cb6', 16),
+                    gmp_init('0xab3b9f9fad72608a10c19f6c77eb211c9910f0e1b0f08d522f39289687f6f9c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc0a8daff1be88cc34341fa7f86559ba7a44bab099ce8bdcba804e89d6a8abb99', 16),
+                    gmp_init('0xf9a31df187fed567de8aa1277889378249690d804a0e232683774bf4f4ba5dc0', 16),
+                    gmp_init('0x9cc23436f667f40a6f611bdf0c4745f91543b7ac7becf41b4eb2eda737a4a4c4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xafaef01d7451a990cbf4a580ba3c635a1b6899b4bce134c688a54ba834133729', 16),
+                    gmp_init('0xe56e3fbe7c2bd9d506693c9ff564aacd6f2ca0fc9b447b719d6e9ad82289aaad', 16),
+                    gmp_init('0xa3c04d39597f9ce5a1484c4749e23205a1f4b59cd1a4cd7a9c3e55316e8ea156', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2a875a9f66a6c9344a16efd7058bcf53bd2435d8a306ff5210ef71b064764ddb', 16),
+                    gmp_init('0x65833f066cddf33c5bb11d194877a8aa7fc1765d1dd6602e450e2191d1ee79b7', 16),
+                    gmp_init('0xc46ebb02776b1ad2861d9c6fbe7b9491c3a31f9e4885392c9a4bcd1b45b83e47', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc8d757eb82fe837272828b1c8aef9ec13236a7c898adf8d3319e447a137317c3', 16),
+                    gmp_init('0xb5d1bce74561e9a940912d7e96ea84c37297e0cf79c1737de51ddbc99f86b3e4', 16),
+                    gmp_init('0xd22a9f32a9d8feefea176ee6e2c6ca0032c3213a04555001b2fc9ed7b9fc737b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6136214914616dbca796a29eea315462e1d172d8111c8385a521c717478ddd3a', 16),
+                    gmp_init('0xe5031bc85d64938e580498e03b0798724acf0e2da662ecd672ca787458868c17', 16),
+                    gmp_init('0x27ff3fd9abbffa90c60d4fe65981a2624670e38753bcd7c7540034336a50fb2a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x4a39968a5cab3d9670752fac141a1ad8cf501da2e5a44aa064ed0b8b9a92725e', 16),
+                    gmp_init('0xa384e51c8e178beee477ed9ab1cbc3abf7bb5c54ac4ddc29ade6193a93f9fddf', 16),
+                    gmp_init('0x4021c3611aa914b12b3ee75ba76877465d91b9f00e0dea10de0aaed38842c410', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfa0eca54e7cba8770a167c5ab7df895afa1dfd4962221ebda71256889922f89b', 16),
+                    gmp_init('0xa692c2936e49b7896dfdd4185c01d615aa9a2bed1e79559de6ef27039f8c43c3', 16),
+                    gmp_init('0xa1952dcedf89d74ec5abf34be4a4656835979459e3f7fb7029aa87ef54c6dcc7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3bd07cbff240146193e2dbd5658b1a74d61d8416d293bb63c1b0707a30a309d5', 16),
+                    gmp_init('0x6f3808234352b773dd0b0b539b41bd8bdb7dc4e1391d3efc6dcbc607a175be17', 16),
+                    gmp_init('0xb4d006d425b7be0a7fce642a66ab9992854b974163f6b8249d0bfc55fd055b04', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe10080428e1d372444c7e733dcbdcb2582d99fdd60d084950eee9437a0f4d28', 16),
+                    gmp_init('0xd0c716e01c008ca7fab2828a18cae574eb33396d2a09f747fd22a5c27c485981', 16),
+                    gmp_init('0xfec668bf2ace3be389970ce6a23c1ad17d7d20a77416211f07299b5118e71677', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe240d73644a3b101f7a1f8ffb7a2012745d9dff26fa4e88a75b7023fde742bdd', 16),
+                    gmp_init('0x764f7edee657c21142b0a841b82953ffae9efb05780c5324edc58240733cfff9', 16),
+                    gmp_init('0xbe758d80e80418df32d92412435d4f670962860dd12719e2fa136322b98ebfd5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x486705a6eb4c62d2634129f5e22c1351fdca9abc3f0f171d2f9fea9068df41e2', 16),
+                    gmp_init('0x41c463a9931ecd437b46343e5eac5612d5de5294700b4eca6857bd7894133214', 16),
+                    gmp_init('0x27498e2904c7a243d165bcb4c121f62c0aaab3ee9ad3b8f612e7ce8ee8848548', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x51c39b1abbf8539fe01caac8cd3f9f4e5f4643fab68ba727de8c5edf2623b67e', 16),
+                    gmp_init('0xc0e8aa097f7ba1c78a0a474e6c203060405b9cb7eee4544a06e72d490cd09687', 16),
+                    gmp_init('0xa4a73ba07fa900544c6ce03d51df2da07b9fd8c9171cec2f95235849e69bdd14', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe46bf4854da55c7519445c5b2c6cde3ec4b37cad805fa35fa28d2505cf2e4f3a', 16),
+                    gmp_init('0x3ae87e59dea46df8ea267c62e6e84a56f374ea13df5bc0eb1cf2895647df5c6d', 16),
+                    gmp_init('0xf8cd9503c6de41f168d9045d3e14ed6c4ff83e2b0593a51a5f5022d8a4bdbcec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91ac781dd6d22d52738ba9a5ce553fceecacf53b0a7c3c52c7458be8186522c9', 16),
+                    gmp_init('0x85976bd052c56a04112b5b044ec7fb29d8eafaf5a959423b528c4d282a3c200f', 16),
+                    gmp_init('0xefbd4d9fc785bdb87673064270533673f161f975189408653d233fa00c7f27fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c79c1b75d9ccb2d897184a7cd2d7c8b73d40c42932d80c642ddde5278eb268f', 16),
+                    gmp_init('0xd16840b679a06de0e489afd92d48d779688591464a1c373f7e053a7fe0946424', 16),
+                    gmp_init('0x223465e989bf8fd9f6bba72c3edb7ac9e204dbfa413696ab37a3068cebf4dcd6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x39fb15f5bb0636ff9338b0dc31f85528d4f20ff00e73295fc348599d68b5e934', 16),
+                    gmp_init('0x6ea9c137aea0f868b77073a346d80b18c35dc25cf168c63355d46d56fa094bef', 16),
+                    gmp_init('0x24501041e5f3b42283091ca6f5c1161eb83d108e71716448feb46cd1b7f886de', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf3d598f5241f678b8a613fdcba5f7e1e1cdd68770f7cb0e0e3cbf408e69dcaef', 16),
+                    gmp_init('0x6f630868522d353fe8d78da766e4594b8fb826a4a6b6aa8ece003c47b1b4c9fb', 16),
+                    gmp_init('0x5fdf933ba344999863c6b5bc3c888faee542e69b3faaea3a298944327eb47b02', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x42843f98b76de0a7779c0521b7a0c6f57d4096dfaa7724ec2080998e0575a861', 16),
+                    gmp_init('0xfd2a5ec7dab8598aa176835ccb8fd3a4ebdf9d42dfeb839364a31b59289c90', 16),
+                    gmp_init('0x9861dbeaa75b50b528193cf12c0574b7832c85ad50a4069268bf4394a83b39fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b9ff8c5fbc6e2de170da67e1a93f58ee145e64b1427e095737ff0442c139219', 16),
+                    gmp_init('0xd9a6441906e5d8bde6017904d121b3f0c3e498220f97420a633b456c3b600414', 16),
+                    gmp_init('0x1ec14e545ea9b68eafb545216b844ac5d57dc63037b3363510c834f632e632bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf623de556ecf8391cbe3cb97673c1013cd1d5bc9fc2ca3506c8a631b0f0ab8f', 16),
+                    gmp_init('0x5c76bb32d237965d2d160ba8967a5f4d839975eb45ef716292442b047dc86f70', 16),
+                    gmp_init('0x409185a91f1bbfef02554e1e4d6858c58a0c1f0e8e4ae3bce4b208aaf09046cb', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x1d3aacff4ac09e29655404d1bb620fca5166ea726242613f6362b945205d17e1', 16),
+                    gmp_init('0x29ea9d02860c6e311d4cd188bcf43c3b81c27bc927ef7e506efa2407b4c9d821', 16),
+                    gmp_init('0xb5b4860c9e3737f2657140deddb0a61e56f6ab6193a3efe659a4301e0f0e9aef', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2abb0a9853534d2838c3cbd6e4d0bbbd6c3249306e4c94c3f1ffe20a1b28515b', 16),
+                    gmp_init('0xf13895c60cd41fe46b4fce11d3697c672c1c388934c530dd01cdb1653116917e', 16),
+                    gmp_init('0x746628c1cc313bfed7087e54c08aeb532436525da4183ec39761f145a0cf77ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x995932634b7f179d03c54a3e6e1dd49bb3db5e4f62f55c34ce26ccebff70ef87', 16),
+                    gmp_init('0x5abd3f6ac11561da803930f997cf4af6666742c9782eae3d45e6987aa50812ca', 16),
+                    gmp_init('0x5c35ac7a82d2707a4dfe351f2e75ff9e07c74daad76b909365621e263e836790', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x681f6d3611654448d08f77b976019870ef0e3de5c2fecf2d66d2209db69f23f0', 16),
+                    gmp_init('0x49fa510f49b19811336a967cc2f82f84b896e7594f27ddf71e1105f08056e96c', 16),
+                    gmp_init('0xb3ec2bab40dbe7d840e17308f403d6e26105eabc485b7bf3d8b2ca6108d006ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x68375290d14410ce36f4963e0bfd0aa368f4080642169030b1a136ba74b73348', 16),
+                    gmp_init('0xbb76fea47f09af78391d6b3cc43469aa7daac0663939f8fa36f2a715548251bd', 16),
+                    gmp_init('0x5b8dfd8469e012ceeec1a16e7dcbe8182d45e519022375d1f278884715cbc70e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3e50b2435712492290ef962e965f824e95110f43f0ea81853fba66c41a2fe903', 16),
+                    gmp_init('0xaaef09b90688aad3edcbbf8ffa4e8050b4341624eabc5070d7022c4d946c7e09', 16),
+                    gmp_init('0x58936bb9df6023b2af56aa3f319ef73d4d8d1b3bce62323810c6af1fd8fc3456', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6202ea50eec1a9443777f6f95915a51eb0383d72925a99f0843ef0e6e7575b0a', 16),
+                    gmp_init('0xe7011342daa1ba7f93f6673268d170374dc5415363cea435ea6c4f9e99a70d9', 16),
+                    gmp_init('0x75e08aabaf4770c5da5d6e218e07d225c6977866be4e14ebcf4aee6639a7d271', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c30196df4c780a5d5c14c221ab5f47f44b87d5611f0e126c7d16e9548d9287b', 16),
+                    gmp_init('0x65630d0708e6f78b0d73392f2de3c67d6d611b37809801ec887dad190d94f78d', 16),
+                    gmp_init('0xfeb8371906c62472d949404698d4ed1572acc62b5359cff37450c2f55d6b4100', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2934898f32dd151fdcb07e943c262aaacc281e3a9ee65216b9d74e96939352be', 16),
+                    gmp_init('0x856478e47cf79aa9c6d5b1700f5587878bf885b7d7c40d367637b8fef28373f1', 16),
+                    gmp_init('0xd493fdac09dd76139ae385c51a58606875c61606dd0b86aabc1103dbe1519823', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd296e5b43b056341b8a4208c91db53064d7f79b17dbcf3d8351a06f9cfacb80a', 16),
+                    gmp_init('0x16e86f5ba501e3b770ea6789d8434e851b54d55edeb3fa9cffb222bf42ae2374', 16),
+                    gmp_init('0xbd41ac199641a8810595d981f60ebf741fa5eeeee7796a4a318460d0386b3c00', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdadedfd567eb9025727874b4d05a54480ddf70b115cd8dba9cf099a807508633', 16),
+                    gmp_init('0xb5d3ec31ad24a03e0c729ffcef38b363415c066583c942e4a93a836dd4040644', 16),
+                    gmp_init('0x8dd2dd48200f523c0f1151b6909cae69d8469ff3b2b913d614bd0641a579e8c7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x21b639afd6c2b6137c89be26a681ce0b9f2d07b423eb42818818ff4f7a81513c', 16),
+                    gmp_init('0x895a8fffc6ab1aeea408daaacb47c9b444822546024db92aae6fcb803d76cf0c', 16),
+                    gmp_init('0xb36a4c22207c16a9eed186e4bc518e39efa32e18491695aaff11879b7ef0a900', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5bfe89864d57cd971a1c2cd1f1725fbf149f3469c4373104b2d7ceb0c61a52a8', 16),
+                    gmp_init('0x70180d85271a4095d7fef610c8a36fee7d792f882e6bbcaf7ff42018813192aa', 16),
+                    gmp_init('0xeacc09a7240c10bb91b48a4207add33b7e5716792d3cd6b37c566328c1ebd70b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x36265fcaa8e67a92125e1471355b479cc9a0e8b8071c1f980f6206e3809f3f94', 16),
+                    gmp_init('0xffda6d95f5e4ca80d1255f4d038f0ac34ded5a447723c896b3c69d27447dbe9d', 16),
+                    gmp_init('0x1ff199abd2226006e9de8767e90bd1c26759caf8c9a21fe2d1ebc37775a998f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9577bc4194165f36f76feb10ac6d65e55d87e8de6adc4a18318d78ec4655c3d5', 16),
+                    gmp_init('0x1c061a86e652b5e003a186c9ba8e510c48c3c94d81edf63f34af2f0b984c27d7', 16),
+                    gmp_init('0x9212474eba14bfefa541495a7fc2339b0b63740fc55cbf225f35e87f3598453a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc519b33f84ee52a5dad3a917a8f0d97ca58a0cea04ab860f4ac223aaff05c20c', 16),
+                    gmp_init('0x6ce7ff2466abab56ec20b054a6f96d8fa11dda4b5b50be320fd045d0fb0e0f8c', 16),
+                    gmp_init('0xdfd1809eda09f7d03694836a3406c2bde1ced49a198746a1b67119adacc8f5db', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4a0dcf06d525c1fec669f4d40f1ff8cd857ca5e1b57b831f3fa1b6c2e50da819', 16),
+                    gmp_init('0xd24d5e836a8b789fab4517fee0627e66aa7af2d94f7809bb7e28e82ec2e660a', 16),
+                    gmp_init('0x9f8d9ee03a2d3b5a87a46f84ebfd16e17e649d5c7da15bc5717c73082da875f9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e9fd888ba4749128e337b7aedbbdb4935909351a9acac4241b58e7a916a03e0', 16),
+                    gmp_init('0x672b24357e83ed19e3cd4772153ee4ca5125dbe2e15dc4b8d1a284d85df3acb', 16),
+                    gmp_init('0xada94f204d504c33a1ccca6a5bfbde69f6015f1758244a453b73fe04a26773f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5060e55a21d5e1f4ef17a10f98672012ae5dbdb2b8b923a8e558936679928655', 16),
+                    gmp_init('0xbd3dc79b022a182af30518881cf2ccf047f16f701d85e41e5851bdc86fe558ea', 16),
+                    gmp_init('0xfa2ee109faf5d32cadada8110eeaff8c3539f227c9a93b78eb1a9c294d0892c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb63624e51ccc9fe55ddef2ff295d0fa3c875fd7bbc79fe8a08a03b6811d3bb20', 16),
+                    gmp_init('0x93da91f16db6b26f6a7e41e8ebfa7594ea97ef4cc6c4f060f1942ed0afb4292a', 16),
+                    gmp_init('0x236a3e0c46355c51e0ec14acb2cc6a41087c911962f4897d6dce4b93b0c41851', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa0b1f96d6a95824fba70b1dada58cf077883d6a9004a1f06a284a52d2694f14c', 16),
+                    gmp_init('0x4b98ba271062b3e8ddbcc9007f69701e5be9fbef6c554d3df4c3cb42a00f7b19', 16),
+                    gmp_init('0x9fbb71bbc695b08a80e2d4ed0a6dbbd2cb4287f379850e21eb08eae99fe24d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x11a8e019e296199f420af4d2e4ca51cf623ea74713c6e8f8263362eda2d7021', 16),
+                    gmp_init('0x7ad2b544fd43411d88b88cd70b6caee94d26b9eab9794bbfe356e019d322c37b', 16),
+                    gmp_init('0xecc85524ee0da6e79cc82515adc4f5b517b718f749c2f875b937beb5d2bea400', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3cc9ac925f6360b7ad1ba4a46de1bc865283e2b4fcb1d73598fd7b31471a390', 16),
+                    gmp_init('0x52fa8da62e8e32cfccec4158c665d5dec66556a78587f17e73f0718d0a50a950', 16),
+                    gmp_init('0x5fda4d17ca9d1bbe6265ff2034fccabf2fcfefab0eb46dbcba9dbab3a403d416', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6dedb5c79731db32f5ef3f691922d86256cc093665e6c45d5dfb8c4faebfcefc', 16),
+                    gmp_init('0x62f0ab8ef52c1159c25460fa59283cfa4d04f577eacb55556466b2c446256ea8', 16),
+                    gmp_init('0xe847bfe1ba9fbc8eae65ee8b359a7ca6ce5eccf2fec60d4f0d830659396fe0fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9849e4edecd90cd8dfd053b42cc5fbe1e55ef2726d0c7fd615fdd5239c435ea3', 16),
+                    gmp_init('0x30ce7d0bb569607d32404f7e008a1ceb29ad72ed6bc95669e672027f0be4d050', 16),
+                    gmp_init('0xd42335285a499651f53227fac1971d5c26deebb9b4d6e14c5440d1388498f900', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x635c5e1320f38e7fc071c43d481d624438e455af89f2b97ee8082bff0a2f8633', 16),
+                    gmp_init('0x280174d8119ba3007fe0f9ac9a837084dfcc7e6afb7e53eda781fdf9fb0b3f6b', 16),
+                    gmp_init('0x52e0eafea7a6e4f4da756850544d1de4e813dfc83406b55e8ce7be27eac27957', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x949de70bd473f5787ec367609c8f0a3d311f10e37d410de5d1bcbd16a475b092', 16),
+                    gmp_init('0xdd9a7f356e21eb99efb4ca55e3c82985a5445e7fc597b280b97283ff90f32357', 16),
+                    gmp_init('0xe1cae78846ea63312fc04f7e6b4ef8da96e861ffe2b68e883897e31b3d00858b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce5c9e0d8c5c8e0112d14c62482d8c34c68ad5072b84ab99bb62b879f8afc57c', 16),
+                    gmp_init('0x7a7fb6605838c86fca18408cc827fcad64354569e0452c34b342d38ceb78c36f', 16),
+                    gmp_init('0xf34ff126650f5dcba2966edd46a2e9ed9ad88072a464b4dcf91d6785148ed5d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9006158fb1bfa5a3ce1edcc0a6138df391a9aaa134fb0b7c1d5c06198d6a1fb0', 16),
+                    gmp_init('0x67de01266b69980a0c76c1c7e22249bf935cfd1703955df8b85d3e5c842c4a55', 16),
+                    gmp_init('0x931719de0431e3c34c4db4708820eabf3108c975ec52af940b2c8b28bc6dd762', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x20fd55bbc2e3cc478171f4800f8024cba642f55a6470b293dd5f3a7260661725', 16),
+                    gmp_init('0x38a60ce469dd6bb3909310aa3fbac5b1506825e64e9e289ed2b2e49798a745e1', 16),
+                    gmp_init('0x7b9c4ce3e15763ea92025db568230d95446e278bf8fbef311b01146e5fd7d081', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8a7def1026fc843cdf910a4f05bbeb20972ffa6bc1926abca1796eac25b4d328', 16),
+                    gmp_init('0x7353136983420bebe5c419b8deb8c0023e2979a2d8c712ed6f5ad9ef41690f2f', 16),
+                    gmp_init('0x3f71a6f8f0cf645e6c84731b5520ea07edf47ebe6042581d064238e2c0f87c3a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc9599cd32585810b246c5cd81331bb90eb9f2917e204c1e2e2e6739f075c4888', 16),
+                    gmp_init('0xd2f993d9002426f54b029657c6a956d9a083667eac937e3ff32fc42d1c95c082', 16),
+                    gmp_init('0x8f496e9ad55f1f4035440b3e668552b997c5f8685d4255cd729f4f005798b97a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3b7c4884e483db87568711ed6301d8503efd21e5523830683e2ca724ed1bc042', 16),
+                    gmp_init('0xa9eb6f0f01dc93845c3d6782677c7d31eea18e1df66f5483cfde41c1548581da', 16),
+                    gmp_init('0x939e5a8af9f9291d54c138fb5ae77593d421ce5c571cac64711db668b5cc587d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd0e2d0cae66a66af2d5762859e1bcaaf9b8d74c9b736029c9f0bff52376636c2', 16),
+                    gmp_init('0xd3c5868e2a4a939c4f6c6c364f720fd77b2fb939056d5f771aeefbc293d49f6', 16),
+                    gmp_init('0x7001db3435e658cb20d9e865d401e1e11e02662f99fdd6c8d13d724dac5d1790', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x15bbdb3ca580181d1438ffc2b87e82a32db0b7fd4c4bc2695dc314a6a43752bf', 16),
+                    gmp_init('0x9072b7814e1b4350cd7ea294a6827dd136a9abf73b3dcd14cdacfe0fe31bd4b6', 16),
+                    gmp_init('0xec1c1739bc7bade39796bac93c5a75b94118f88eca417ba5ce769562b045248e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe27d29868eda75e47e296fd5db5457c059700f910553ad6316854acd6109c02e', 16),
+                    gmp_init('0x2bfc2df5ea054c9d84bb38b5527c3964fb51a907f2d963f393bf2ee149b45b5', 16),
+                    gmp_init('0x405a16ade26ef7186396a8a40ff763fd3d506f9ace2b6a1faa05cfff80454f07', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xee426e3a1686894a1c8526970838a7e41b7a72dd858e404ac6302c1982e6f910', 16),
+                    gmp_init('0x8753aafce3cce85cc726b248780ff7f7a1575ff7eded821fd47cb00c81c936f1', 16),
+                    gmp_init('0x5c38e0483c477238ba88a7c9788379100b598754381a795e8a1ba5dbfa558ebe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x32116533e5b1ba7fdeebc135c7c24befc9394f65d85058c0eaff3a1788e1fbcd', 16),
+                    gmp_init('0x9ef7aebdbb7df5c9144ab866d4fea8a70ddefc203bac6194e549346905254795', 16),
+                    gmp_init('0x22e3e1c7e217adbe24da80fef0f03cb6098acbd36da12636badde359c5025f45', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x71f2949cc7fa710e015c74dda474d892e3b87259a1b08f00e77c0f61394a013a', 16),
+                    gmp_init('0xea22c4755b9e36762a599bfabb7442c1af5e90336b199b8dac86cbd746d477eb', 16),
+                    gmp_init('0x66dd5c6ed25e51c2ecfb98315ced558e908e9cb45f5d5f90113323da65d23124', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc7a06fcc367b51c4532798259f8de94dbecaae58a1faaaf11cb14347ed9108cd', 16),
+                    gmp_init('0x76b52c12aef138b1ba52d1114b69a5517c8ee6bd12a0f4027a3b60644871700c', 16),
+                    gmp_init('0x8573255df37eeb5a92683cf8574b1d59dac67d4c0a64b2e60ae036e1a4c13649', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe200c47ef8787fc0918d03ce7247f1ad8c662ad681eeb3f5ca31e1d906cc1303', 16),
+                    gmp_init('0xff2333cd971f0e6e4912b7e05d7c96ce8d86f6d4a57304bf8da7e95eea09a0d', 16),
+                    gmp_init('0x5dc066619fa6bdbbee7c9ce7bbc8776895b93a99945bdb901b9471519f97c6b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3b8b3c3cb387e529c36b6738a4d5b7ebd5b848e58dd5456133256974f37f5c89', 16),
+                    gmp_init('0x9da9f9146149b8059ea5c2a188525439581318a9fde4e693f7ba5f22caf25b06', 16),
+                    gmp_init('0xcae6bf6ce62b3728af5c5e06f292a93e18ba0cdff45975087c441252e750b3d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x37d9213e2172b296d114e941818cc7d978d4e460635b16d40e3e43df6670de86', 16),
+                    gmp_init('0xb25a6662a5962ea8413385b95ffa293c703ee8058587e03576acddbdd229d080', 16),
+                    gmp_init('0x680de006ff4ba17b2da12223313147ff2c3e9b5e95e076ac6d97d5d963a78a9f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2dc09f72bb6862214ba229e9928525c917b13405aace2a1d7f83f5a19c7817ef', 16),
+                    gmp_init('0xcf9df8cad1013ae595beff7ebac1682b15b3b22d213e53074939a9c7688ce89f', 16),
+                    gmp_init('0x8278c0532e94114e52e88aafedcebce9632d9bb1e45eedf93b22138943678296', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb8c0769661b806088677a98783503122ba45e98f6b6d3009b85d077840c56208', 16),
+                    gmp_init('0x3cfaad80634de830a7b3e87f6c15e6b249586ad275ed7d5ae7433af2331244db', 16),
+                    gmp_init('0x9d5bdf758dd113733bcee8064758608bdad5953347fe738bd8b660b6d25f45e7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x9d3742cbc13021f841cfd81d20f68bdf47b78ac74eb742ba6620c494c692589a', 16),
+                    gmp_init('0xc096e369327bd3d1f006ce09bbdbfe31a052189e8269c4783d2151872bf84dbc', 16),
+                    gmp_init('0xcbba0daaea3c34e6b63fbccafe965bee3adf1b82316b581e1d739aec915b23b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc85a5da13c4cb8ddb3afe3719b5781ac05ce1a33118a6025fedfd99a98edcd79', 16),
+                    gmp_init('0x4b33b89966ea849c6e2855dd0158f44240a924b7bc0b0fc6327efee96beb558c', 16),
+                    gmp_init('0xda2ccd59a537fdcb4a18b0f119dee49406378a44a3048b9980b26ca304f2ca3a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7505826c05be28dd97a8a56517f6fe5075114b39e7fe570db78afe33f9046eda', 16),
+                    gmp_init('0xcf8c8fd54620c9d53357128f595e30f6a6f1a4d74e1c05ff2639b0026c28435', 16),
+                    gmp_init('0x62824083b620f09b7fab260d2d489b956556f15927fedce0e7009d83492a34d6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb3188c80f04a340945e7ed1903fbd3a5be2f972236b827b2df342b9c9488c399', 16),
+                    gmp_init('0xc68733b9e44f4d4381e61becc3d3117308b947285885876da4d41364349b48c0', 16),
+                    gmp_init('0x66a9735663ff8526f93a0b6b347a6212bcaf02ab1994d6eae4f3d777b1e2c95e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc4c0ed898a069236de5169f7ea76f7e2290b289f2234b6d07052ff4777d2ec', 16),
+                    gmp_init('0x6fd050c5af474270b5ff688149d7c284f657fbefaea409b5bac5e6ee2cecd27f', 16),
+                    gmp_init('0x919053207ed6fe8ebaf540b130d00af09fb0464e803a834d9a31b18af78e737a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca569dca69d3e922ae9443fb746a5ef10b35887c42ff343f7db960dcff5092b0', 16),
+                    gmp_init('0x9b4c35d289c6187aca8ecf45ea512b1df5aa1c4ac14e195c95c8f8e7f7aed94d', 16),
+                    gmp_init('0xba64d0c6c19faed55b7888ce1c252bb47edd97370275146b2b11373ae46e6b08', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4e83ea14af0410bf68a5e3229f7e7db678da0f395cd57a889bbc8f4ded4341f3', 16),
+                    gmp_init('0xc383038c3cdc90dc56e58ad482b566bc732b9622c64d947f84954a3f653eea77', 16),
+                    gmp_init('0xda316d4090f6c91c90f7b1176f328be7b727d9032ce094b68c868694b3d80d48', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcfe754065e98ea986faaef1c862eb029bde319bac7a4017089a4ef7fa3397ac7', 16),
+                    gmp_init('0xfaf8137f7fd7c8d8b2158fb3d5a86223a0190862b6bd52334137413cf869c46a', 16),
+                    gmp_init('0x81463f8c6e223de5e75e41a6e849d2b693a0aa942c121c6fc5bccb58110bccb5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xed1a9c7ca8f97819cf0875ddd4f09dab65bc067a18ab2d8bedad632b42d5a687', 16),
+                    gmp_init('0x8f6643c6b15d54d9b6442a0163b968c8fb2bc264923d79e24bba1b588ea67e1', 16),
+                    gmp_init('0x15f051e70783818d33fa5063908fc328638872ae8ca10f09ef1663d663c6b090', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55e19955bf58a49f42ff5635fd14d77ef1349cb13cc476376f0933aebe7ff4d2', 16),
+                    gmp_init('0x8cda3dbd6370f0a6b784ffc65dcc5d32304ce93f2a1b457d92922d6b4157e688', 16),
+                    gmp_init('0xe6226b1abfca694ec43d9a64e5b774589aa07518bafce23dd9c4bbaa7b386c55', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9660ee10270f2b7f9472ee83f02d7b6c1cf87f3b22fb51a298fa85f37eddefc7', 16),
+                    gmp_init('0xcf28fe75f907168260e9c70b5c0a6a5be1bd72aad3044f044888b6d977e34de8', 16),
+                    gmp_init('0x4f15664f898c82220509edcd80dbfbd03f7ffff0890cb6fdcba8ae938eba681b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x47e1829b36024c85a8ad1289b2f5d3966c526fd9a2fe1556c1a3bab99cda48cc', 16),
+                    gmp_init('0x98dc04a247d9d622ba4187c7e61d4b09b5ec1e99084c951089893b8ce085fd48', 16),
+                    gmp_init('0x2bb6cb4f8acbeadcf68778d8b5c34ab59c029c786dbe93e89f364fa7789a820c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1a300ec1813f4a2a67dbfa32f892a434ea0760b6d28f071ea6fdd33f84fa38d', 16),
+                    gmp_init('0x359225eaac310874827dbbf1d0920213b831664cc05241f16fff18b7f66046fb', 16),
+                    gmp_init('0xe23bdb220d21b36596d5e0e05b78f4e80f913e38734ce7f55b4f533b903ef70', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6cd6e43409e6d0bb4bccd58dbb83e97382351347c54a63a5e1c840dc1b891ba7', 16),
+                    gmp_init('0x10195dfc9fe3f3035f2b554f3e580568a02fe20115bc5d8a810904c5dba653ff', 16),
+                    gmp_init('0xaec37614b0c2290a4596ab9412293ddf0ce221c3677a31b44fe85d3b40486672', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xea9c12638ecf981ea3def022fd997b11f2af164b7f3de08ad7cbfa1b04a11231', 16),
+                    gmp_init('0x1d1a8185b12e131ed1c12242cd53eb27cba22450efbbcc7b616f2de0573a216b', 16),
+                    gmp_init('0x88557af8fcda0236a997592e8163b041aec15a2f84a7fb85b0b7f863b254d0f8', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa6ad3522291ed5c912181e94d0bb67b1027b733a8490670222bc370cd97db5ff', 16),
+                    gmp_init('0xb1838583459d2f3e2177b92a10480011a58d404ee85357fee0156c56dfb6cce', 16),
+                    gmp_init('0xf237ccbcaa497935113c566104e8e6a82fdedd6afddcd770d7132731613ad63d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x493e0864407344d0dc2329f61fa916784e3ecec73c044ce58cc3773cbc229730', 16),
+                    gmp_init('0x28f953119b34ae7bdd46905b7cfb6e5b78faf81916ef241c65805b673e307296', 16),
+                    gmp_init('0xea13e0e05c07850bd2590d42f815b8a92b7320b9f63c74539c1f0f004a4c2f15', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd8a83a989f8118c1a4478fb63249313e56e6611334807a6e598a4efae1aad032', 16),
+                    gmp_init('0x4957224a6a29620195336e6f319ca1fc61c363ccc53afef2ad945c3ad729b1ec', 16),
+                    gmp_init('0x39a7ed35ff435cb9f2255be781ab87e76053f9a25df3e791cca220cf372ba6d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4d7525af7e3b76088268e8e63a91465ea23a3eee68333ee54ec1b6458a0e1b71', 16),
+                    gmp_init('0x5bcca2275464087f53d93535078dd6768bd93c9861a0ab479f22d43024cd0485', 16),
+                    gmp_init('0xa280894518507c180bc0bcd0c5463eca7b4f42f31eebd27a9742ba9531e07721', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb09116c47b916009c509f5e2162397ac32201854b700c401c31c14973e1cc401', 16),
+                    gmp_init('0xbe27c70983f417912fbf14026034f8767166adc3eb0a476b26fdaf83a1ef63c4', 16),
+                    gmp_init('0x2f219c72912f0abc7e0769ca20900469537dfab4ed4daed6333dabd720db9f05', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x75cc379c0e2b6250376c27978cdb0f9334d9c2ed1763f69d2056783d9c8fa099', 16),
+                    gmp_init('0xecdec5f2c460f427a0e9960a57de6e1415f105e2573adb54ec830ed3e4bbd49', 16),
+                    gmp_init('0x1b314b22282e061585e7125b09c8be6cfb3276dce7dbaff120a9126239a2a1eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6959ddf1619810366d976194049c8172294b0c6889f703264f3c642269b07602', 16),
+                    gmp_init('0xaa6674a539de7e0d0223ed41262ddafd8893ff59904234d67f7adc0757942441', 16),
+                    gmp_init('0x81ec371a7315f17b67168b03a4e4cc35d66f651fdf3c039fccb7955410337837', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x273a5e229e38f023c47bb9df5376498e4d550259ee75822cb4f5f70e673c78b9', 16),
+                    gmp_init('0xfce6745ff85ff6c0dad16bd062a0f9d221ddcb60686c4f2bcb12675b0a999e92', 16),
+                    gmp_init('0x63045c9a836c70df4497b26e58ef80babc9b126cb917b19307c5ac1f4b4c39e4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x957fd0406f40f21986447b42feb10c26c1d0a662ad00445deb0fb4f18a058f52', 16),
+                    gmp_init('0xb862bc6cb4066662d0accb06c66527720a7e784ac75827531462ad17edea56fd', 16),
+                    gmp_init('0x8968f23593655023d8cab178aa0418f52755137357248e212872176d3ebce635', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd5376d781047cd31b6999c9be24741ef4309211cb9d0f6ff6cab0d26cba2a732', 16),
+                    gmp_init('0x5b60ddae29596421126590c05ffaf42f8fb2f2e5b353dbe37c2b8b201f4a3cc1', 16),
+                    gmp_init('0x173c69066bc03f9c498817632cea8512d85ef5e40d0d6aebf04ff721e782d483', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3a995da29819f0fd270fc4862e3c8832a80ff1716d028598af7ac5469e0a9407', 16),
+                    gmp_init('0x4ccae07f80dc6b876e9fda8062e4640e9f022e84a59d4348ede7013b15d121e3', 16),
+                    gmp_init('0x9bf12757de2ea88c2101cd7ed36b70a980ae39dd9a94574c2372e0fcbb474578', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe928fc00db9abaf43f867675164ae7db0cd470bcc0cab7cb4b79a2e2766b5152', 16),
+                    gmp_init('0xd943c33b4199d90100657d385339322be47134f314ad52e844688ac5bf2b3ec7', 16),
+                    gmp_init('0x607e0067bd1db1a0513d0ed7a69ce3d7f20adfd51ac335dc8e8aaf7e6e02e4dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7bd0a19ff0b1ff05f6816183ad1474fbf11b1a97c30124354195ad54ac430d1d', 16),
+                    gmp_init('0xedcaf461e53ccbd0db4cfaac00ac5599d11f360d867a5f5cd11a975739b9dede', 16),
+                    gmp_init('0xd8779cd4039c5671b083457b2d2ec37af4b716381a77c3488f381df659877c14', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xad8045b6070bc11bbedb63d391be489c6766629a459f4aef2bd64599ae9346bc', 16),
+                    gmp_init('0xe1cdbe5db6039b888da698f9c84edc7bfaf0d86cb33ac01fad9f127cbfd6a8b3', 16),
+                    gmp_init('0xe66bf9120d23aff49ce43bff310bdf05590f890920cedea207d63357993aea8d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdb965e046765947990f728ab2f103f781378904a0d0e5d862a30de7df38db573', 16),
+                    gmp_init('0xa848108d14689e9c45739f281d9e992335d2f8c33836edaa33d395507995c810', 16),
+                    gmp_init('0x88d76c8daec8e42bea61c67812dc4a042ac9887f432b67a689fe814c4b5bd5ab', 16)
+                ),
+            ],
+        ];
+    }
+}

--- a/src/Optimized/P384.php
+++ b/src/Optimized/P384.php
@@ -58,7 +58,7 @@ class P384 implements OptimizedCurveOpsInterface
         $this->p = $p;
 
         /** @var GMP $order */
-        $order   =  gmp_init('0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973', 16);
+        $order   =  gmp_init('39402006196394479212279040100143613805079739270465446667946905279627659399113263569398956308152294913554433653942643');
         $this->order = $order;
 
         /** @var GMP $b */
@@ -157,10 +157,16 @@ class P384 implements OptimizedCurveOpsInterface
         return $this->toBasicPoint($doubled);
     }
 
+    /**
+     * Computes the reciprocal of the group order
+     *
+     * @param GMP $scalar
+     * @return GMP
+     */
     public function modInverse(GMP $scalar): GMP
     {
         // For now, we'll just use ConstantTimeMath.
-        return $this->ctMath->inverseMod($scalar, $this->p);
+        return $this->ctMath->inverseMod($scalar, $this->order);
     }
 
     /**

--- a/src/Optimized/P384.php
+++ b/src/Optimized/P384.php
@@ -4,6 +4,7 @@ namespace Mdanter\Ecc\Optimized;
 
 use GMP;
 use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\Curves\NamedCurveFp;
 use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Optimized\Common\{BarretReductionTrait, JacobiPoint, ShortWeierstrassTrait, TableTrait};
@@ -49,9 +50,13 @@ class P384 implements OptimizedCurveOpsInterface
     /** @var ConstantTimeMath $ctMath */
     protected $ctMath;
 
+    /** @var NamedCurveFp $curveByName */
+    protected $curveByName;
+
     public function __construct()
     {
         $this->ctMath = new ConstantTimeMath();
+        $this->curveByName = CurveFactory::getCurveByName(NistCurve::NAME_P384);
 
         /** @var GMP $p */
         $p       = gmp_init('0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff', 16);
@@ -217,7 +222,7 @@ class P384 implements OptimizedCurveOpsInterface
         $q = $this->jacobiToAffine($p);
         return new Point(
             new ConstantTimeMath(),
-            CurveFactory::getCurveByName(NistCurve::NAME_P384),
+            $this->curveByName,
             $q->x,
             $q->y,
             clone $this->order

--- a/src/Optimized/P384.php
+++ b/src/Optimized/P384.php
@@ -1,0 +1,322 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized;
+
+use GMP;
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\Curves\NistCurve;
+use Mdanter\Ecc\Math\ConstantTimeMath;
+use Mdanter\Ecc\Optimized\Common\{BarretReductionTrait, JacobiPoint, ShortWeierstrassTrait, TableTrait};
+use Mdanter\Ecc\Primitives\Point;
+use Mdanter\Ecc\Primitives\PointInterface;
+
+class P384 implements OptimizedCurveOpsInterface
+{
+    use BarretReductionTrait;
+    use ShortWeierstrassTrait;
+    use TableTrait;
+
+    /** @var int $N */
+    protected static $N = 384;
+
+    /** @var int $size */
+    protected static $size = 48;
+
+    /**
+     * @var GMP $b
+     */
+    protected $b;
+
+    /**
+     * @var GMP $b
+     */
+    protected $p;
+
+    /**
+     * @var GMP $order
+     */
+    protected $order;
+
+    /**
+     * @var JacobiPoint[][]
+     */
+    protected static $genTable = [];
+
+    /**
+     * @var GMP
+     */
+    protected $R;
+
+    /** @var ConstantTimeMath $ctMath */
+    protected $ctMath;
+
+    public function __construct()
+    {
+        $this->ctMath = new ConstantTimeMath();
+
+        /** @var GMP $p */
+        $p       = gmp_init('0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff', 16);
+        $this->p = $p;
+
+        /** @var GMP $order */
+        $order   =  gmp_init('0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973', 16);
+        $this->order = $order;
+
+        /** @var GMP $b */
+        $b       =  gmp_init('0xb3312fa7e23ee7e4988e056be3f82d19181d9c6efe8141120314088f5013875ac656398d8a2ed19d2a85c8edd3ec2aef', 16);
+        $this->b = $b;
+
+        /** @var GMP $R */
+        $R       = gmp_init('0x1000000000000000000000000000000000000000000000000000000000000000100000000ffffffffffffffff00000001', 16);
+        $this->R = $R;
+
+        if (empty(self::$genTable)) {
+            self::$genTable = $this->generatorTable();
+        }
+    }
+
+    public function scalarMult(GMP $scalar, PointInterface $point): PointInterface
+    {
+        // Initialize a 256-bit table
+        $q = $this->projectPoint($point);
+        $table = $this->makeTable($q);
+        [$bytes, ] = $this->ctMath->normalizeLengths($scalar, $this->p);
+
+        $p = $this->newPoint();
+        for ($i = 0; $i < 48; ++$i) {
+            // chr to int without side-channels:
+            $byte = unpack('C', $bytes[$i])[1];
+            if ($i != 0) {
+                $p = $this->doubleInternal($p);
+                $p = $this->doubleInternal($p);
+                $p = $this->doubleInternal($p);
+                $p = $this->doubleInternal($p);
+            }
+            $windowValue = $byte >> 4;
+            $t = $this->tableSelect($table, $windowValue);
+            $p = $this->addInternal($p, $t);
+
+            $p = $this->doubleInternal($p);
+            $p = $this->doubleInternal($p);
+            $p = $this->doubleInternal($p);
+            $p = $this->doubleInternal($p);
+
+            $windowValue = $byte & 0b1111;
+            $t = $this->tableSelect($table, $windowValue);
+            $p = $this->addInternal($p, $t);
+        }
+        return $this->toBasicPoint($p);
+    }
+
+    public function scalarMultBase(GMP $scalar): PointInterface
+    {
+        if (empty(self::$genTable)) {
+            self::$genTable = $this->generatorTable();
+        }
+        $tables = array_values(self::$genTable);
+        [$bytes, ] = $this->ctMath->normalizeLengths($scalar, $this->p);
+
+        $p = $this->newPoint();
+        $tableIndex = count(self::$genTable) - 1;
+        for ($i = 0; $i < 48; ++$i) {
+            // chr to int without side-channels:
+            $byte = unpack('C', $bytes[$i])[1];
+            $windowValue = $byte >> 4;
+            $t = $this->tableSelect($tables[$tableIndex], $windowValue);
+            $p = $this->addInternal($p, $t);
+            $tableIndex--;
+
+            $windowValue = $byte & 0b1111;
+            $t = $this->tableSelect($tables[$tableIndex], $windowValue);
+            $p = $this->addInternal($p, $t);
+            $tableIndex--;
+        }
+        return $this->toBasicPoint($p);
+    }
+
+    /**
+     * @param PointInterface $a
+     * @param PointInterface $b
+     * @return PointInterface
+     */
+    public function addPoints(PointInterface $a, PointInterface $b): PointInterface
+    {
+        $jA = $this->projectPoint($a);
+        $jB = $this->projectPoint($b);
+        $jC = $this->addInternal($jA, $jB);
+        return $this->toBasicPoint($jC);
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return PointInterface
+     */
+    public function doublePoint(PointInterface $point): PointInterface
+    {
+        $projected = $this->projectPoint($point);
+        $doubled = $this->doubleInternal($projected);
+        return $this->toBasicPoint($doubled);
+    }
+
+    public function modInverse(GMP $scalar): GMP
+    {
+        // For now, we'll just use ConstantTimeMath.
+        return $this->ctMath->inverseMod($scalar, $this->p);
+    }
+
+    /**
+     * @param PointInterface $point
+     * @return JacobiPoint
+     */
+    public function projectPoint(PointInterface $point): JacobiPoint
+    {
+        $ret = new JacobiPoint();
+        $ret->x = clone $point->getX();
+        $ret->y = clone $point->getY();
+        $ret->z = gmp_init(1, 10);
+        return $ret;
+    }
+
+    /**
+     * Return a new point at infintiy
+     *
+     * @return JacobiPoint
+     */
+    public function newPoint(): JacobiPoint
+    {
+        $ret = new JacobiPoint();
+        $ret->x = gmp_init(0, 10);
+        $ret->y = gmp_init(1, 10);
+        $ret->z = gmp_init(0, 10);
+        return $ret;
+    }
+
+    public function jacobiToAffine(JacobiPoint $p): JacobiPoint
+    {
+        $q = clone $p;
+        $zInv = $this->ctMath->inverseMod($q->z, $this->p);
+        $q->x = $this->mulElements($zInv, $q->x);
+        $q->y = $this->mulElements($zInv, $q->y);
+        $q->z = gmp_init(1, 10);
+        return $q;
+    }
+
+    /**
+     * Convert from a projected point to a basic point used by PHPECC
+     *
+     * @param JacobiPoint $p
+     * @return Point
+     */
+    public function toBasicPoint(JacobiPoint $p): Point
+    {
+        $q = $this->jacobiToAffine($p);
+        return new Point(
+            new ConstantTimeMath(),
+            CurveFactory::getCurveByName(NistCurve::NAME_P384),
+            $q->x,
+            $q->y,
+            clone $this->order
+        );
+    }
+
+    /**
+     * Return (a + b) mod p
+     *
+     * @param GMP $a
+     * @param GMP $b
+     * @param bool $reduce
+     * @return GMP
+     */
+    public function addElements(GMP $a, GMP $b, bool $reduce = true): GMP
+    {
+        /** @var GMP $r */
+        $r = gmp_add($a, $b);
+        if (!$reduce) {
+            return $r;
+        }
+
+        $cmp = $this->ctMath->cmp($r, $this->p);
+        // $cmp = < -1,  0,  1 >
+        //          lt, eq, gt
+        //
+        // ($cmp - 1) = < -2, -1,  0 >
+        //                lt, eq, gt
+        //
+        // (($cmp - 1) >> 1) & 1 = <  1,  1,  0 >
+        //                           lt, eq, gt
+        //
+        // $swap = < 0,  0,  1 >
+        //           lt, eq, gt
+        $swap = (~(($cmp - 1) >> 1)) & 1;
+        $rPrime = $r - $this->p;
+        return $this->ctMath->select($swap, $rPrime, $r);
+    }
+
+    /**
+     * Calculate (a x b) mod p, using Barrett Reduction
+     *
+     * @param GMP $a
+     * @param GMP $b
+     * @return GMP
+     */
+    public function mulElements(GMP $a, GMP $b): GMP
+    {
+        return $this->barrettReduce(gmp_mul($a, $b));
+    }
+
+    /**
+     * Return (a - b) mod p
+     *
+     * @param GMP $a
+     * @param GMP $b
+     * @return GMP
+     */
+    public function subElements(GMP $a, GMP $b): GMP
+    {
+        $c = gmp_sub($a,  $b);
+        $swap = ((gmp_sign($c) >> 1)) & 1;
+        $cPrime = $c + $this->p;
+        return $this->ctMath->select($swap, $cPrime, $c);
+    }
+
+    /**
+     * @return JacobiPoint[][]
+     */
+    public function generatorTable(): array
+    {
+        $table = [];
+        $base = new JacobiPoint();
+        /** @var GMP $x */
+        $x = gmp_init('0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7', 16);
+        /** @var GMP $y */
+        $y = gmp_init('0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f', 16);
+        $base->x = $x;
+        $base->y = $y;
+        $base->z = gmp_init(1, 10);
+
+        for ($i = 0; $i < 96; ++$i) {
+            $table[$i][0] = clone $base;
+            for ($j = 1; $j < 15; ++$j) {
+                $table[$i][$j] = $this->addInternal($base, $table[$i][$j - 1]);
+            }
+            for ($j = 0; $j < 4; ++$j) {
+                $base = $this->doubleInternal($base);
+            }
+        }
+        return $table;
+    }
+
+    /**
+     * @param JacobiPoint $q
+     * @return JacobiPoint[]
+     */
+    public function makeTable(JacobiPoint $q): array
+    {
+        $table = [clone $q];
+        for ($i = 1; $i < 15; $i += 2) {
+            $table[$i] = $this->doubleInternal($table[$i >> 1]);
+            $table[$i + 1] = $this->addInternal($table[$i], $q);
+        }
+        return $table;
+    }
+}

--- a/src/Optimized/P384/GeneratorTableTrait.php
+++ b/src/Optimized/P384/GeneratorTableTrait.php
@@ -1,0 +1,7406 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Optimized\P384;
+
+use Mdanter\Ecc\Optimized\Common\JacobiPoint;
+
+trait GeneratorTableTrait
+{
+    public static function generatorTable()
+    {
+        return [
+            [
+                JacobiPoint::init(
+                    gmp_init('0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7', 16),
+                    gmp_init('0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f', 16),
+                    gmp_init('0x1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x201365949918f0c8ae8331444741ebf07ca861073266887de11e0832cdd0204f8a2c4be5e8a1840af8e46d54d17fedec', 16),
+                    gmp_init('0x5b939b5a52ac7ebed90b8c1a809fb3a5c068b421b9e0a16208c2e53b1fe41e8373333e360ad2205e9dd63d29f1e0757a', 16),
+                    gmp_init('0xb30dac73155288a5880456a9081ab9fabab96e5803007b81cfa2546b6df2c78d6752be4b1d7e0071478760576ad88471', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcefe28e5bda06036ccdd02098df40e60b0767e4a8d6ca739d00b25bfccceb15735eaa6f1d4bd55d0856cffab4d1c7c1a', 16),
+                    gmp_init('0xb2b993d737f399192b3a5482be0d15d8d04b1725bad58bb27d4f4bc36a3672529448df3794dbbc4ff1470f0d74ec7d91', 16),
+                    gmp_init('0x26b517ad773ab466a2234ffbe03811f166a28bab4ba574b71928b0987f37e6e135de0387921f8f5b9abef9a969dab9f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x218f95cca7c0bce243206fe728b40cb7488692dcc6f6c6dff3b0f211c98684dcb61050a49747fe274be3f71edebdad8f', 16),
+                    gmp_init('0x83320f98547f45bb7bd6f3269b504fe248fee4312abb748f4052a2c625ae46e0de78079c60b796a1ac235b4013a5b702', 16),
+                    gmp_init('0x572f199a21af31790207097ff5e6e88d04036f64991d9c920a5b5ee089b8f7674e33057849ee12fa2b7a98ca68dc9b94', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf0eabd2be23bbebdb668ea1e39417e4f6b86c6f426a7f13f9a63f92786e2a951decc0be17b2ae4f03ce5a3ee655854c', 16),
+                    gmp_init('0xf2fdf5b05fc6df44c99ce81940f7bbcd508be2f5703571e5fb89c4d56b4da79d8de0bf876519434b3fc6385b4d5b55f5', 16),
+                    gmp_init('0xcab61213476d2c796a241da61bc9619b6639786288490451b594c764d2788fe169420f01b2a9912d0cfeec0239c9c5b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa63a5fea84a376491fedeee549a570977b1ee264241c62681ed0da2f7e0dc92b8f18cc90f075610f8a959a9c5335fbc4', 16),
+                    gmp_init('0x8b6bb4ae00f4d06a47176b765dd20e92e9352859fb0e9131800181bd7d5c3c0dc0172008a04d87f3d0669b09a757fcba', 16),
+                    gmp_init('0xf258f182053ddb0bb03b11b4c3064ab26020026cad111372016ed47ff3143f26039fe64d2d6222ba3bffd3d8eda283b6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x49cca7c96717bbb1a1e27f42c42e9683583f468ef3a142c903c9492ca31f6a0f1196989282e2bf6a2711d780ce3ee821', 16),
+                    gmp_init('0x2a065a80d841a6fe57e687aacfd504cbbb5ed63e751f1bbab3bcc144aed80a83f24d3a22faa02871d4e8bf6124c4f3cf', 16),
+                    gmp_init('0xb5f8557b8de4ae7599403a22e2c19036fada34ad14b54dca8789ac5a38ad5b1e72292583a9d9062a75dd317e475e2ec8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd01e292e62b1f984c84294ba98dfb403c58ef51ee4fdfdd99b17021157ec65fe94d90cb019dae32f64e738f0db6701f2', 16),
+                    gmp_init('0x7397a9df7a752382d63b4b9dafc56e1e812e5a57e436aea5ee99a74092b4196160844e02fdb3290ef791b3c45bc92a6e', 16),
+                    gmp_init('0x61c2730cb53ed3688d527e223923a72de8d461637ffb0cfaf3cbf7447fa552109fb915e0cc198e230e54d028b2926f2a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc67841381e209654dc65a8d2ab589370eb6b5aff0d37f4530822164f0e30a0708092be1d008b1148b620c41b4c6af5bd', 16),
+                    gmp_init('0xddef6af2cbd76a9aba4be4c7a0d5aca90757aa076e5e0e4c890d5826e956785892e5b13b6d74d45a9202861454dde164', 16),
+                    gmp_init('0xcc87e0a666ed625a89057ca15a525b9d846652eb9704c37ea605be33636bb91224f330518f045123d5a8ccf08daa01c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa10cd4d5ee07b647dfe8d88d3d670808a69d9c3f75a3ac0b27230a92f9cc1f68d51a0857efc1fb4ac2b4d5b9fe0980d', 16),
+                    gmp_init('0x9c7d16bb38f451491148bfb143bc145019518033615d05a1680d7f1ee2ca0e1fece3679e62b4ebcb85214f440454294d', 16),
+                    gmp_init('0xc9f07f1876c63073d0b4732d4201961daf0803cfd8f005ebdd2e459c33caad45f9e58b224d6788ed5b901a5282b8625c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa07d4ab63512e796808f9d648fe026545f4a9512d645f1ed7526263a16ae4a20088f4bab0dfde816739019a3dab12473', 16),
+                    gmp_init('0xb544611212e3725168e12b1fab1b0abf7588db97ede0cb578151d2ebf027799c0aeb346fa9ccdf07e4fe019505c520e7', 16),
+                    gmp_init('0x5b571eb5ece4571be1b0cda5949c0735d52aafb3a06a8ad9672a9e937c4e293bb5b4c18e78e6d78bd5f0857cfb326c05', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1acd146789cabac5ba229a08173d4017215114211903e95f213b8d7726f67796d3f6a2e01d536a60f971f56374b87b', 16),
+                    gmp_init('0x4b08dae8d490ffa3e03152a70a85220a42453d15c53cef64e4f94edfa1b909b1bb214f801e4894133b1fc165ffa42135', 16),
+                    gmp_init('0xea7bfbc386f0c827def7b2e865ea7e1b30dff400d761c437a70d0d6f1c33a503ad1f3df80ca71a247258d879a830e0a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x19eabcb102377161db77024e6585c756096267215f2df58090cd9998101d42fbcbc63508fba6d85b6d00f17c031d8d13', 16),
+                    gmp_init('0x463644f086a1c2281267821c4a18629d708bb760e376a606bbbbbfb121eec480841157b529df304337ce112f362c35ac', 16),
+                    gmp_init('0x86c21a29f12bb724c04e1a13af064a6d1f0d2465622f7a87c311d0cfc2c2596acf2c0bcb22627ee736f0c76cdd88d741', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaeab8d35862e6e91df7f22ef9b4ccb33a54806e9668d60d89ad47a59a7ff96cca8c40ce04a1d327e770108cf2985c819', 16),
+                    gmp_init('0xbcc0088bb6012cea5b0519751d83a9ce65c7448601e8e032fe8b73758f57e39a13447307b46801bce82d178cd8cb2a66', 16),
+                    gmp_init('0xdb3c11b51dd32a2777d3a24d3aaaab55453f14d2fee4ce5e968b80c1fe22d2d24ce09df08aa157eebb7694c5e19d60b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35d05b70ddc5d31631f0a235997503734b7b1f0bc38429cc05f733069a50eb6f1bded8c6d0ae82e8a60a470ebadb5673', 16),
+                    gmp_init('0x787faa4d610d24d2e49a85cf5c77aeda5d99e5d7ccd0d0dbd60ffbe027e521370451cd678f69757e3ac953111b1c5f8c', 16),
+                    gmp_init('0x4c98435d7d4f54d94d1c696dee2a8cd207be0218f472e85867124fe160058652277fff7a97b277dfe247647ffe2f0c48', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x188395715643a757ef5af29eed28137f1e4239f338fa80495062cfb33df2f2822d5775402157d131b63708ff771131ed', 16),
+                    gmp_init('0x20fb5e677d38fe5e54500c0be81f9df866d76c0057910583caf7bc0b74f7c07ff9115f14497da82d8fdf75eca9eba73d', 16),
+                    gmp_init('0x4f7cf3b9a82a5281a69c53a572f23ad7137e60ec9cdb982d845db0cd5fe1116b94363f0772e1516622d7af0782052d23', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe2e8ebb3f4f538a6a1939196af557296088043f473a5dadb5007909ff8a173c9f1cf3b0118d59f2571984026830ea21b', 16),
+                    gmp_init('0xfa310ee4cad6f6e81be99db7d5f6fb612c5155b9e7cd392664730fa3c5cfbcac801c6d6cd3396049734b0a1578aeb5c3', 16),
+                    gmp_init('0x449d932c31fb8c83d0125ea01e3d66197eb71a506ee179697e4542722ac204c17ffd9c0c09834db3546e833ccacd81db', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6682e52fa02f2b8d93fbc3bf722743d2121107ee7cdabe211508619a2f84a79ba6bdb0da354bb3ebb30340386d4f7783', 16),
+                    gmp_init('0x1ff6f14029983c90c1518122a6f2eb0417d210a821c2ce9b29fc82e2ef7d7379460a64339852e4277c9f464e64267f34', 16),
+                    gmp_init('0xc72f65c2f585e98260bac4a5bf51c5f096733a8e0adea49bc998723222de12a6505cf7a89184105ab95969573de2043c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x670b969b6d0dd4ec0e2a2236079bcdea9e8eddcc3b079696f160f91f3cff7d07d542fafa9cc46f1bfd367350bae9a4c5', 16),
+                    gmp_init('0x584b28426dcb2c85a992fa60eefb16093f62ef6d4d5a7aee4e47bd1d461b2ad3c073717a98b24997896c375d2210bda0', 16),
+                    gmp_init('0xf4380a6cef42f99d2c95b697cf4724a4a59c8c7086e7e03b8d46c6e5f8989464c17d95f5ae0d3741a7d68ef1fd0b1e11', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf99ee2174d4ca4515086f0bc70d7b86e9e28dcc041b937391f4a19b2039659067e9fb45cb5d66f326fdd4758091276bc', 16),
+                    gmp_init('0x3a78315f5fd99becb54d6eeecdbf3a1e35a6f4e32c74d1eeafe5ace4c11aba77368941c69985955da9075d09ae24f72', 16),
+                    gmp_init('0xd244afb542ed1b3b1f3c6ec30e1a0263ba9c93f5d1936db6e6405abea3b04a3688a122d48a528d27d6ab09b76bb17d01', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa7dc4f966b1ce88cf47e1a108e33b46f6c9227092575422bfe12cbffca7f4fb31cc235c109dad63c63d381082708641a', 16),
+                    gmp_init('0x715edabdf1ca28cf06597263b4c3b46fe86305c63c2cae4a30ee373aaf84afd789b68cdba759c4685e59ebf998197e72', 16),
+                    gmp_init('0xd7cc5a8ba006210e13b40956630d3842a3444424bc6ea290db33929848b123da48039d337c69eca357a7ff75e8c6d07f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x51497a2c69843d06c871d70c8ce55b3f50b0e09162ca52e00cf5f155ff2e9604e384f2a6f23ddd22478c6168194e2d0c', 16),
+                    gmp_init('0x9be3a0e2a31ad0115cacf98f6a7495319930d3b29b754db2e1d0fddd0b1118c3ddf30a2a0ac5b1d87fae18a873e44e92', 16),
+                    gmp_init('0x1bb544767ec772b09f0c662b1a6ea09ced4a543a669cb8fa5ac778381b60a629a6ad10fe078cffc8006020107304179d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x44091d66faa891de9d44117d7a98e11fbde2ef6bd2171b1fb426b03823a094a6e572afd3a3a5ccf884925f7223a00324', 16),
+                    gmp_init('0x34836a8ab0e3584a478c0538b1b75ca9bdd03a0b1bac37368311d4544713b4765cc6343b6a4437b3f44227e7a37017e3', 16),
+                    gmp_init('0xd5a0774c6b66c8d2db85585c52cadbc28282fbf8a77c79c24b95d1fec71eb785a3798d1ae76dee1bdcc2c5db8577fd6b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd0014d1699c47c3cb18e8343279e6137bb1b93a6c4ff6f578d8e2f8bb36be8f41ba84854e868af825d2c95b102d3dce5', 16),
+                    gmp_init('0x2bb499dd386c56c0b6b1b37d78c23705797cfd83f0d9fb0c9963f23681343b989d655773731651ed3d6143262a234563', 16),
+                    gmp_init('0x8c45f46cc2855be7a3701fff55df787a4ab8c704d3d6c0e4c07a13810e719b5a44ce1e2f6c0de9b346daaa78b49e1750', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa7250d26c46322728e3b2723470b96cbde9e3f46849984f01b8ac1084775814f70861c0d4f26037003b1f851839009cb', 16),
+                    gmp_init('0xb672db789c0052c73f2a3de333169bb7e32e4e7cb5e8740f7e07802594a2e103ac52522d0fdb7bb3fae14213a82ce20d', 16),
+                    gmp_init('0x2d7ce1b4f2c4d4d463fcb473ff8aacaf259e4d9e1345a3d8a4406e8711ed5308c008f22116b475fc74524dc0295c03e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdd813ebaee06b1b6cceaf8670c442a4a7f432a34dc215501ef81abf779ea7466e99626b70161f7e7745438193b3ca3c3', 16),
+                    gmp_init('0xb9d6146554baed5a7410c0754f7647165dc0e1caa807b40873a371ef0beecb6d5a72a45503caab51721f94312415191f', 16),
+                    gmp_init('0x1ccf66b238a0f9972c392687b1d972da6ddcdde461402237bb2c2388b5bb2292398e5532013ea6f1a964e4584025dda7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbdeeb6ed1808e32336b00f0a3c46dd19b2fd68bcaef2725a3e5c5c79142f305dc5d5e61350638c544766c4be4c9618e8', 16),
+                    gmp_init('0x92f79a6194c6ccad3af6e986617baeddb0cbc9002d38c3b0db477f75d1b430bb81b2046a507857ae23b3151bdf0ce5ea', 16),
+                    gmp_init('0x59001f541c819246ea299199b1bba4c685df25b84d86a717eacaec150e66b818eadbbfee85ce19623cfd416e23bdad08', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x139f7083cd921309a31f1b657a8bab049d69ee39db06e9e8a29b5c630f56fc6052434622dfcadb3f3d9f69e3feb68e01', 16),
+                    gmp_init('0x3734f4a37e98ed3aac99a6c810a818cb73af43baa892ca802b29294775864b75c1c0c4d4b33ae1d7805f07559f84ff29', 16),
+                    gmp_init('0x1585695aa217f6046409f5c27ef2aa44487c9b681290b20401ad21a665509f0dc0ccae10d568cf58982ea4e7bcd117bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d3aa54e61f1085e3069f5d67c35563ef34041a4262690aa4a3d96c020eda288f9f18409e8a3f1317721f7cc6c18ae79', 16),
+                    gmp_init('0x40020a2d47083805659369782687f32671a83b65ed75d2267db1c58466a78ed2d15eedefa2042a783ec99421aba3b3fd', 16),
+                    gmp_init('0xc12fc62c7a8e2289a3d0add93a96f0013e7be4a548bbc0c8248559ced4f29f3b05738bb030d2d624a52558ad40555af7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x495b5a78e9bbf0d83b40e9a2c845bdb78b2fcbd0533cf8d083b0ba56c3f42201e2a47b2ba90217dc9278831dda28e638', 16),
+                    gmp_init('0xa486aa30bbb2575158fd0e3095b2e0432146567b172973fe713774a0b22228e647c12038a6c7ea39e6e0b79b54e474e3', 16),
+                    gmp_init('0x582064d652de796160c9ba9b6b31380a51ed0f28b98c02c3fed2a007702f35dae016d151c7b2bff518936a7a9d108c05', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x2e028d8c3dbb227763000924bd20382bbd8573bcb59162d1c3c8d88600081b335c2e7775dd783f93ffdfad581bf0bc94', 16),
+                    gmp_init('0xcbe46707e81ede78ad2c5d4c16ecf0157d0366f829e78a2cdfa1bb6ba07db9488dbe736e6d6854ab0a00da75c557cc47', 16),
+                    gmp_init('0xd445eb8b48eb16b61acbe8d3c3453dc5d53d4ba0f7ce6af13f69c0eb60242ba41e9c0da2251e8fd8510436680a36a448', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3326e7b8e39610d40d3096768431c920e378dc03e119cc6788f5983b103e7dce3b2d4e69f442de9ab94a7bfe45efeb96', 16),
+                    gmp_init('0xf380d92b088e9cea9b8d289dcfeb6e155781b47900cf62add1dc4916642687288776172fb6d32cdf9df865dd79f674e0', 16),
+                    gmp_init('0x356233e48fab6e2dc43f77ccc8e9ef2f252d1669e1244700904f509d060c5e55e4ea14393e6c2b59dc4ed00cfc47dd81', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4fafa563d67471537aec57b7f7cc4cf8703cc42a36ba33661956285acb0fcb56af2410189d74da14d566a494f3c8807f', 16),
+                    gmp_init('0x628364c18197e060efc25c0e4c8095d18b7600523b09679aa2199dbcdd290120a115d37723962426986470efff04c02c', 16),
+                    gmp_init('0x6c08d51ef411e77bde4bdd0c8884483212f55ef409e8ca67ceb4e26bfa6709159b45d948b7c1bb5613a35d788c514126', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb88c71297029fddafc4bbffbfb84779beef991b1d0d43577c7b9ce17ca64b46b23169c398cf282924952b92850b9e8e', 16),
+                    gmp_init('0x6fb6b6b36cecdde99ac96c569fbdb5eb90be4651616d2ee7d32029ab7800203d14b17af0b188d59480d984c09898037f', 16),
+                    gmp_init('0x788111496d69197b218fc4d600f5f9af7d0d6f6bf304f5181fd5a8e4d59516c8a9ebb6eb3dee0dc4a319d69ce5127a46', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa65309edfe6b6602323d136d91cd54d832185dd23c4fd4d262db1d57a17727552a00b1f4d17d4751c9c785cda6eeb198', 16),
+                    gmp_init('0x6d0ac3809ea20e487cf340d1b2861c931a652ab108db22a2b2ea4984ba6b3f95e2c06886d9f65e3c1820544643568ae8', 16),
+                    gmp_init('0x7f1511b670b095d015ed80f99298d7f515506d8ac8e592dc0ccda7547b799a3c1e4ace9805689bf265493b4341a3246f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc26595b6004c9330c1a0d24fa7773a46ce4342d96cb4114efb3fed8f7249d8d11465df1cf218a455f1a9ccb4bb441ebb', 16),
+                    gmp_init('0x409473ffe0d79792333a8d4ff6f323c49a3e9e661a4db8b389537fd5e75f19e7de0076dbfb7c53dc1af4415c8ff1630a', 16),
+                    gmp_init('0x975aa23d331665b51d11e6250c758a36220ce9ebc83b7aaeb6cb8f07025260a0caa667bf8eb326203b854454af3d48c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8700fb29bc42cb93dda1aca279e3288455906ae26e512ac7d03daaa95df25aa199cd1170890f330f010ae9eed25cec26', 16),
+                    gmp_init('0xa0a8235c05d09e81cf7d5f0b913a94c586c53b6461485ad75c28a18abd0a0767c0610c9cc0abb125f8ed2a3c8ed7a0f8', 16),
+                    gmp_init('0x11da720502b5fe816b05b94c58a46a3d59b8c9c554d8b1f448ac11dfce2b34d2921ce548835e41ba2759d990c243e7de', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x54d4daa225a0414c3f3e73a94a3e588fc3b2f975165daffa0d3ece3b8acaa33729f9278b31888576eba223582247cfbf', 16),
+                    gmp_init('0x625cb2d0bc81258d07f080c7682677ce01b8f7a0db5295d725abd3cc298a1f6e4b7ba88efaee0468107450a4e989ffa2', 16),
+                    gmp_init('0x1a2987964bf647dfde6a4736b1eef319d5a090b75b0d6365b4a003130c351138d7fd74fafce222d1753495716304bdae', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6a190cd2258c35743ea94139aeabfd417e64e9640d169a8d5a3ac0d616ccb6065da5e21a3f795862d4376fd9ded66b3f', 16),
+                    gmp_init('0xaed52df6bd62d774d445977a8fcf2eada395b1c8f5c349040035860e67506564cdf21c3cfdcbda4546adce5333cba207', 16),
+                    gmp_init('0xe5df813e2db53ae9d714d1c9296d28e115f925119f561977a30f1db27cdc9580b95a2ac30b2c66be193b1294cd634b9f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x702cdfabfff2298e239afeda9cfd2581f3bca6c6ada9f637101da20415c230564e94b3f73a0da78892e38ba9ffcb83f9', 16),
+                    gmp_init('0x2fae4b4d0c960190fd22769a7fea37b2c76f3e66fc2b12c777f23eb3292771dc1449622e82376ed2b829bb6676e69b01', 16),
+                    gmp_init('0x848937f982eb8a6260d7a4b347a04079469ffc28fbd76610f08b4a108bbb08ede9b5ea738a039729f3b6b4b24d3fbfe7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbeed2f51418e5e4cd17dbc113f7447aa1de81ec10457497a6c5d4e7b50707320a308be09908dfaca0c79f6aa354852b8', 16),
+                    gmp_init('0x7fce76f03338c00e44fbe092b3d2f1a9b6321646ea2513df0db8d2c11f0b40a7ec2ff9c4c7ab8a9bb3c60a4fe510edb8', 16),
+                    gmp_init('0x2d3eecc931020877806fe06226762c2c9ddbb83b053da85a474261b5d229a65d9fd871946c05e214b4bd74d9f9c9e429', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x787b73a9893498d44102a1bb82f14384f703f3779e594dab7ae25c286d24e6368cd6d1a972ad64ac41869a82b0372f61', 16),
+                    gmp_init('0xbca49d6ee36d1b30f8f1f2b1c20592dcd801098e14f8eb231eabccd3f4270d6afef217f13bca9b8ef1ca3eec2654d3b6', 16),
+                    gmp_init('0x2820ebef3fc8ad253866fadaf683a81504a7ec7b53db8b3a166819348f97859378872b395781c2677afe270d1fa3e90f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x767c15d4c80240c6bd6e20c3d1ccd57ad630e23fd7c92ccf603afd390916798e45787d5941934546520c4faf9c49f831', 16),
+                    gmp_init('0xb26f642df7bd17efa5ac265abd4d7f85f88404ee59b53a72495901aeaba5a6c5b5786a3167c72ce364c71378d4e0ec03', 16),
+                    gmp_init('0xdaf4bd91a44115c918ba545348fb522a4623c79bf03ed95a42cfe30d5a1b2d1d6c9d49b92efe26d790307943b61c7211', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x34becd58b216c781c46bf1ae166d38928052fa477ecc553f2763f157377fdda266622478e76b669298c1c4b69e0566f4', 16),
+                    gmp_init('0xd6ec3fcf35e636b8e53815d5a83f1f34ef6f3f2aea7417598534971a2b196165c46bceab4e9800b762200cb05667d02e', 16),
+                    gmp_init('0x607bb3e16f90d9a73ec62fb27365881fcd320a63cd8fb952b760a8b101ba9e007a0de288b5f05280ddcd71f2b8583829', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e264b3768e3520a55045e0c8e1bb00c0f6773f3ad954da31e632e650c48924def2e92f6f8fc8ac6e9e8e6ee942f39e3', 16),
+                    gmp_init('0xda190e9ea0fd2e3845524a61ce14af5dd72766b823439a65fec9c1b915fde181e4e9b39e2298fd07a2a9cfabe6c577a3', 16),
+                    gmp_init('0xc58f0dbb7c1db9a8f8cb55fc922de223dd5b309a64fa7525194518f2627c99e6c3c5672b75208d69882af6864380d09', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8d9455b8fe362bad4358adc6c913dc27ed70718ba73b16156a48e3b214688722e0381ce30aaa1be0e8474fcce5d49b63', 16),
+                    gmp_init('0x6362578a726e672eae707fdee5dd79cf9c7bf1291ff9fc5dc8f17c539f1723910b846f91d46796cec791aac21919cc58', 16),
+                    gmp_init('0x8f97e6a4c1977b13719f649e28ff41e484e4d6387bb24235215add46113dfc13920c28d261d609d22089bb887c902f21', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x86c77871e738e7f7f54069a66d9556be2961a457662ed2c9d5039366b9e645c71524aa8a71dcd7425a486d53ab0a35dd', 16),
+                    gmp_init('0xf605d4f30152697a61a03be4da61e464d99413d24f203b525ac993841d7dfa6e21d2eb224fd6d7bbe0eb010796f882de', 16),
+                    gmp_init('0xc4d0096578fdcbc430a74e47337eada0c38b8892651f151922dbc10660c7518c2189bfa8eb0a7c6fc0724ce1daf199ed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x980e90a18f6ba6f69cd1fb22bc30f34ce314b991508b14746fd916b74af45c5d655ccc8cbe364129132dadf4e20554d6', 16),
+                    gmp_init('0x591ecb3e22826b93d50623115b9de664404926cc594b15ca8c9eaf380caedc457152b6113dfb3c577740dab9178e3223', 16),
+                    gmp_init('0x432eb212999ce29ee36314ff04e9cb67ed72de6970ea763291ee38b92eb9e2e1db7335bf8787d77ce8397f54d8251f5a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x523fb33697b8d178a51527905c96ced75473c330f7b6f3d61083150d9c5f503b450c330b91bb212707ee380385c30f27', 16),
+                    gmp_init('0xe4a6352abbd05590ee5d687f5674301d60a5a79371aef2d3116483d23332f9115dfee4e477e967ebce51518069f90be9', 16),
+                    gmp_init('0xbefa6ca9780dd5d430f9396b1f93bb72db1f483003d5985958f5438d78ba2f488253bba3fd8042b8d73556ac8c17a2f8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x630c36247de63438b2e3f1e31266412bbd8326bf0b95ae9131aa1cdd492aaaca3bdd793770716e902e3954c40fbb8213', 16),
+                    gmp_init('0xb5ea879352d2e967474c7f55d3dedba0de992fd4fc34d5897c047365d2f6da80754bbd01ad8900942ad163a85d25e3d0', 16),
+                    gmp_init('0xf434ad8709750e074b249c8235de46ec94b69c01d7836254b2b2c89359c757c5808a19d01449807c5b73fed69cd462f2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb47c680f9be18d9334c543cc8336c37e84fa3d0224fe5668cfaf1409d8f5969882e7d545f3512f5c42781e5ba1a820cc', 16),
+                    gmp_init('0xd52d6b240c32f385282dc7a803821f4727a5f4a712927fec93d2d91e81f24cf1424007bfa726f3133865e32e3cf3bb00', 16),
+                    gmp_init('0x18eebc42b72f9e9f012ed3da511e5a522bb562621aba8790b9ebcd0348d00886e22768bf08a3adaabb26a31badcc10d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4c05fc48d9a21e92ca4e6f0211be992c23bb73f047916eeb57e62f3b752a1e69feb6279734209117cff3a8508282f425', 16),
+                    gmp_init('0xedd68b58b8d86fba81604592f14b728c5ec5e31f4aea06bbdd84c0b54181174700f32a6949f542f346cd3a47a1641485', 16),
+                    gmp_init('0xeb1fefbcdf7dbd1e8fef3b2e77c49c52df7e1f9edf333379b71af5959926d28b6f9f0f0f8558a0f6f4004f75c0d108a3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdb340dadce294a85c4f648861acf08d9e46ec05717529809c82f08e96b5915bc4f78b3350c825a8424c27d7ef08f9227', 16),
+                    gmp_init('0xf122e11e91e918f26fba17f5c1c46bcab001d0ce1decbc71c71e4ce4818bd86192e754cf95ec76402a283f5bc4e85ee0', 16),
+                    gmp_init('0xe49288a08e898fdac5f173e9c377545d34fb194270075ee7a5913672bcdf3475d470e70c0f4860e16ba3b2ea60c65e0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x298d182ca7715d0b11b9a30fb6dda6d75f7647f25e2e2aaf4b26358142f6f4280dd45ee4cef0b8b7fa288af0359179a3', 16),
+                    gmp_init('0x378723e615a0846521ba90563038060bc8712c3721cc1d1fda5e4bde2b2d09c5a053c24afea766375f6708d145752caa', 16),
+                    gmp_init('0xb8e21b9ea678be933284d6ca923329bf219463c0cb9b67fc3e8394b946c98104946b2da529205624be797dea37a359d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x64753685db7c5bb1469993eee7b282544cc24a38f8b6590a67a0e691fbaa4e40bd9e0256f03174648f91dc01a4c58736', 16),
+                    gmp_init('0xbf931ee2770405354c2f273ae9e58feaa1c00de6f2cd33a02ebe083d87e686c7a7e4402c0d44595a7eaa9959dfa4c6d4', 16),
+                    gmp_init('0xb9a914721e4301b134af643613a4c97d025e8f4df3e7dd035970bbfb433c9bfed2e26344b7947f47ef09a1011c501a14', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7fa99a99638ed606d170c5d2426574c5e987a8750e31246a844bb0e1ee32d7d994ab349ee6069116e859f85e53f4db96', 16),
+                    gmp_init('0x3f01521bd9c82abcb37b6e4b15ebb663d1be03650ae206ae7bc32edc87702827a1fe90dde5c16dae0dca950e9eeeba63', 16),
+                    gmp_init('0xbc689645f96a3d202c791fc5204a416653f460f6a746f8e0e2228ac52b12d3efe8d211d7ffb40a72402af8510fd3f26f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57c19bd634398c6e11b98fff0788e7509037864d33260f89607bc6da0d62dac6e2ea626a7f70685afbdcb5826d459634', 16),
+                    gmp_init('0xe3791e7d881fb425df4b50e704e8b1a8ca590385ba947af3f75348315af1fea3b13ff51b12c1e479718b84ad211de61', 16),
+                    gmp_init('0xa02f8bac14c0432437fc2f5aaf0d5fc68e5e75332d64b02960d73b8eaf98baa7098ce22c88ffffb8ea9c795d926f1d2e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4dc0bd674dc2c1552abec455c5a2ad88b0f8a7d5b325ccd4765cb2d70073ea7fa414f4500e696fca434947867d376046', 16),
+                    gmp_init('0x6950b128909360df51278f9674bfb10fe64801f96955980add36339914e720242b6fb986fc95b67ee24e5286b649f451', 16),
+                    gmp_init('0xd810827e51e52940a3ea2a30f607e1412b1ed6220bd7026f07801f48f46f215cdb57815ee512c30c09d41d8843efd64b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6c6e840cd1a28115ecba952cebc9e9a9cfb035c10035ed49b32b93a1a1930c1866a8b3805b88ef8b1a51fcc19186f39', 16),
+                    gmp_init('0xc5f0c0df021a1bac0609c37e685ab37ed212843aeae906123f242cb42f0c612e0e49181eb532c853b4f3b18579631db3', 16),
+                    gmp_init('0x67e740b00783cd5709dbd7ec9b9a525a705fcc5036bcb1ea48b9ec7bb869cdddb5d7d6d575f7cacf0b8b3705c227c789', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x205bdb13b988c9b0f7068d81bd3eabafb415886fdd34fd80d51f0cd525b12bb49d72964a557e5a7dc63ce41b401a5fbb', 16),
+                    gmp_init('0x93690af7899c64bb67c42f7882cb4a4492e13d34767d1976618bcd1ddd9f78b92e696f5f26275c096b8246820fa5e092', 16),
+                    gmp_init('0xf0ff89e0cd65a745d99298f655f9f17f32e29a76598adcc7e870fb5152b2c835c9c20b4f2fcaf7922a4048252eb28fd8', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa8a7c4b62ef6f890faa1dfd6a844ce74a3c8bcceac8c580f0b2b543147fc7c1baf4253b761b061f4a107f1a6aae36756', 16),
+                    gmp_init('0xdcb74b8eb37b1daf28af3178d29fea8a5d831446743677342cff875c50d8dc73af44ee91e88ba8d1b38eb41c3c5502ef', 16),
+                    gmp_init('0x4143069eee25e6df8671c3e7730d5edddf820e3644bb372155b69d378718f6d942d6425c94926649b356a20e7b4b18b4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2722fea6d1db2bc29d3b817e6044461339ddc19e0e7f29cefeb52b5669b4fcc0441e3b17ae10ab4a35ade8fd00d43dc7', 16),
+                    gmp_init('0xf1cb0e221dc56b8303a851fcca495ecb28c2a4474120662713cf9227af2990706b761646de893f52d0817c38b206b41e', 16),
+                    gmp_init('0xd7645d58350cf89b3f01111cdf6a7b105af0a0ad498b84bd2218b1cc6987c5261338ff13f59c2ae9015595545db36a24', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc5782b5c7211f9c1c4a228e5df1c4c944292d0bd044aa53795ae9a410621d7e3d91b9d939c787fead627219713065db7', 16),
+                    gmp_init('0x63e5e198b1202feed919aa78cba639fa25d12114872c5719f8372f96275f19ba9ec2b498e943a85fff8079e7dbe28f9b', 16),
+                    gmp_init('0x2419a83f82bb7ab96cfb9b7f25d0f7e861bba005bfe03188af81b7b836f90da7279312b49f048adc80101986eca3857c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4a71bdfddc6ff9b7c420547f8309bcec1ee60add39ede6529ed898896858fb1494fde5e668a2f8d0431affb1d4c61db9', 16),
+                    gmp_init('0x5a848612ab37ee36ef74d83229b790afa3b89a1460a6689f5b9c040cf60b7873c2bdf17cded8de3bdcfb98e190eab839', 16),
+                    gmp_init('0xe5fd6c9dd5c33a55b888ce8c19e66d9ff4cff9755edd7a38c0e47f7fee866b9b70540c34fd6597a99bfd8044bb46bc9b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8ad6681ee39ebf99deec71bac37a92739603c27c85059a8d23c72b48e5965f7bb92e0fd2ae85a5896cbde93e7e74991', 16),
+                    gmp_init('0xc3359a2229a36bd34ca5d9df707fc19544cebf901eb7e0183d3ec586ad682a90d60cd95a56fa59e898577bc1c4b153cc', 16),
+                    gmp_init('0x186f21b9498f76d5d26a9944231bb070de797eb6ab42f172c3be25b9bc3515124d3474a98ca17d5b1637b389aaa8348e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x45a0cc6e5b15f8cd9d2ff39152ddadffdfae795e80527ecf9a569d606fd8ad84ee6de37c8b2e212f600dc972fdc44e62', 16),
+                    gmp_init('0x16e91eff31dc90744eaf1fd883ea80e699b27f9362658a2f860c49cda0187928e84241eca0b8ca048a9179f1ad3bc656', 16),
+                    gmp_init('0xd3ca0a6b4c64ad3b6e20f0eeacc91a606a1c0a73f8165a618ddf87b84bcdccfb06ffbb43492cd9e8671c47c4069aedfd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1482c1f48fda099a3afd470a26891434ffea7fb75475fe300bd6363e10250dca73ba4f63ef2ce5b788a975290f730364', 16),
+                    gmp_init('0xba62d986a7fb71849e60e460f5012f7dd3705057e7d39288ab1438040f04d2b5c3b88f4fdb73060e43ffd2036dbc34df', 16),
+                    gmp_init('0xfe18e3f06b365f75ddc16b06bf0a751504676992e1361e73ea7baa1b97e6945c2e419cc5e70297b3dc3af08788ff07e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa34d947c352b3ce5e611a0978c16045818b5a5b2c9a238a99f5e8c4c156a36dfe29b3a043fab2fdec96c7d719a95bfd', 16),
+                    gmp_init('0x5fa201a067749afce69a3d7eb50865af6077ba942e696c4ee2f6f8f50ddee3c0075b77e3d8d669bbb4619c47897a4fb0', 16),
+                    gmp_init('0xe4ef79b49a954f5e58de7f7da1181690f82c4992612e13fdbef15622f5cc5982c783a9746a9aa3ca93e123df8654e27d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4ed9908684ac85211c844db4cdc9f966da6606b68a1592dabceaa810894fb2a503dc8464838b9c7ba26ca69a3b0d3405', 16),
+                    gmp_init('0x83b60aceaabe1b3ea6ef5db2ec7f7f8b177a2f42e685d092248671e3701f496b455a972dc5c923c75312be39ef830401', 16),
+                    gmp_init('0xed2bb445cd117aa865d8dcab9f35b29848ef6a4f40492aa337950b9e73f2afd4d1e742918bef23a7a4940b16257e40c9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x37ecd48cfcfb2e8a397de94afccdf8574b94aa0eb6613b88b6f8c4982f3719ba2f95fc35765cc8df4b19e1d548208f65', 16),
+                    gmp_init('0xd66fd48b1b7b309eadd95284d4f4f7f3c0fc891077b6f4773bd758ea10f6cc353432ddceaa7c43c6712cfe08f7fbed85', 16),
+                    gmp_init('0x1dc937c9a0ec231586f8550e9e966f925b02fcd99bba248caa86f2417cf7dd4842fd8f4e76162d5e3a87c556c5c0b5c9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x355f58b0d283ef28accd9a27370048cc2a1245141d81f97cec62deeff3568b78f94bd8e388f0a68085938f520877c024', 16),
+                    gmp_init('0x7640b40570f160cc074c17310a04f140d793ee852c91af5b16179d4430244039317b2f1e6e96910e8b112bbd88b2c3fb', 16),
+                    gmp_init('0x1f7e555818f8eb4231d90bd267926971a99186d7a0501206131f88b107ea45ca11b46aa694632ef92435fa94832901fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2ae3d3f999f79ef1347e25b9188248d30c2e07f9deba89729d1d74cc4e9d442e21316b44507c724ba2437666f75ecf04', 16),
+                    gmp_init('0x7cf2feff69d4c96b524db1d22c8c41f180c588bde17b542fb609bb4476ab18cc0a89718da78d6598fb743fdee5728979', 16),
+                    gmp_init('0x6b2877fa4f0807ea9795d6242cb03f395360afefa7c43e301197d665e87b3d2ff95585300b4bdab9f2df6da7c3540edc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9df4632b98fa5a475626e37938e5f36a85417d6cb6684fd9d016ee2a61be5f39a0525ae8cf36baf17cb2ab5d4effbb3a', 16),
+                    gmp_init('0xd12cfa847324c4a3d585e8577a504943cbf831079c26e14ff974ee00b9efe92b4e4df64f130d6836d6b0a7708d9d0864', 16),
+                    gmp_init('0x526a43268dcb8d63c7f73fa0cd426d5e9a173e853e3f21b0d2c4951cc0ebeeccdb00bda2222702ae33afc75ff40c6222', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc87e1b51d2f175bcde55a8ce5a925330f15bb15d274c8077545d60c93a1d1a3723704a1184b9448327c244a28058ecc3', 16),
+                    gmp_init('0xa7e1bfb3cfaf5e30f090d1f1793cc8169bbe238170e99f915339942d944443076ac8647cf64d3f4f49b27ad45eb8e172', 16),
+                    gmp_init('0x45a25e60b0ef0423047b7305da9233f4843a1a492ec24ae5e098003f0e52c677c938afb06cb61ab82b02042f2ba639f7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa825da4a923c3c1004c1c108cce122de14e9ca7825a1ad028b957c58a2eb9ed7955209fde294b652ed022460d423298', 16),
+                    gmp_init('0x8ed7c08dab13becf5936e7de3b140cde891f7e2f356ba3cb8ff5a8d1caa703b73d33b7e99c34bbf39767399d61f11dfc', 16),
+                    gmp_init('0xf04211851fe549e88d19068e13ded26c9dab055f71af41325d6ef7a0f44ddd04010c3c6b716e9d2be2bd574323a3f4bb', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x1ea0bb4ae42a392534d89ae763ccd3ca852791691b26b5b115deb6d254c48d90fcc9ba82e35efdf30c4988dc023d667', 16),
+                    gmp_init('0x62290a0a6d94a7d787d3ff238c22f298bfb8d44d916cf6fdeb264c765690631ab77677579f62b54e4c9b1db707ecc77e', 16),
+                    gmp_init('0xd112c227d3782a0c75378112f3ad93ae5e54408643c939edeb6c1db9f7fa197819eb0492c1d771ce2462459c763a9457', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3578aa08e6cd8098bc2b598f01bb9bc21f00d01b5286a72061433298d1817129600f5911961ce98db3cd1bee8da63b04', 16),
+                    gmp_init('0x94b63660135214b621c2041ee8684822a855532bbe58d66bc7dad633100febb4a18c765ae950e88d1e7a3ba3732d219f', 16),
+                    gmp_init('0xa914dc9d801cc5eb15986d3904d7891476f860238f757df060622f9a9d3ece43ee3b09c085a4c3f805b4a785a994eb86', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xadde16a111a95a700986ca554d8572257b0c1937a96c4cca7290ff92872c52a393d6fe35e1940e26a31bc2065e00fb21', 16),
+                    gmp_init('0x63396b16bfb61fc86cfbd8254925fe4809c1e5db0b425ab3ebb5aa88a3359624c5627758ff8d03387d6092ca4c661256', 16),
+                    gmp_init('0xc809d46b337a65cb7a2dca1cb3aebe8387bb971a2ce4da432e7fffd7d7770837a516a124cace06cc5a821ff7e53d35d7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa8254c394835cf28307d6a606f127e1b0b887ed7f9e22f242873b62fd17e0fc059769c55bbc498ab9e88cc5382e5c325', 16),
+                    gmp_init('0xbb1e00dcc586f1f7b11a3c0a5f2fa633ff0dd4495db16c28fcd55892b48d4a47b582c957683ce8282019957c682cf92', 16),
+                    gmp_init('0x7ea847fb4a49edc15765793aef68ba4403473a8bdf03837c161a769e2a40a1ba0e4e22f26f3cb00c8cb8a42c064243d5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdd1af6daf2898ea298870720d17f7dda48f94d84585f7dfba132acc94e6c70faff9388fc2e68d8d764323db7a1c711de', 16),
+                    gmp_init('0x3fa9fa887fe14b233dd3d9bb7b7a3d8c757d7da46137e7c4d8ce34c48a0f6ebcebffbeebb5da52812696279ba161acff', 16),
+                    gmp_init('0x6ccc3c4b43c6dfc99f8cbe190bd23e4db98a2b6fd38b9fc467e79912183d022d828fea07f21840d1265d2aebfde2ed6e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbcfc68eb11202cff3d6ef285d6fb83bcc8473c4421dc848c1e9b92a3e15fda9472560e90428885b45f092baa3cb9517e', 16),
+                    gmp_init('0x5824868bbb2bcd76a02ba3c9b3da7f1a36358cc23f2abf13944c9be37529846c935e4de9afb31859e32c94f74898109c', 16),
+                    gmp_init('0xcf8862e11da8a8486d40667f69a1756d99457dea6ad849d293b250de7d906989d2c7fa042e6c55c5da1e2d0a98b621d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5db0827c864484090f6057e9f95c51f9f1ef7d5227d9e66e4d879531955810fe724fdeb72cb5d2563e3d4b8dc4e8ba9b', 16),
+                    gmp_init('0xcc5aefb541c3eb197f933f21b24239234217813e853126f1f188d08a8ac692b74e7e5c1d35a46ee0b493984f85639a08', 16),
+                    gmp_init('0x56dc2ea3bc1d42a4bd06dfbbd36bb3cb67508f98b1b68d405640bc5c74619744994373b89b547f4b10668fb4b5d7a39d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d50d142ff3a9ef510fdc6ac720be2a97c65af9ca8a4611fb356d8e689ead0a00cda4a81196601e237aa288f5a12aa8e', 16),
+                    gmp_init('0x9d9cd296435350857afb0f2f214cb264f32650d4c414c180fd140db92617668848f8602d4e0d39717a792c34e8595651', 16),
+                    gmp_init('0x996db4f1a3921413894aac116ebd20574d6fd43b5bf129bf3ac06b340a758ddfd8fd12322d38b9919e99d101840ed0fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9612ee4fdebd3c6329eaad9bc40e57d876b5070ad6a73a17a4c8ad8db5f22e0c3b979c2931338cb7895c6ff7a31ed13d', 16),
+                    gmp_init('0xa654f837bc9a4cad0207f062391b6d7237cccf70a9688174ab95b03e7f7754e3743b40ae9592332806b58e959d8123f5', 16),
+                    gmp_init('0x654e3451f2b4a2fe4a1f9b2486ac1cb3ebfbebbb61cc6ce218e7f3c8589a8d4192bbf599da57eb3a1443959e1895c80e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c53ac66189aa4c714ff74ea5716e98029f88ca6ad85b79e92cf058a307818e87b49172e79e0848a38e2bd05d62855e9', 16),
+                    gmp_init('0x2d25686107aa504198543d83a11cb045f05dc89a0712e13593b3170355aca2b25d7f1a0d52e4430b52a4e5021b465f1b', 16),
+                    gmp_init('0x6078553a4bac27bdcc5ba0eee7807ebd557b5444d18a2a908b736e4e67f797f2bb1c664aa4475c6aaed433e3dc2b1fa8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x66c39cb7170824c65005836c9c1d9cb951a1673ce769df58a721a66046cc1c5f7cca3495ded683228d10f2273e77d93f', 16),
+                    gmp_init('0x6022aa39bfedfcb25761429af20d3a27aad726bbda4f03ac62eb7f6586ac3efaf3db5e08779ba6f5db843e91cc884633', 16),
+                    gmp_init('0xdff2e6ea746939e0c5a71f128ad1fa89cde624f1900b47e0859afadea17dae9a90436b8751e2a819dbb251e6cb8ff88e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf4cb251887d271ab5217fd525e96eb33593a6908822ec85933af7c9111dd858017eaecaef5584c6e7d072c62acfcf91f', 16),
+                    gmp_init('0x879644eaa91a16cfa82790c55f747677c21f332d1419b12d052995da3d756df40cd52e6c202ac7f3731e7bd6c85106c1', 16),
+                    gmp_init('0x679f19ab0bb8783abe25d5389ecf18c9f1fafeecd6515d2cf66102128e8f0fca0dd8a34b7e5dcca6792b70675286e06', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfcd8d24a58338c51dd2a4fcfd17d6acd41052c1f6f8822591c2c792e82cbd53bc195ed96005d0680149433bc6971efac', 16),
+                    gmp_init('0x2406ca1781536f7e84ef58ae94d0ad9ead0930db37af3d6bacdf99928a68b98b3025e4e31ed3bd9ad8851c831d3267c8', 16),
+                    gmp_init('0x15039aebf726daa1c7c5e37c824f9a7dbb5bf71fd5a2bae336b33b90f0e76b5b2f6f15a9579c9c46cbb0842003b6b5b4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35ef78666bba38587cea5962ab87e8e1da3b2ccaebdc8c5f0706fe5f506e943fbcee2316ed3b025d64392228deef3a9d', 16),
+                    gmp_init('0x78e516bf25afa695a90a3c1d56b6e80e2e1cb1696b059d5fbfb5a23ca2c99913e9a9ac3c2b5812c5abbf55c9cf321295', 16),
+                    gmp_init('0x2bde5a5000152493598e80b751c35536a6350410a01f0dd43317b0d57c335f967833bce15bb75a08a0d0f2d6b386eb33', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc04bc49e3db2a82a6b9349cb122220ef345a989ca56a8e961e2ab8118b784befa8041fc13f110b2460fdcdee9c618333', 16),
+                    gmp_init('0x335499118d7abac100c313d9bc7566a1c03381e610883c0b5f6cd9a1f1444d4e2b9419ab597e6fa06139eb7798f8b6f3', 16),
+                    gmp_init('0xf7bd172296708fdfddf6d34be8d8b561a50a0d55c3e4b4c3578b2c08231a3825255d1dc2c1277a3d8e0e045e40ca93f7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x9fe75e60cb347e3bc744cfe7a21f9d136c1208a16e6d10061d68bff97309d64284f3b7229f94f7ad39767e91f2a0a497', 16),
+                    gmp_init('0xc70f654a7cbc1d50f2b438dc0301e80127a08f23ffabc943d2f65fc3831571582a744b0be24e4754b552637e9f6c528a', 16),
+                    gmp_init('0x67cc8814a1afa269b4a2154a0debca8c769f0a9ec335834f092902771d54ce629ccb53d346853d38e59870fa2d6dc79', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7f456efb6ab8c92ee4fac615d6227450daa924cdbd4729c6495cc92c7389baee325c571e9b843d760c91b112ea0a439e', 16),
+                    gmp_init('0xf8cfab43b375397d1e1d8fed75df420127fd0203ff638c76b6e8b65737243c0c270e3847d68029757e22d5c72658fe52', 16),
+                    gmp_init('0x472e29c28450a5c7b84ad999aefe7e931ac99528cfc36b33bd3066e50d9f23a34e2ccb882a9de53d3d0792af8d773bf8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x770b9cb429c7b5613dc6919c7c8094fff3ed2c702f45963a74d100756dd20248934b8afebf69910db765875ec96989f9', 16),
+                    gmp_init('0xaedb4b61e9e1c861e2e40f291004f23e7ef377c5167859298c0bf424e265f5643aa58b780f74236727401e83e52c177b', 16),
+                    gmp_init('0xfef9985952a21aa7bda1d25e38752991ef427d26268e78f46fab69eb821deffec63256df96387a99bea05bea10fa63f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbd75de2923cbdd242ee3896116b79aa4f13c0ce5500dd43670e0f4fcfb6bf76cff0c5257ca25ec7b38a9148ed39a8b97', 16),
+                    gmp_init('0xc61c818b30a7a41bb26683154e148b23f75b2aca8c786891f3a452c285429a7ffecd34d53d93001bbdb5ec54330a0680', 16),
+                    gmp_init('0x3fd13bde47ed03215402c21e534820c9bcaa7e6d65376b1d38d1db428ec1774114112e9da444f1b1aaa0b1fb4bb3a6b9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc019745696a9d7f6a3f4e3838fbc42450fb9c2917fffddde88983ef2eb2ae8af9c38d7152ca99a160ea8c1191990b0d3', 16),
+                    gmp_init('0x733a3e00148c57dc97d9db8f0379e99976b73beca5a4e639862daacc44e7e5bab23d960ebd3e5bcbc32e2ce918bf812a', 16),
+                    gmp_init('0xa167fe0cb87a3f2a30f50148e2372d44d99e642157f5a4e2885bc522e14c7a379c7190d44d822c35bfdc1be65c765f19', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd0e3e4f651518f04409585d5ab2a9e08ef27f00d89b09dba151fffa2c715eebadd5a50c942d6d73f6a7591211ffa6cda', 16),
+                    gmp_init('0xedbccfc54efb38084b00aed24bdcb01c818b972bbf3809abddff0a203472607da0b1590002b4e1326af80862eeeb6c07', 16),
+                    gmp_init('0xbbc3bbbaf7542a93cb5232261ae119493f806bb2e4a0cbedd7974d1c222a55f77bf22fdf28c2330a7ce4246943c7f80e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x47ea5669d2523e55a7473607f525f23f34aa4a2c316968055b65d62809eb2d268db4e153b3b59af4d63080eaa19bc6a6', 16),
+                    gmp_init('0xc08a1a5dff3176eeb03115af3c2c36da72237503c9617bfb21817e9088c037ae99c8d28040862634f974ae5e8a05a1f0', 16),
+                    gmp_init('0x238e876dee17aa0b73f2c576783f67aa881900816d34ca697c1c2045a934a296ab51438e4ed0bd43f58a04ad0943b349', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x873db3d43bac87208c05f8045fa24e2f40bb8272725a10ff3b4d31bb7e0820dac64ddaf1ca38523b11e163f2bfa222dc', 16),
+                    gmp_init('0x6fd4c8628c37abdd4190199a30fa9c80e9760436c9d3535cbb664d384c5b29bee9736d18a26792f9d47a9df8c742188b', 16),
+                    gmp_init('0xd89021be46b1b809a7bbd1863996fab95669479d3cfade64ded03ec9dfba627df227e1aae2005d00054be19386ce3dc0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x63ee0f4902bc810ef263be69e8fc61b1c8fc4a5e6703b12377e6c8d29aa9e01c116a6494551ff054a37331daa206977e', 16),
+                    gmp_init('0x9db2c57b1574de5a58a6bc9c7d3d429cd3c63a3162e8906eff9161f2386adf16aa308af53dbd4512aefcdad473906024', 16),
+                    gmp_init('0xd2ef5e260b2359637dbc44417d758b77afb4f148ca548f63a9c7b12905030d5dce8330208ea750fb7a39d81c3de52472', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x50bb53d014a5155792cd55e7b4fb20bca30076d6e10d7abae208aa03e43cea2e2dd2f1193eb183a80ddbe71d26ea33aa', 16),
+                    gmp_init('0xe640a0abedd6274578a87a0392740e58cd247cad480fed5c3fe88aba343dd0d2f738378d2d2f25a75544023706053076', 16),
+                    gmp_init('0x701e55cc5272910243af0fa2f0fc59e452a072f565c04755c5a2d71a56f3ea91c9e9008e609c3226863db82626457a86', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x383d1de892e21fe3817769d1e11833ad414424ccde755526ea013f40dc8539918cef70c30e0c59a205cf83236c0cf663', 16),
+                    gmp_init('0x251349e154d4f10a55636e0109218822b05f612b032b13129b36ff69d53cc634897a8bbd18fc77c6cd534f89b562cdf8', 16),
+                    gmp_init('0xaade0b58e60c8217d4d65528501622d40d4934d31f1ca0443f48cbb0d133bb676d10bf518e1ce14154c87e73ae2db376', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x694eed3a23d3aa6dda7adf7bb942220beb657fa2545c0a1f21ff8baa6246c9cb16b300e44ac30af2d3981061c40a78bc', 16),
+                    gmp_init('0x548be237e9fc9e76190bef9b5016fec09896c6edd8698375ad4d49c87a6567a9132ce572e800ae7cc12362a91284aa64', 16),
+                    gmp_init('0x6c72f7346b5d492d1cbefa64b6948186e7c77285f62adbd2ff6ba47b911a71bc6c4bdf9ba81f67cfc3c0b7b30ad9c0eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48aa5b12bccc6380dffd56ad1c164288432064071e64d27a1a30808682795e40ccbfd3ee064e9326ab69493f0d6b0529', 16),
+                    gmp_init('0x83ca514972afa492153af5e687c6bf0acf822b032d932c03d2b8b963ef709eb697f702f51c4e65361f31741c8dd5b79d', 16),
+                    gmp_init('0x41910c19fed141a6e319b701132e30b37851a0d50ec4961ec1a9b8648084952a2ccee4089f27a9a983183c58256e4d5c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x592fcd74700a59cd772e128df170ca66d8d63913b1c6b7605964c8a50da2359fca02397e89303580642c18b5e00e3764', 16),
+                    gmp_init('0x59b0d521d9bb86cd7c8894b9714abcd520c0f9dc650585a67dfca1ad1b7b293935e54965a1de30b42faabe8f90252466', 16),
+                    gmp_init('0x1fcedd50d30802770cde1474efe3632832c1eb8e6338e4533acd5048b70d9994102f0c347a1fa1572c8421f14ce91d8e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x98c297bc17c5ed6d6be3dc957ab1816668ea5a431de6df6fa4c2842d74ba1c847bc42bc21f10c46270a11070260f14c7', 16),
+                    gmp_init('0xd85765eb6a1735647ba9c76a16a77f5caa2be939f715dc328a3f529971a1aedfb4f9eab49b91ab7dab7af0593f1e188f', 16),
+                    gmp_init('0xa1ac40a723d55ea3fed4fa0d4eba266a12a1e7ba51d3489dfdce8202fda8ba47944b0ea669e1223644b0626fbb3aad7b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa9360f1ddc018a00adc8636cbcbafc71f4a5101395e7cec214cc0600cf171ef1d7c6b14df25d3db1a18ee95148a3544f', 16),
+                    gmp_init('0xdf385ece5a9acad90c5c8631c2326aab7a2f2d5a63a7cba7ecb7f280f94acf8291f1814d4ff42e16362b410bb92146dd', 16),
+                    gmp_init('0x11322162ab95e235e29410189df5f95e383fea767ff1f402b17b3c3eada6e7f127c3d5b5ad4a8d3bdd6790a6634415d0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2d0c5d4edb9954579ba38c6c96f33081a5cd4b091b67b62255676ecd81220461035af4a861478187f879fb3dd224c325', 16),
+                    gmp_init('0x7ad8df0f5d376711b2b19713c555e18c0f73b1040dc4c779c293058de13786b73b3716f38b93ad57dffb7a2b33d87069', 16),
+                    gmp_init('0x8cf011d7b2de0ba14a4954c12b9fdd8bd967b4e6417b4bb6949637a7aea8c1d05c922baf81dc3cbab657e93c0804f9fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbceb486133ec39d1996d5fc0fdef54a2eb9c42d5311fbdf98349bb81434817ce8a11f8476da4eeb2fc4e36cb66a494b1', 16),
+                    gmp_init('0x1634dfed0f63b816c096e86b647a403c3fa53e779204417d9318f5fed43a07192c6112d0ea7f0f398eb7cd31b09dc65d', 16),
+                    gmp_init('0x75e063edfe9e8b6ccd144334060dcad4cafe012e9769f451e12f2df971887bf0e56db7cb2c57e0ffe51044dd27e98cec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf7b1baf71b1284310f48dd943c122300deea9e2b73bf3fd6fd64c81d79487c6a938b5ad4d7315fe83fcd0ff128b52184', 16),
+                    gmp_init('0xce33db00fbdd63c93892b2cfbe1715abfa7b62cdae4514e60259d8b646bfe25da3099715dbaf600af2d492f79e693b8a', 16),
+                    gmp_init('0xc83fa75a2481c08d39b2aecb78f06b560dfc25475b8f400774185c2ffa8b8c0d6a266178f48536ada3a7603d268134b4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7b8bdf800f5bb70e39a6458932762b11c7ca622f56c449f07ccf3e27486061e7d4638d8c5d6d6ce4d0d5b39dae7bc7c5', 16),
+                    gmp_init('0xed6542a57a521d8d45bc5a683510775fcbe25c63f91b41aac9fb2dbfc4901f108bcc6a83f0c40df6d8887e12ee9d788', 16),
+                    gmp_init('0xc0024c33776ebd8c13f94df88959a5a948b3c809351f4c7fa5bf2670a756a1a829c32c3ed66e0c1004464ef6fb1ac094', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9fece3e4b6f4289742036177cfb29a38151419d6ee55cbc857833d8d895570f5f8e1313135a7a93dff9fef0df46ec99e', 16),
+                    gmp_init('0x293418d94fd1e0ee8f480710d0b48fb11ab9523270da12ef4b0bcdb97c77ff129e675edb16a18ec823b92dbbd1d53b35', 16),
+                    gmp_init('0x26b161e26952fe1d579e0641753b1e7c8cf591bc34afb3a126f3d99e671e5a63838e277c98434480a18b1dc0ad8ff940', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa2f9261a90ce03efa526c85e58bbc8c453ca729fa726d466f5756706e26c8d6cc18201f8fee5a0a7b116236c1cd23f20', 16),
+                    gmp_init('0x1035d5fb645767aaf09be1f1eed74196f87f3a8ed1a54ca14e6f90322158758897e1fedcce7898411a8fd9ba749751b5', 16),
+                    gmp_init('0x534ec780f3fe8441501b8aaa6d9fb75588a1f5aa3fe96f4a71292fb01335e73268c732e37c31ac84110115c14e022553', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x99adee1ed5cd817d1050da4aa66d251fb9291ca926136c44ba6c2a0dd2167bdacd6ed34788fd831886017d5b412be775', 16),
+                    gmp_init('0xe7f10af5ff2f049660a2dc28b94360d935dd744d09c5e2e0d93a93f48e1bf23be07614876a033bbbc63ac6207f419db2', 16),
+                    gmp_init('0xee9aae5724645b0e3e47a397818a8092cef78e7ae481877c16c55d5e650667a6c266b48bcd5de21edc3f7739a1437f5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x103d82c4ac10a376b943736fc4a9773bdd0845a71e74341274362372281338c2779212a7e6fc228146deb54fe96c3e83', 16),
+                    gmp_init('0xfa1140a4b69e089c1417886b61ad112ce9193c608562d2794fa202be9215112cb0005891b664b7f20f10be22ef3472e7', 16),
+                    gmp_init('0xde8536494782819986dbcdbed79d1c7e35af5eb3e7d3ab18695e97b7b7d58ce3213bf09f9fffb9b34d8ce064d093c45', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x708f17a39a4f19f9324dfd583be68a82c596ece996ff64165f77044997bf0c1a241134dbbc7fe7405a48aa4bb7fbe742', 16),
+                    gmp_init('0x49e319fef96427464eb4dfa1b1f4836b6e71bb61d85b8f3355d992ab2ed612c4c53646303a039e9a7ff77bda915ce44e', 16),
+                    gmp_init('0x33493adf3aa3a435e9c8dcf1ac3f0324eb0da85cd91b59baf0728d03ac4edcff516d31b9ed0a1881b1ac29d4767d165b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x498fd6205adfab50d6079eaa8536a8146f7554465d62dc7cc3ce1f5adf1a4b58ef060a50aafbde0f0cfbc3668ff144bf', 16),
+                    gmp_init('0x54b1753e8553830c9e75cca296d59274bb9cbc616f89da193f22ea1f10a1213b118323a15722332d24412a2be6b34d5b', 16),
+                    gmp_init('0x99b7e6785bef4663dffe31bcf96e3fad990f3496439c79b620c14bc9bf10dc16e65c6e44e4f052d0625f19d7f4e3942a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x691db28569619dbd4e6d194a36c9ba1fde4a0fb18df30beba938261e2d71a694987312b622e2166f1fbaf5c4c3244b80', 16),
+                    gmp_init('0x3316581bd7d9b2e161ba5888cd6c443595a583c221db3add9bfacbbcf099ae321a6e7424cdb243e0376570b42b970052', 16),
+                    gmp_init('0x6f6f0346d14dc785d3f644809476f83a0a1b8b3c02b6cf7a9f72d8990a58b5d49a1a8872a0c50f1fe8ac1d20a48e796d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe6da2179c7f13e4ae0b62266d5b15ed5897c918871ce532d3842e69a4712998e25277eb286ad532044c496b8781c59', 16),
+                    gmp_init('0xea025a87b2290549183554cc410f545e6002147d574ae84c90c87346b8b5db97d2ffe7f16692d8b366419c263b4f0965', 16),
+                    gmp_init('0x2d6a42c859c2f8627c2c3f657638724e6d7ade0e01b850188444e62042688acfd772ef468b5e143526b42d73d3ec865e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc06241e2797d0a80626748ecd61e573af820b15a62435c71abeba213f614dd8c8be59ff57ea4a85718701ea7bd8bd61a', 16),
+                    gmp_init('0xbb207eb63e41e426aefdb40cf4f6a6ee5aa091e5fc639fdd386c49c41f946eb5027708d5828e38ab00aad845e55ccf4c', 16),
+                    gmp_init('0x267f019d99c3df654e36057b94b3697b5532ff51952eb1fcfa0241d5f664fffe7ec23283518bff362663c8ad9e2360ff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfe8a62cb21d5cc570b30dd01381da0b0ed2e6072db0240779dc6ca8431acd3c0e61778ef4f312fd8aed6dd47e85e5a09', 16),
+                    gmp_init('0x583ccfaf25c47829620652ed677b8f64164f31af8a156738b9ffd082c84f27dbca738af27b2d0bfc21af22c9b9bc7e43', 16),
+                    gmp_init('0xe9d9eb44fd7af3d687bc423ffbbb58027007bcf261d8f684ec2110e26b3e4a39334c2d8bc4388d6b108d13ec0006782a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x2336650454ce1584d42740d3e3ea0030ef39e85c240a84dc58de32dbe40d97f5533f11e85c139a2947ca01f40501461f', 16),
+                    gmp_init('0x4664f98f4924ea92257b9d65965e317e0b7a54ba54831c023994abca6f6408a9e0bc958d146cc96ae03d7ef48ddf922a', 16),
+                    gmp_init('0x9e02df1b83de02d2b1cfec16163c8124b4f426b903f7d98ad5767b7e7e9bb5ba70c69004902b487d1cc3c4d2c3853c55', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x682f28ad9f3f1aa5847df202707cf4de04638c3715a42fb4b2645338ef48e73b0b7abb3e3ac80cda9542a6b72c0d40ed', 16),
+                    gmp_init('0x3ec3ba0619028fb2c56b353666325106c09b331bd5b8e9546aa21a13a10a5775c22351d87261ab6176547769e1955ca6', 16),
+                    gmp_init('0x837a1b8ec0d91dadfcc1181bfa380a13101c63f1a6c912d28038f3729e1ad3347dc3ac56c34bf238fce76917b5f49d40', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9d88c5e1ad31157349cb7e2ef2edafb22cc051faa9976485d0cc31ea08c13cfa964036dce49d357f3cd1f635b619d0cc', 16),
+                    gmp_init('0x30cc7870e3941d271bb3b07793e429d1e7cb482c24063b4ce6b6d022705955126cae7d449d8f7d296f9ff1b1b1444873', 16),
+                    gmp_init('0x1310c246d9a2e21e7ab22379e80875a24c7c7783bb6b21b42ae1b16a05ab65e99344714ce54c3d063c27f08c315a82f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d3430352e4d1bdeef80402d696edddda9beddef27afeeedb177d1c52694c51d276a6bb448002af80026a3c922c8a2fa', 16),
+                    gmp_init('0xe8db80d194546ee2be32ae005db8ed6191313c5525746833c96f1df9a20fa6dd059731703302dc754875101cb54995f4', 16),
+                    gmp_init('0xe33870b9e85df7aaf28932ee3c5569b45841b5e35983519b327667524d19ef802ee2713f97d393c9bd74606daa2ffc6f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6b708e81a693287f310cafc299f0a86ba018a762db1709b2cc8c70208bc2e9746c38e4be1f38bd2153e2323663568894', 16),
+                    gmp_init('0x7c3cc78f8efe5afb0e1a52270027efc7110af5e2bdf2a67292d6cbe92af2bdd4601a04138d55813907483191098b4cd1', 16),
+                    gmp_init('0x7fd35e840608ddd34312166f6956eaffbecfd1e0b7ad9a0eb86dd5a30041324f2ed7c574b33f197fd85820a0e90a8bbf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc0d0614b8317f120ff26538c88925278df83a160d488db3470c1818b0aeb2d8f89f7909fc6eb43866a29db76794c936', 16),
+                    gmp_init('0x59f16e60c54db458d5ea3d029d03b2ff323699b56a92985cbd5a276fa9a1713c5781f6f312c65e3342608feef2609af2', 16),
+                    gmp_init('0x5ba1b170e9743e5922795b3be15fbab112f7c4b8aecac073a92a2365ef8d7831f2f99c45877e7b90d85d132692025f1e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcc4e9eec9175d32a886599cc5a3380ec85e80f15b0db18ba70287785ef8e3eedbabdc0ba6c39715182c359b0907cbd3a', 16),
+                    gmp_init('0x30fddcb374fcb2deb31363c8db280439a915fe1230de199f2feb1ef6cdfb23f10f0844f24242763c1e89ed3446f20152', 16),
+                    gmp_init('0x33b75e11e41bea9829157d90b4dd643f42c039fd4b2ef2627722fee792ad52692973efe6532c51d1f5f650296b1fbe24', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe0a00ce76de35f715bcefa8c45005cc248bcbcfc28f188238a22dbbe6195d25c3d8017aefc776497e17c492b8cf34b2e', 16),
+                    gmp_init('0x5d782beef69e2e0c25f02b1a95e578cf9090d029f01bb5314b8f1642129afbf9398dfa61a7dafee2d345ac2f770f1c44', 16),
+                    gmp_init('0x29406f61b54aa006fb05f0570e385068625a64fc8cd41eb8e28ba46e1449a081fe3670254dbb1a5cf94b63630acb1d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4efd0a9e6cbe7c99b65f8ea2fa8844e2b4bec68f4fce708c5aaf43d8768ec28517b6a66067d670954b9d95bf245aa9e8', 16),
+                    gmp_init('0xc7a7fcdb1b9424db690cf2722d685593e4292dcd7a15d3a8c9296a39a691e9821ff4c90b0a8a6f9a1e4d08a29e5472c4', 16),
+                    gmp_init('0x2d8b86f1e7841e2229bdc0f189ee3e5db3f2daaff277203e377679fdce3b99575d31d6dda9c400b1f039ec6fd5b92904', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6bd5fb17c84ce3cbcda48697edd2ece49af8933136d03f26c9fb00d416e737c3150b080fa0e02215b25142e16f6fbd9a', 16),
+                    gmp_init('0x206c173ad4b6b293c37bb89c9116c116831228eabcf57787df85c461a2028f12cd81cf05e259ed84ee10c8d173011244', 16),
+                    gmp_init('0x9436ad262a74660b4df8a9d7b468f447b3d6938db7b3c0c76c0785f8a115817710adf1e0b5b3f0f224bb6eb31c47e785', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xab79abeb1d8179c262c76d17d3b9d61210c6fc3ecde1fe509887d0286c2cd8b46c0113e31967afa243863b99bd29976a', 16),
+                    gmp_init('0x221cd485ca1b3612d27c872c6fbda2d59a468f3ac9cf4c119086858095d73cb71cb9418b321a68cf9909cb70f6fc37a1', 16),
+                    gmp_init('0xa3eca92ca1f5fab1dd0204f79c0ae4d51498d3da10399863b439e849358ce4d8f4306f7e2cd7332aa59bc703651f6ba9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4f0b4af12c810e37f48287f834935af15bfc7a15329cce052b3163aa9cfd882532d0b1f3b91703aee773f01491714dfa', 16),
+                    gmp_init('0x3fd64a18c1312c1dfcc4d90fd6cc828bd2343cc821e9ca4d6c4052bcf70eac84fc9d1cced19be79e86e9dff098ed282', 16),
+                    gmp_init('0xc5ba317440687cedf37e21cc432415a52577a57c05e670858b991981220b1441f1386c0f4759d1e917c64f161a8d7ac0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x366347084f45514a11a3b3916e3e5cfb9330a934b90643b60f32a35c86c2c77bd0a7811813eedda77c1348fa4e211c9b', 16),
+                    gmp_init('0x2cbeb14a3f926cbf5326e1f418e60fdc3ce792439d273c8d283851f41360da40a6518b0408cbb6bb1749c15cdc0887e1', 16),
+                    gmp_init('0x49f858b975a5e573bd8aea05908561c225abb130862d20fb2bdec4b8b5c0bf5a40d4f8d68ec179427979085fccc3aebb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x801267edc6e0493eba12d163b5c36b34598f6c282779347b2ebfa85fe272e7e689d39d9b917006738d6393a5ad16d389', 16),
+                    gmp_init('0x54de4b72e5c1dbb9964dfc00e82826a1292eafd7eb18d7ab9c08071ae81a0526ebbbc9693b8e193b8510a7a20022eefc', 16),
+                    gmp_init('0x6eab764253056aa017022051018c1ba05ab2e3b7b13ab1a023baea4b05eee7f9d27b7326b70d7ad148b8c4e15a368863', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe831a4d7591ea5a3b3505428be3df1d0833a6df3239532bc64bfe2e047c7f076a04b0ab493a5b12b5514627bd2efb392', 16),
+                    gmp_init('0x148a31ca4bbd7e06d605c0b2dfac6709efca3879b75e00d63d2f241b5fbac0afbea72f2df1954853f984d4f5d6609dd8', 16),
+                    gmp_init('0xad51fb02a291417ef247cc5860971d1e7dfbabc4ff373174eb13e7999ebd07edcfd4faba79c90c85a929e68e400aea09', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x75237aef81aee3d3e9567751da6d45c97ee2253b3bd950a628aa44a95a8b470862d1d079155d31d008634cd758726091', 16),
+                    gmp_init('0x8efd08650bc55fff2a8e5d3324daa4083158fa1da08446d31de36c19e16b36b7c5fc9650e6af54aae2c5fe77c799608e', 16),
+                    gmp_init('0xea7577a2b9a4bae0b58ae38eabf01cd9fc469e54f77e07dde2e3b4147450926e5a2d167bce3e7081d818806d0ee3861a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x67929c7138261d6401ff9bcca4312ac77ddd0d1612309fbfecee1d87e1921babd7aec50524b76603cd126db48c781ea9', 16),
+                    gmp_init('0x6fb716b03eff677e6b5cf564feb8a4a374c64793f12879507babf68315ad4a00c363836bfc131936d6fc048d3d7cbef', 16),
+                    gmp_init('0xe9b26785607525413bf114724e1784f257d069ecc4d90751e6778eb10ecdd1b06a093f15925d48ce42e6269b0adf5472', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e9f1c04cf099bc12fdbf42964598db72d64479a6e4822dae031ac052e203f6bcf7cbf2e4d2f259f6f063090094bc742', 16),
+                    gmp_init('0xf70eb7a25f299e494fe68f9fc1f145cc08c99dcaebe0318427fa53a5f4c1b7f51dce53036a4b1ba40cf79c15b770592d', 16),
+                    gmp_init('0xa3a25c3aefa25091ba684312cefe1b6345aacb0086c9f1e0611c506c24aa97bb27fe2a294790778cb53882fee6b86f14', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfb6f6da7f02fef8fbe368555b26c2201b83bda3ceda3e8ef30752d8dbbe4190540228711508b994f72e6abb9f18be840', 16),
+                    gmp_init('0xedc6476dbf0c0439c5745b94f220a653771745b22d42ace054864883c4dd655d316ad9c5eecb19f853189b07eb2fd7e9', 16),
+                    gmp_init('0xb4dd11288c444c2d856bd621f0a1237d13109c9b8fbf212ff0c98ae21c11217be7f01b38044377625bdfb2b56f9175bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbb38f86f81e43397e9059cca3ab44b7690fe3ca3441a8202994fe22db285eae159f998f7d5011ee45406bedeb57a8ac4', 16),
+                    gmp_init('0x69668b562c9b3e996f1ce5d81719629295f885d279f0e1d4babf516938c688343c83a9d0259caa0af2b45ef777cdbff9', 16),
+                    gmp_init('0x6dd8efaf8c9c081c9f4a71ce8c456aa20457172dd7e0c4c81bf7d0839e9c0e2aad15d7c5a8a440d72acf9c83e74f040f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaddd5d879a50d4ac3c7f902166e5f25f7da067232885f22a65525fc27a4b6272b816f3175fbf430eecc85afc45f01326', 16),
+                    gmp_init('0xa56d25ab189e764df7b10337ae8fb1459f847f4fffbf134132160c28e8afe1572673d0c08aa35d22201e9f1c3ca88736', 16),
+                    gmp_init('0xd7a08e4c0eec078aea2b95ded93da0a9ae12ce807b6093b2db1de6966d2eb9824ad8fca86d27f2568093d7639a735532', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa1d90a1f2ff0ab6f9ecd8a31bcdeb93c3bc98c3b1e9b5c46103a86ebc8a2285b2bc418569cdf26be6e33db4d95547e69', 16),
+                    gmp_init('0x17e96709e99b5875025461c400b07a8ab17c654651f2583b40bab04de3c25975196d4bbe051472d4eb274499f867e0a1', 16),
+                    gmp_init('0xa5c6881f48eb5e0af873b3e87893da521d4b015f085f1b1d9cd9e75113ea10e59555e493722e7cc51c45babaa2749b67', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x28e68413a698c61d09dd34e4375df437c88de334d1b98567d607b5d83ac518a6b8f02b73015f3485661553e931edea0d', 16),
+                    gmp_init('0x1a09e95130488b3597c89410e560c873eb297dc91744be23f5ef19649478921b7eddcedcdf91056139dcb92eab73e9b0', 16),
+                    gmp_init('0x95f02c1fea4dc00dc53d5c37005d87748f428a31361d73442f0b301b34c9be72726341d298973268ae6c5e9d270b06b3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb798ae5dd98bb3ba7b762f342ea7742808b85ab0e9feddc5eb39f4c11586432dc4f2530cbc468092a77e8cc3e693fdf6', 16),
+                    gmp_init('0xfd20de472a145a20adb700ca7e45cd905af6319ed5627579a873a7f9b812bd1f31159ad6b6b7f908fd8cdbb42085123f', 16),
+                    gmp_init('0xde8b41fc750a617281db1a583db28f784ae3916c04849f1aa54bd7738d3217ef621698bf5b03d83a82d7e00af15a7eb8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa9c2415d71fa8e754e4cf5daeda4598d8a57601dceda1e340710859363f4b433390344405befd5dc15d7083000d371b4', 16),
+                    gmp_init('0x28952f40a6bc52db850fe0d9c79b1bef042c26191ecf22090a9df31ac619305529de253748a13e045239c03440ddf5bd', 16),
+                    gmp_init('0xef3d7120038b603b663572a1e20945b8ef1a5468647f45d6f23dec06eb1ec934195404335e4011625a52bc9e05516bd7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd36743fb0dc523761ec3582c75fe4b0e8a95f32d559a73537c7116be491bca0a00eed67bd3a4a458a350c4e1d8d060db', 16),
+                    gmp_init('0xe2e297ca01adafdb76b0d223a47a7106b92804cfdb555fe797cd97951293966d689f3e1933cc6ccc88e53c7e36516b3e', 16),
+                    gmp_init('0x98d1bdc4b8e2e21a6b0a3ccbb21bb01e7a777e0a5f47127d491530017dc69a266765d50e808676ea1bea371ef0bd28a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x79a3157f469d78946bfb21e0dbd6f46adfaff53b4a80a1dfc480442c6a8d8160c2a16392f055544799193e34b19bf55b', 16),
+                    gmp_init('0xd374e9b12beaa5194c261ec1b37a5f742c7ed1c9ebd7c226706a2deec6be33dd7b843cfb5b1a61814f885dd69a3ec64b', 16),
+                    gmp_init('0xd2ace6970451973ffeef7b0b850d13caf54741f387c6a8e960face01668e1f475910e1c31cb2f4b615d97a66f1fab543', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x925f362f190cd6e2a620f822ea21bae14beb85b61c883e4cb38d8b451740c6c4b4c8612afdb94b4f4983859fa2124f3a', 16),
+                    gmp_init('0x277f894e89091c5dbe0ef046c74e5b0bcf44c193e04245e01ece89865cc7be75e514246a0b2f795b39e8012d9967ecef', 16),
+                    gmp_init('0xbd69073dc549a4bd68868c400b9c0661de1bcbd16452a4860e4f1cb090000d758945e093d9cade77f507a06828adb30b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3a56363409b100c6a76dc237073148ad86e69ac1aeb8ad841cf6c0be5ffe1a3d13e96d542db70d34e6bea993e3641357', 16),
+                    gmp_init('0xbb15562c07f3bf7b94ac34f33db00db7d77a02fb2e2edb407f4d56b34fc254f9dd08544d924649148361d3dd16d90745', 16),
+                    gmp_init('0xf7646147c527f967c48bfaff9784366581dcf415e0f282e76804b63a9a664dd5fbb8c3e4d6220d39815cb57471fff1a0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcee2fbef1e4f135d89d46de7f26b994df5960b1abe1e0d578d7e4eddc1d4bd1c9b99faacfe250ec4775cc5b17cf78bad', 16),
+                    gmp_init('0xb83b0bcd4d17c761d78eb8e9c7e2a4009abbbe30162beeb36005f49473f404a9d02881afd19b17a088fbe2dc6f44be0d', 16),
+                    gmp_init('0x8ad539d48591825007103ed42ddb785d6fdcf45292782b541e9a3c2833c080c4bb436c06ea667462d377543db57f0a8a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc8edef4fd9756b2a0fc7fa1828ecb26734488856ecfad7347bf90749887911bd29d6d8d2bffa4ecfb3ccffa6b63bf789', 16),
+                    gmp_init('0xb11ee49269dcd61013ae9bc8be2a2d282abde6659630cf5451eaca8168f942713987dbb2c3c455068c174aaf3e3219a8', 16),
+                    gmp_init('0x2534c9f4287dd1162e73976e32aabbf7c340cd3e4cc90d48a06831756b15cca52af5a434481a0e9667ffc08f371f8925', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb9cdd52b782a3035a58d6b3f3e9dda63d6426c06e6c9f8ab39b4cb27df5c758fb800aca8486a92e6f3e9000ca3288c5', 16),
+                    gmp_init('0xf208d10c122e4a20c3df6dac88915eaacf6b1287b32be139e70e2d57ff23e3af6703cc0f50333f8d6c7ac8e926cb392d', 16),
+                    gmp_init('0xa85f7d4cfaf60540dd416d4d5fb989d298d02bdaf1053696531d5066d7bec17516d0e78301ef7ec1f5f66df6e2f7199d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa1f42de7f14bb4d15fd8c9b141a04a3e98c0b776798463a7b0ffaa4354efa68af1cd0bdd23bceca6d4cf66d9cafb1d6f', 16),
+                    gmp_init('0xf01a23da1938bf7594db2eefe9f61350c42c6f2c48e3dd2c4c20b93d3764157464fc7d092666ed0240d9012a2fc823ff', 16),
+                    gmp_init('0xe4744bdbc8db5c25e814b47144649289c96b6efffd5601e778d25cd8f03caa2328d8dbbe5692562848edcaa7ddc69a56', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbdd54087562c6d7b89ac246fe4eb4d548c1601dd33c0116cbd5942c9f91580ccbe67a1d276037b0172ec84baa27b60e5', 16),
+                    gmp_init('0xc6f43309ae140cb4026547df0e940724d4295aa13a31ed3fb988743e52c04e0b3e446467b03fabd94b8e3d20b80e476', 16),
+                    gmp_init('0x5937dc42314679deb1e9a28c1d60f76f3578ad0cebd6ca727a1e9653793eb7b5bc6d49875866c588d6f47671bfbbc36f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc387bd57e687fb7846ee5ca15ff883757e0352344dda5b7470512ff8eac856aaaef3c4ca4253033ebcad600926e41747', 16),
+                    gmp_init('0x1c7703a626a9fac80d4bd61e97d4dff88f256653931e3305ac82ea05df77e00c7369ef87c4696879b6fbf0b227d19aa3', 16),
+                    gmp_init('0x57865c28ef23ffa6f3de0a1e2c34ad78f3d0300e7e067e8543f7e7a1517644ecdcf566f38d60e3b4fc339d96260ca575', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6be8301b1b4ff0c4a27207581a99666985466fb0a51680662ac7dec257670ac0a9a13ff1542714a52895cee8f110d2dc', 16),
+                    gmp_init('0x3976ca4297537a55c8f9bc3825277cb371b7536727bab9bfc2086735dc7d330fb919aec3ee946b256906a6557aa81204', 16),
+                    gmp_init('0x7359a9784febc8de1ee67079b492b70ed153fc932b58a96ba18a2955f0837b2927dcd1b41c44845206352b1af49162c7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x64ec3bc353f89762d879c022200628041ee9c8295cbaa67168bdedf4aa209e5337f1d77a784cbf8f9f90fe708bf2d8c0', 16),
+                    gmp_init('0x89ff969571b7e580c3bca9c7414179b5e528a36576fd1ee01d871e845312b91e288fb13a6d688130f43887c76c9b7ece', 16),
+                    gmp_init('0x137aab36a593e8866e5929bedb2a0ec9e81b9d44d0d8cb841f20bc812bb96775cfd4277fea2bf0c7149c638f9e185afc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x903f4c8039dbf08e5b40c35e46497c6e031357ac3edaed52c366091b41ea340215d33e2b82f364dbc350a0e24b208cd7', 16),
+                    gmp_init('0xe85bededa4c3cb4594e2ad7d66a43a6997d17214ee145999b7976387fd61ba05b6124742dc38efc5705e1699f63d02ed', 16),
+                    gmp_init('0xd3ffdaf57586d510bc395da05f177478b70f1ff09cdafa1e7440be457ec184fda4f4bfd7127426d19a3fdb0b80447a8b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc6012c6a52e625c3bc1d50d02b6a42c2f2c650eb337711213283c5f8596324317256da198cd7e9b9217052e1ecc420a0', 16),
+                    gmp_init('0x89b37f6050009cbbf259f478ad7c3ffea156c92a5d49a73b442b64a89c54a69ca89a0a2c924886b150c7db71ddee786b', 16),
+                    gmp_init('0x600fbb0f5a4d5aaa268c42a669c446443c5aa547d48a05c0ddb637dd4ba41da2cbc182c310a0083615afd2a54792eae3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbd5be8d5d0b43e840559da1b7031f8dc577cae6f7004aed2f41087090e83dd1245dd6badc272f3e0eb204ff87e929c6d', 16),
+                    gmp_init('0xa161401381c9b1b5781a7248fbd36a465e836f3a72618a5da53ac1b2d2ff7dd01830bce734dbbc1e2c1f1800a81c49a0', 16),
+                    gmp_init('0x3c88df9bc4af37ec696011be28f0c5f8bbc8658851853def8b50de6067779aa22345eec1b80adecb9600ab41c1088345', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x937206eb3d60b5f0ff1327833f5783f0a8df675996403b8a88d69d5890d932b0b1b5ced753d6b37ae4cc8dfc6a91e53f', 16),
+                    gmp_init('0x16f6496501e346e48e35aa09de2ed24aca2d38bb8004072ad4a4b533166a6fe5a5a6b7ac7e118fe704857795cc84668b', 16),
+                    gmp_init('0x6939c37bb794d462fc23c3870367cf01a6d09477394fce143eab73a61be8088e4344b0c662c12101c29b9e0df4ffaae7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x74636de87a049673637a37d7799413b3e035d42c49f649acb1cdadbc1ec93124958d3eff34a687d6952b7a442499f37d', 16),
+                    gmp_init('0xc19997824b888248157bf330fbcce50b86cec416293555c91a4096a90e8f1785b15288293e2f77d425aca7299f3ac849', 16),
+                    gmp_init('0xca4f18dc13854351aa10ce4e548903f8341d86e4c992faa19036ce8bbb485e02bad8c5500991270ef2b0656b10f3a9e9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc14fda5c9d361769c5ff305398d81831fa890a0b76b7ae485c431033f6b96f71c2c11a0f2f283a7aba33add68cd44822', 16),
+                    gmp_init('0x52a2df550d410ec18962398ac1b9bdcb7c4d098e84d975d36f04a2e8cb4caeaf70087c59b1d3a3428b371ec6202241b0', 16),
+                    gmp_init('0xbaa2d2a20e0e79350d33ce95a66165638a4259c28980e758d3e8b1a70713cb493fa0605953cbf2616ff29936ec44106c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1b0cafc5d14bc32a653e7886c556c0f918cc9ea059f6fa6e03f725fbe1afb99f9992ea514d6de2580f26d49d958bc4e3', 16),
+                    gmp_init('0xae9c6d87081a4858fed17e4775f38ddc08acee4670e0ce87db5df133841e70bb6d4632be70c17844bd2c4d6d90f787fa', 16),
+                    gmp_init('0x7da74980aa8bc21d327a808c6fec0af0df6155fb8fc77108a337410a4f865cda516cf6a601c78b7b737bce7c94cfa74b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9e5ad9d9ed7ca9d0a86872880250b27dcd178091e6e1109bd6054585e3e7cc2ba12d9aa5bde7dcb7a9163178ff8820d0', 16),
+                    gmp_init('0x23e075ff11d39bccab1456eca66d997d4e62b37314a28efc68c0e30049f3e8779479049421809d5a5ccbb53fa2222e98', 16),
+                    gmp_init('0x9bcccd66e2c331c38571e5ce8a6757598e6c80e8390d10ad7228389c08b0651b09eede55f655d308cde9705758030d7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xd710c8865ebced90b6c39612a8ec971eb13ba5a00ba0acc82f30e572eac7d09e3002bc93d179f7165844582a3ba0b763', 16),
+                    gmp_init('0xdacc63346a4ffe0ec8bbe4c8c31e6e929e5cc6c422daa91d8814ebcdd3f2e1bbca70f6b206492b6eca40e7b2eccbd1d1', 16),
+                    gmp_init('0xdf818a677e2ff98665aaea647d83841214cc3db9bee4e48e5b85be6b0a9f50c2efebf6a221bb7e3b67f4278d35b089ad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c7f993d0f317c814022fe0a0b768769a448273beb5edb6b192fd6d6db94cd77a3449c1705a45673f1d4a0c693f5d238', 16),
+                    gmp_init('0xfb5fe523b7c1fdfcae0360a5e572f82b17e8623d54c6c5799f8189ae480af1ea16c211a9fcb2f2d73e3ca75ca7e6285b', 16),
+                    gmp_init('0x3de2639cc0f9bd3a5f377951c4cefacda75742778e7aa70222f01cff54003f0ac31791a6ee1f21a7862fede65e8bb707', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca33b7ae1f1f0f62ece386ab633e30c1e0700fb49ea4f5d82fbc8501bc283618eea68c683dd04b90042a83d3c2ab7d9a', 16),
+                    gmp_init('0x777a66f41a2e04b59cbfe7b5198855746f1bed5ab0be06b92be705972de1dd39d7e798aae36d7863a09bfa4b9f03bed6', 16),
+                    gmp_init('0x6a54c468fde271f0c3ee9ec02a3c87ae426d0764ab140a75690bcaaf56563acd3d3d9281a50b1e8c219c19bb2c82574d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa0e364cdde576d86e66edfc4ee255c7549097894353a63bbba9aa77d275102ea26465e9016b391d3d83678a93ea63782', 16),
+                    gmp_init('0xc2d5b857d2ad0fddefc380bdb097c450e9e7b5ba876affbc8888b1aca3db529f22be04593d7fb4c2c157b73b8ca9b40e', 16),
+                    gmp_init('0x897c368bdf19283620fd50683e03d552c068f65462e99b8b779c9673da93593f423cbac8d662102cb5ce3cc6c4f677f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe3c514bdaf85be0a0b17bea1d80d2472e813c757512c7ec84b4cf61f4749c83747e678dc76a050c4c9013fca9ad4e9d', 16),
+                    gmp_init('0x5c13f3a3ffc0200b42f75d32d4a2a331b55592f860879de8b3db7d600d92b9274b61abf63592b726d0ed9d851a0f131a', 16),
+                    gmp_init('0xb7e46b59fd7e5b8d9e5d68a366c1bc93c23addec93170d30201e664104c43f403d6173e2e186b092ab339826414579e6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaee5cf9135762f73eca4c82c1b93aab22f470203cec840541bfeb614ec0169c2c850db80c4d2a2412880523f0d3ba0cd', 16),
+                    gmp_init('0x4143bc4a7b88823eac6f7c7bcd56cab299436247776b1fb5201016ff2f6c571308d0fd296b255eb29b1b8c7201624556', 16),
+                    gmp_init('0xc6492130034f877e12661686166e50060fdc6c48ac5dcfd6bde29e1a049242680d54994b28f8863557010bd38149ca3a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x784aa96af786f09f9731060ad526cc472b5960f566758085fc155cc65a07032f7d811ba1c8338abb17a0501793eb60a2', 16),
+                    gmp_init('0xfce4fe3d65a0ae11f0e340769d9174e314e115249391f594e383ef333fec86f4e6466d670c62a2e28fb1d165607172ff', 16),
+                    gmp_init('0x37a770705e884d0a1e3def34539ae795b9307f0435d855bce1a304a3aabc54ef9bd3e5d473f875fac9e4fb53958dd179', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x357b50786b6858ea7e916758622589c1de4c30f6a3091aa2f3ce0ce6ec518f074ff6767bf00c7faec9bf219dd60ad35f', 16),
+                    gmp_init('0x5f6aac0e9a246a206aae588660f95304098b69e42b8f2f4828c57da696a6d39067173c26164a2e66437a4cd43466e94d', 16),
+                    gmp_init('0x8cbc584f8a0c45cc148a8660401339556182ecbf4fd54c1e6e6edd7447af06bead1ab133bb387e38a8fdf4ee858649ab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe527edbc1c2774410ea8547bec564e912911ca60d06c772cd8a94fbe5bc68d073aa14dca6c252e13d7393cab6c81df21', 16),
+                    gmp_init('0xab63ba7b6cf9084e3e2dec8c8dccb1bc46404f5d8ac9d0b8d2569f1a8ed2ad566a25ecd639804ed7e5a87e126baa1b61', 16),
+                    gmp_init('0x9600a7189196577c23d1dbda2db8ca0c01de3214c9513d09fae760f41d095b81fd83771a480136f75b672d42eb72f00', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x896223c58f48ae532ac4018b11b57df95a6e53159f0627f094bbdb8acc2eac62506b2e3791145c4e2747833fd7efc1f1', 16),
+                    gmp_init('0xfa509e463ec08691d07ae36d1453c9391dece7ca05b4695b0095babdb3b3038665a5bae72e1f86efe9a92e9777cb5bfd', 16),
+                    gmp_init('0xd433813f354ef7bb2d11086eaba4da6b69d2b64b93c2d3c771549d4fb6a453301a734194e74701bec30f079f6d182979', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c7824a23fad2b5fc5061cde897486fe211e9e83dcef5d634243faf0415ba08abae3c1fa28bde9c3285d1696a98ca756', 16),
+                    gmp_init('0xfb2d05a5052764a97a99466a3c6a2abbb2f3a61e027ea841659478069bb016511f91cfc0a55e09f2dd604b36b5e8c9cc', 16),
+                    gmp_init('0xc23be102a3d4fbfcb508da8ae2202465a000c156e8a511c09be2f973abbcc6f1fe35b7d052a6978a090f1d05af89cc5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6005c8e370739595262cca9ddaf09db8f2682023ed33d295546e6a8dcc75fe224959daba838e4e87c9c3e35951f001aa', 16),
+                    gmp_init('0x3fa3bfab35a4ab302cc06b5da62290bf2c705ea287bb2a6858b32b740ff884f71854aa68e90460c3c3f487fb0afa435', 16),
+                    gmp_init('0x3ce01a5dbc31542dbcf8e0e4c681a030b4981b910eaa9986b13ea54b877d8273570cea3811b9bfbeb273614a43aed8b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c85610dd5adc0ad50ced5353f3f43f58ae31f1c4b35ca22264ecdad0cb3afc99743b1ccf9f3e85ca99a698a5f09737a', 16),
+                    gmp_init('0xbc03c20ee38fefbf46b90da3008ae11f48eff8c57271da3bf33a3b0b6df349d9cdfd79165b856d65c545ff10a43eb473', 16),
+                    gmp_init('0x64188ad93621b7963a4bd6758d71c04c2457258ca53c5d5cc5ca7adfedf75e956c3e8375a43732997064abab742985fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb439da826a1453c1eb455ecabd980624fb37b4a0787eb095a2aaa53b4bac2b259caceb53181094dc3248b80ad81f4e57', 16),
+                    gmp_init('0xf6cdaea7b40be6571204b48ee5b71107248d68eeb0ad988fd570008ce264f3ce2033be2395283b2244332e36bde34433', 16),
+                    gmp_init('0x52e28ede8054722c7d37434ab9da9460374bbc6776e3a2ae55417012407fba15595685d2ba7bebba048f66f5c4cd23b6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7f137b3f22cd7344f5958a621b7c370ba33f5ac48fb289661464f3b2f55ca215e9ffc25000f024fc3340235c85e8687', 16),
+                    gmp_init('0x83e145d19e72a4163246b310d906fa94b93408ba85d636e3811d78d672eef74bdefaf09bd4b98ef62a9385e38addda55', 16),
+                    gmp_init('0xa7b74effc2bda0ccbacde4334724ad3a462f31cafc6a9be9c7a7f7e2e38a7679cc8f9a703c1065aaa586cf911c3db3', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x5a9255eb819efb71649137035239111b508ea6d08d0069ea86e3b16e0328dbbb04dab7126b2cd616bfb4b9c1b55fe0a5', 16),
+                    gmp_init('0xbfb908fadbe904a0f7f64a59482f7bc07ad3085d9b33a0eca37ffca1088216fcbf5e21a2d7bb7ed01007addf1e3ee5c5', 16),
+                    gmp_init('0x912231b877add741f4d77bf93e1199773d870c960b59604cc5752d98cb0cfa563fe1983a9a163bde5b93791e45d8f3a4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35a37c12e167e1b82ec9bcd6be4e1a554a28ffebc66b81c866e62623645cf4b5ebc29120af43afe8236eaf17d6e5fa16', 16),
+                    gmp_init('0x1709e5d8466b66c4f18a064d1907f218101958fb663a4f2e86d9303b863cc1ff8f6be0c2d677fe59110f7d989257ab53', 16),
+                    gmp_init('0xeb6bc0ed542b6e3f4aac0126f97c9f094a751f75371339caa452b1c236cfeb2a55c6e740589e5a643870b7342b99e56d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3448584920a147e0a1ed3d9bd7d778f9f9cad0ce179d9b7cb778e54d2738c5304c83838729d803464d67d110b4dbf095', 16),
+                    gmp_init('0x27c50de99bddc076b6a96c3f33dd1691b15c3e173f052654ac2255cd90c66a7379587756150be5d540863801b615329', 16),
+                    gmp_init('0xe9f312c0978ceeeeadbc729c5cd793a75bd48ac17c73cb49ceff5e596be4c2fc60bda3a6e3dbbf9162fcd0672cd24ff4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbee4aeed5d1826328d7a23a0cb098c7d37937689aa69183cc35d4a5672bee3c762aeda8d582c7a665dededc0bd04394f', 16),
+                    gmp_init('0x872d8956efb4415d51f68ed823f0235e6dc2313a3a08e839e102aa9aeec40b824c194644f6332c10eef93271b56e6d64', 16),
+                    gmp_init('0xd392f76857f678de227b68e88288b98e4721725a248286acc0dfc63753942a244fc3c3e2cfe7e7d412268a91a70d89e9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d00a554136e3af495b00718cdd962141ad0e89e418c41ad9f3840c7bed5e84270023cc8b0536ae6bc37bb0a1190e492', 16),
+                    gmp_init('0xb665337c35abaf78f44a7490515b12d363cba101cf9f48864e6688e1f3fbee0b6e9e521853de8bfaa2916bea116d7071', 16),
+                    gmp_init('0x410f97c02c6a0b8138ce10e6b97e9c9623cfc4b67463d526b67d4b0ee47a15de8bd745b694c75363d70771f79895bcb8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcd0d2001a38bce3176500cccfbd3022880815352d3666004b926d9a8cd12403128a80982d5d442e33981bc9a946f8c68', 16),
+                    gmp_init('0x36e57f9e144b0ab4cf2303f93929b4703ecdadd7048ebc64b31e97c67338312c453c3061ea54b5e043e0cc7420f2ff23', 16),
+                    gmp_init('0x8231b9a906618196a2d151459b1376494c370f669ab3b85759a0cd6cbd37d32da86d121b48f636f747813d5b68618ea1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x60c525bb5d44553d483ccd190e3dabb9195afbf9b006ad017660899bbadfc76e42240efef24b78c811b6f82de961ddde', 16),
+                    gmp_init('0x64bd5c20c7886274310783c8327a141a4954f004e5642512a7ead6e13b6984aa24d4cf5b4f7886c9166935d365a411a4', 16),
+                    gmp_init('0xaf8174465953d7acb79cc2d02815d0fcf93c86719737f26c287d1e4c59f7af7e27269610622e6792c794d968ba7290a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa459c80815ac72f3978c0e57d90688e818102cc4353586cc1089362a542862f86b49f3046436d16baecf134a65a8d18b', 16),
+                    gmp_init('0x2e8b3ef8325356ce3731679eb0203e3b2f3b79a037d99bd63fbaa1679d40e9fa58a7f7edd47ef693dbc4f18299c02740', 16),
+                    gmp_init('0x935a0caf68b11a79d4696eaa8dde810c46bb8ca4b2732f106e271035293670e9e0e829914233bf1dd94fa881dbe332f6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf798a1d3659f1063bd710c2855e8e03ad6b27916108de72965a16d9315ae19a795ccd979aa26cda1edb26988d36639ac', 16),
+                    gmp_init('0x8456c444929c63b2ebbc1a24697051c99f0441b3ece0d6b07a04834700c458e962765a16e5ba2042f1c39c3cd678f96e', 16),
+                    gmp_init('0xe33c5931ab239817ba1c2aa37b713d0d116b4366585eca4a15220bc30067e819f178e00cdf1a5379cb3e46a5f9158c23', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1676a87bfb93e360a7c7b0d7fe32a54e75aa58042f5ad89d80579a0dc0253e319c7e156f8337be38f12663578a9c171e', 16),
+                    gmp_init('0x8e4960732a62a40c260c37e92a33f4de423e1449f2549d4919ab485603b2ad0b5b7b980ee7476da6370e5ca4ff21b86f', 16),
+                    gmp_init('0x7423830c0df45b0189789161d8cfca43c7074bb69ecc62f7a3f1713c3e21adb35b9e4e37a0d5852666c1942bcfc533d6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3f2fbbd1851781539ffc6b9c0282c0f5a585e4973ee85cb9188240ed5e296f81a8269001cdda1f61147c51a52c97958b', 16),
+                    gmp_init('0xc0bb3bd2082e4f000f4c9345cb0d73e7437a26a14a286ea35117da7b5847aa4118a5f6fd95e70fa83cd08560fb37b70e', 16),
+                    gmp_init('0x247c9636a2453acf91687e708ff8561f02b8b5946c93028b8806c7d69b44e0b4ff66250a1d0d828955738996a6afbe1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5420d4f81ab926d4a9fa6be690fcc2de1651912dfafa2466ce7c468ed01f5313c5a2852340bc74a4b83b78efdfa4ff4e', 16),
+                    gmp_init('0xf60620e0e16818f18b69c660cccc63af5633f38efb661c97bc8929fb797b3709fef1af2393a94dce8c458a77ac3f4fb', 16),
+                    gmp_init('0x3ce28d4eda0b83f4824e66fdade9620b85d28e6be43bd518f6fdd36dc619ba5c2a3b648477e721d769caa0fcc621a09a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x736ecd7344ae47f23b102873e10998df949521ec25b9df604c392aeae46ee68d5d1b52d78ece66714f2c4e884c6edc85', 16),
+                    gmp_init('0x4c31c0db0bb0a9d64b2939ece2cf3ad8824b1b74ca86eeac858f71cafad99eed61f642d19317e562ee051a5a87df881', 16),
+                    gmp_init('0xe2450c69bd10c7ebe61dcb272a84db031f5c44ec27559fd453ebad441996601b49e43f8c76e072346818cfde5a0dda91', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x291480ef3a2568b5baf1f14480351c8f9ca3f823728746fe0d7584d81a444dd7077bc2ba4ebde9510c5bb24854680360', 16),
+                    gmp_init('0x1cd444ed6d861e3e9e08d80aae1bf5195b6bc7f07229b52a300e5e7a0da7b992786927c13d992d5d448713d4b3ba2f5c', 16),
+                    gmp_init('0xf41e9b34e8c8d4c1faf951df80ff751b2f41a526af2799c3f2614d896b9b37ac94b5cd290a4109a837d8654bd41c8208', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x710dea8f162392d7ebd8a545e71c6fbbc29717aa35189f64070d9e6797187f8d81778fc36c40e247cad8a129b18c067', 16),
+                    gmp_init('0xa38d851a6329e38399e2c5a0c4b66cdff3ddb6f5dc7abe7338650bc244d4bfa8bb1893e329ff0d08c601665fad8217ba', 16),
+                    gmp_init('0xd4e6882ed0242743956bee15a66e2d372c989fd49368c4238fa750ff2e8f0a1693801e564fecda3fc615f86bbb755f4f', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xd833707cd92755d01994e4648de3aa98082bf757e2e7b6b56405c8f28bb549575053d159f655d3eec09d35fe7eab4481', 16),
+                    gmp_init('0xf421b258ed55976b3f56165efcbfc40ff7cc3eacd717b93b3826f395543eeee35ca9844abc4a552252c4d568a55b38a0', 16),
+                    gmp_init('0x91699cf045fea4de1bebb98c41facdb859e04fa9a80a441bf7d6b94d1d6c2381750b919c650717ffda5d319581f3b47b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9a5606990950d870dd2fcb189e603cfd07c90e54e14e49282dad1947e45576d677f03b14a3b7aa8629a664c2333a7c8', 16),
+                    gmp_init('0x5ebb275f0a460174f7cd644fc9d63b1065c24ca6f7512681c669b1cd18b134979af36f903f9c3ffec177da5ed902ab26', 16),
+                    gmp_init('0x5b8c9da07d68d675dd16baf2e9f9400507fb7bf071c9950ce4acf8445d0f530a019dc74cc1194823c8ec51e6687ea23f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2417f95f1aefde2820a06549ebdd97704684f8e98c5a87325c99056b3ef682364fccdca83061d58e6e8e616039b264e4', 16),
+                    gmp_init('0x8871fbc022c2cadce3c4c01fdf8b0ccca60fb3e53d778741cff89072221de5a802541bf639f644d16d030bb3ccec5d55', 16),
+                    gmp_init('0xaeed4b2aec8693146db106f1d94a9ad63d5d9c2f156ea7d6bb53dec27158db38bf5c75a58c89b80e125f29e18acd9b0b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x97be12812cfedd424d19a0e0d482db86c1ccee5920b11f86abc648cc628f4be29ecd7cb6e20c16d666be6512fab9740f', 16),
+                    gmp_init('0x77c3422a3dcd47491a40ef52fda608320c79b1538003447ce3affaaf43d8ff4a7507c0a3d1e9420949fff6c9f9e4d17c', 16),
+                    gmp_init('0x8dfde6522879dad842b731d9b66a20f8d5cc2caac19c5f86c8ace2a0a5d5246517335f72f7e089b99ba40555789d5fde', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x733268e86a9698f1460fa7b644ff24ccd121c463b8c7f1769c0f4f6d6887667a7872125034617c6cb639252d21b24188', 16),
+                    gmp_init('0x86096d5370519e2d8edef450f1847f9e6d898371a5aaf4492e47d7517b808b1c8c6e9e3c4727c5b76bcf7803b6c3fb08', 16),
+                    gmp_init('0x1e9abf872367ba2301d2416c0e57449e84ef54a3e21048dc3adb1d81dd82985b8c5e7ce06ea1d12217d7ea0306ab8f75', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9fdd27c9b8ca1446645be4df431497e9bf6080e2742e1ab74f3dfbf136a83edb04ef780360c1c1429ff3bcaf1020c6b', 16),
+                    gmp_init('0x42c641915b9d66b36ed58e397efbe4cabd537f79c49b02305702780387e4f06dab825e5b6a2c1e7ab710cbaea01f45f2', 16),
+                    gmp_init('0x76684f8a335287e1bdebe46899caa4e2f11fd240839087a977f42bbe2ae4f18a2604c28e8f58cfa12e07fd8360e2a9ed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x60b0440fb787e4e60a574cf3d9ef21a430f3291dc2e46dccb2eb176da1633088577559cadaa5e1da0e34455327cced56', 16),
+                    gmp_init('0x7da0c4b15eeb25b78d5aba9916e94b31d8a67b459c7e9473abb03a788e5f100c774a1531547d58e37c09ee4a57a60970', 16),
+                    gmp_init('0x6cccdaead6316b08bd1a6d0236365d5bbf7438d2360716c4717e4b326d7ce03e8107fccfbddd785dfc2a14b84f658d25', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa0e1a5e54a1990a86fc3b9a32db9710a5a5857198dc400687f5262e93300b513619ce5878bcc4d4ee58da051d8475b78', 16),
+                    gmp_init('0x8e024faa1f137941fd9fda479245e2e7d0cde9f01c72a12519359dfb911e8dffa16456d0640b5353ea1796c799b2e7dd', 16),
+                    gmp_init('0x301ad6120027dfa7daf3d6cd96a6e7f75a033e06e47915f2f9844e9a301a72711bc7ffa8a129965751e48a1146f40267', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x30d251e00243b93c9d44f46cdab105141fa154a0c380fe9e1c997331eeaa159549ef0541e505a08c6078e2ad5f7bd57a', 16),
+                    gmp_init('0xe1bf8adf898d0c2600f55ac60694df6266d9cf4ef778fcefd154ce4bf0007cff8f9814534643ff8adbe8acad887d7ebe', 16),
+                    gmp_init('0x5395ec1369099c0df6f72b638f089001662cebbb99ca4b5c68ae7b11288ce7429ca08524fddb9fcc39b5e2584e78ff59', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd2d767a366de4a675c5634f683566fcb5b9bed26d7b678b2858e0a7602ca7b7e36b9ae4739cca19a88e8e262a5f2674c', 16),
+                    gmp_init('0xd2ba8b0a882ff4801b19c20a1c67afd446ceb4ed528ab6efd1e69853a4699b4084f94419fee05e2bd0785384b5859193', 16),
+                    gmp_init('0x84a5a89f4a7437901ddee6f74a6e4ae579a726594b3ab81f0a1df8ddc1745bee667eed14265fbb686a29525e9ee44f7a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd808d5a38dc9e4af9be942cd52cf01dd1ac150d29b3bade4c9952fbbd4b00b57295bfdef5db5048b2497962e58bc4dec', 16),
+                    gmp_init('0x6cd7bf6b2b923d0d2f1e37f7364a4a7605b4a7b63fc912ad95548567e85e076b3a2b67523017f5f45b15d0a1e97d977c', 16),
+                    gmp_init('0x7379b3719ce2d74c1e1428d6ae1b519bcf1f93ccb6a2047d7f711aec61c6de454bd60de6dccb47f84200ab4395d10a41', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e3d334e0d99e658624d5c216e29b553fcc9fa8072fbad8e608347c2d58fef5082c6f4b1e977b10a7339edd592f7eaf', 16),
+                    gmp_init('0xbff90d645d586316c0c88a4783c95e463f1361019d6b279b517e8f3d5384b467dfba512e167e985192a4baf062795d5e', 16),
+                    gmp_init('0xea7e7afba81d2bac4e972830e7118ac86b9acf4d5537253468ebf5d6cf93c2b21c4ee972be14906f1eb8f7df91daf5c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd568b62803e682dd300f9a8dafe44ef52340cb5087f040501c348ca220ddd27d414658052c3d28390f6c7adf7f48a78b', 16),
+                    gmp_init('0x106f6073bd233c6d98ac43ecec95317f19dc08ca8b15e80a27980131d7c433ad49800fd331f652917543711644cfaf0e', 16),
+                    gmp_init('0xe03498d1cd1fa03c84479298aeddf638945c599cfbab5f69d3fda7193fda526732c5a1222dee4c7ef17d3ff9af69669d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf8a02b4971c44f420f0249e6d439f8955e3e0a4d18a7f202d1e3a1a3090ee1184483036c7e05aa830317b8a31462363e', 16),
+                    gmp_init('0xd3950c6f997088726edafc2e6967ef9e67d56ea5b61111e29c4e52950af069cc85d57395295cbfe147f2493be32cf1bc', 16),
+                    gmp_init('0x2b214bf540b41c20ce3334e6e10c95a90749cbaa9782250b0b57eb0c5fc43c8947fd8d9ab7ed8d37b94cde65c48c81e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6bee442569c10ea644efb31306e523f0c0c63c6b61889d220ab18413f3cbef704c9d0e86e4f63698afcf9f5f0bc9ed9b', 16),
+                    gmp_init('0xffc10f9126efca45d176df9a019fe6e49259670eee8bbcb7b5b0d47c5e1d08bf3ea33aaf786b708544e06a564ae32d4c', 16),
+                    gmp_init('0x1da22c022dec7136837c6e370b3c7913d5f9de8bdb2de0f12134866fcc955cc9691280e2726718098719a0fba41bfed3', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x87d6ba7eb699fdc50189f409cb32d78b0a863b87bf907c4b0ac06e99acacd04c0cac9492901b43a0ec44150b7f030a1e', 16),
+                    gmp_init('0xc350f59d4026c4881ff06942d852e2f4ff7d286d08d9a295b124b1c03fade4af79ba322f467231dc3696d2f4e9692e90', 16),
+                    gmp_init('0xcf765e49f222ca7645c3ce3b358d59d0d42fba852947387f8a87d8a46a835898f0652bb3c6e2957901f1677638e42cc7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaabc6763994ba37baacccd8f9805e393910966aab6ecef9d8549fca14c5560016c06fc0442e2606e4ca6ae135630aeda', 16),
+                    gmp_init('0xe18f01a4c180a6caf5871a1fa18413c6fa157e19c4931dcaba68f8e4ac9704ad7d18136702805001cd7211f6f8ec9b2f', 16),
+                    gmp_init('0x1e5210305390aaa3bed5501a33792a6590378546314e78ef6a73539f3740b06e528efc92b5a41cf76795bb26accfb040', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x68ac2dab6143472b9ab7f2a9bf2ca09b73af347c72d0240fd4f35c5691feda101dd863074c9649092754758d2feec8dc', 16),
+                    gmp_init('0xe0035144a5a05ef89f6ff4a78ad11de6ed847796605549f0d8f634ba151cd22564d709969acbe7a2671ed00d72b79dc1', 16),
+                    gmp_init('0x94c66487cc9dda403e00aa2594afc62de61f0306b4d7e2758d489d93730a9364947da5147a329603fd8fe02cea2b4f83', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7755c68da9728185b7d8c8df3e5733af896bfe5891c57bd9cf30e74e6b07c47a47c4f455d3b863775ecf2e7b4f45afa', 16),
+                    gmp_init('0xbe84220067713cab628db68eb94a6f4b5a6fae9f615202be33b1ac328776b6caead2ead3253c9f4fc11765313186edd3', 16),
+                    gmp_init('0x70a97da5adab5139feef8df904097ea99b9a2d6a6b4e3bf411bd8916942d9e4685658ed104a407656c09db5ef2b4905a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xedc068b3532dc2899448b668c4db40688a4560018e4ffd5ac88833bf9b5274dff5039934ecf2a2ab89f9cde0c2f1d385', 16),
+                    gmp_init('0x9d9af480e8cbd63e8fa8a109c5ae110aa73648a72f63b245f53ff487cf8fadd332ef3a50c2b5c9d8cf5c6a1db17b6dfe', 16),
+                    gmp_init('0x1991edb633e5cbe0a9d1812f798c011176d2661478990de3b812e27c03d926bd7b7b5acd20cfc574d5e92489d780f51e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35abb2c85c69352832829b576435419b1cfd0964dc78a6e9e94a344eaa5f99273e1423d15ed3f0da63a7188028b5ccd3', 16),
+                    gmp_init('0x87c02b7359b005ecc1a788cefe66face3588f8c0360088eea57b01fc40781ed0fef0d1e1551d875feafdbb9b35a3160a', 16),
+                    gmp_init('0x864835a186f314e41439f1e432ba0732973eac3db92fd12808f17c8f19769c7cbc5ec0a44f9908a2a0ac42d066434629', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdd7fd1b69c0b0ea6c781b73f4a63ab909fb190efc1589ec0bf71af73a22d939eba64542f0394c4c4874f173bc50dafd2', 16),
+                    gmp_init('0x31f1de3602fc0c37a003ffd9ba77eff9b00dc1311db6bfcbfafd96016fffaab744af6c4710563df29678bbaa97fb996b', 16),
+                    gmp_init('0x9ddcf2333859cd8bccf71175565529ef1f2128bc4dc18d0853ab8b47f4f995f0b82508be1b632495bd3096b20417e366', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xddbbbbd6d3627740ccd79ef040c77b21552bf65a17bb0651eab09a8deed21c2a24d8a998fd57e36d2cbf96f45e83720e', 16),
+                    gmp_init('0x1545406d8fc4462beaa20084399ae28744a4c4ef1d7007b8947af0328dbea0fcd6a0d8751aee5cecd21a94cd0050a39d', 16),
+                    gmp_init('0x5338ace5d8abf51bca41ae01022267378b39609259b981c3eb78f175b8a7f31c50fa4a8a1c2f4d8573e50b7a7529fa50', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8cc4c9786e94a4fa626e6ede8111297f506246da9f14e03cf39f8bd588ceceb1c51c29981174ca7d676076d912bfffc2', 16),
+                    gmp_init('0x2a5d2d0f492ae35619d5c840434274a04518b0ac8bf7e2a107081e1676a29fceb04135de9c0dc88052dfc3d6683c76b6', 16),
+                    gmp_init('0xd0a9d9c36db530c5ee9263c8d14c3c09c090894bee329c883c811a335bf66a943bf6925f3e6cf3522f93019480dadc3f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x489a02a00c753db495281433a342ffa2d1f92e5d011f1e7f312f390c0a84dd7d22b7c61f15890ade71e728eff1527179', 16),
+                    gmp_init('0x12e35089617472dd9d34e1e27bf022f0849b78b14615d6137766b0b1fec44f9a15644ffc57a86944e553fc815a1c6819', 16),
+                    gmp_init('0x87172094ea61d0c7d5c82d12ec35b1b401b29b45dc90e71b4e6eec321ccccd79a2bda50c6e7c8718824bf3d5575eb5c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x820823ee44d7d4bda7e7ef12f2e477b200e44ca49786b0b53e7a5ae706ca54e6e30ddcf2404734f9f7e77f01fe0a98d', 16),
+                    gmp_init('0xb6b224a5f336fdcec07aa974463865b0d63279b633f682227b8bbd0c7a3a12610848b1e26f0709836830353bd0d39218', 16),
+                    gmp_init('0x73cb5fa1ff15e3ed855396e7b1fd6e6833f6dcccfcddddc9f9551f9c6b70f5561478e36cfc1cbcbea7c11558fa9ec69d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa94d1192ed062ff3a64b8fdc5770ce38f2e3e1ac9ee1b742df11f0ec8b5748b80fa8e6bbf0770e80645ca43724c185c', 16),
+                    gmp_init('0x1054b4ba844ebcbc85119833289f1df9194a49dcb1a5f63c47d1f7a530b37751298e34f50b6d476d81b737405f603e37', 16),
+                    gmp_init('0x2ad11a61724f3600acce1976c08162914b6f99af29cf3300c65baa46c92d399a41551353b09d821a1f05f12ce61d6bcd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b4975d2961e2f8f375daaebabc54c72f1b4e8262127fa022b0be3103f48d23284c943f060b4f984e91d06c54d9718a5', 16),
+                    gmp_init('0xcc15d35e6b6903edf600ccbdac1781552d2d214e602543342aef1f0bcf6a7fe755976d3f7d045cf2bc6d71edb1fe875b', 16),
+                    gmp_init('0x84e1a9d104e250fc68d780c17f3740ff404d383baf5df75b944f740aa80892477e0f0d0a0cf7c3d67bfa7175ee83b270', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x958c1c3228a1f41bc96a6682842388deee26ce784a399f838d84650d84029959430b0532296e6ad61a1b368309e0e6ae', 16),
+                    gmp_init('0x72a41bd9d87b808c5e57ed5a5235eb4be5a1e4311f5da4add499ccb6bc120bfac3c2795af9057fc002a438815e14b591', 16),
+                    gmp_init('0x24978148c73d8bfe911f982b3d7fd48f72fe99fbdc5b5abcefb84fb644324a54d7cebdc3a1aec71eb4399a49144c8039', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdf88adc27357a13d5712ac49e4d5da3fede7182d678e9a1e0588ba03e381a02fad3a01ce0c031b9d7337676b23f9c96b', 16),
+                    gmp_init('0x95cc62df2c0088ae7ef8ae73ea05d825b54a8884a44772b537e937db84917689eb931bd856150b3ec8d624db9a59e257', 16),
+                    gmp_init('0x3374ffea3a4ce95c636a46c9d6854091e4b450a967e67c62e6d46319d0e67c805bbe2ec6473ce7c7884bd45a16f3291c', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x64200caf29cdea38a7580c659ea201fdf259f0a0b7fd33557cbf7e51677cd1cfe6526d038354d825bdc021aee17c614f', 16),
+                    gmp_init('0x76cc16ea1d3dfe11bca972b6a5b2700691d552fba239db7e48ee1ae4f6d6939e3dcdcf6adde264bf815334569099718b', 16),
+                    gmp_init('0x8a438abe728f881b5b22465cf29e6f64eb2889a83b040a9385d8a89427af1af033f2fc6b0e88c4e89f72161068ea90ed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1f9c0b14b295aa994671d1b16fb6bfda6c8e36ab374d412b940d527703844f52ce22eb37cd34029c94df9e7bb11daddf', 16),
+                    gmp_init('0x716582c7a4e5758c25ef2d93d7605e8920c7aa2a994626635d874eed5621b10bc0fdc2d9b95ee19948504069efa20137', 16),
+                    gmp_init('0x6571f29320b9e04591e24ea7fb003383d5f29f3912ded704d840f7fd37811a56681a7cf0e569e150d6306eb7c1cbebc4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9a3b5933adc271d66d7f88603ab6a3576f7b5b8f1f04f9dd23662f97bb217ae3e7498b6a0d86f7b1e4636f88eb78e2bb', 16),
+                    gmp_init('0xc176205fab7c0ff6e1c3f50ffc4408eb59086957507dd3046a8d94221413fbeeebfdb4adad080a8c840f46d920c09c03', 16),
+                    gmp_init('0x1dd1a4635031522d3d2b49401fc2855a48f9fc2258973aecd52420076ba532de6f69af8a764252e61f37051e61a8643d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4b31593a00427a4327a8c6a64c30361ddf631cb5950cbe4c0a2b2f575b239fad9b5b7f429ef4558ecbe9e82c80d1501c', 16),
+                    gmp_init('0xb27a8a98a4d4ffc4a35525d2ae1792f6b092f966e1d1a466315f47fba6ff36e107aa361304af5197900fccf073af822', 16),
+                    gmp_init('0x4b079113a4201e75aeeaca0f4b0b1e00cc358532472a2d4909d8a3415936e3d6928d65b4eaac5873fd214a6aad5c6a70', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1ad47bc36e6af79e7427d543a21f38685a129f784c56c196c11e921ad0754eebd7fb78a4bdd7ea590816a2b60f7fda28', 16),
+                    gmp_init('0xa35ed1359570e18057404098bfcb5e25389aa0303219369f55474e82a17e18d848cb90f5fcd6b0fc080401fbc8d14a29', 16),
+                    gmp_init('0x8aa30b0fc064f65f7a25ed22454c075eb6983fbce89e960541ee8af01daeeaa66e3a88764b14ef9f3273500631995aa8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4873574fd3aa35e0275ba05233096bc1cc221db63b686d22cf311d080e64a4a7ebfcc5fd67ae98c8bbb090e32b4b04e1', 16),
+                    gmp_init('0xcb3363aea4e07ceb5471b060e15cbc726634afa3f7f574eb33b733e65d9522bf01c76e857a86b02d5577d38f69136ee5', 16),
+                    gmp_init('0x73a0c246e82739e29b4ee6dd798506807cc625596dfc42efe77da41dcdad8f4903f7750f14aade160d5f9e70c1585fc3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x432c4d9c17435e1cfc6d13d5780c73807a245c4049eb44c7ff5a0c8f801b2ef2c290b9bf0030e1584a80c3c0a251f097', 16),
+                    gmp_init('0x1104fe164828541dfae58785df0cfff322c203e53e3287831455fecee89adefc02d41286c105f8b7006e636f98eecd07', 16),
+                    gmp_init('0x9f912f9775a2429461e550ad2784c25e91bccca8730f4e0e35d99e9db861b14d3ac0871e09fc311c2955d0f5ac488d86', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xadae5452fe4faa9f0cb8f99833b6068248038dbbe0ef9445ef78fcfd082742e009e3399823afa32f5f5e805c2c5c480', 16),
+                    gmp_init('0x4ce036169bd3a5e90702621deca47a3a99d93818838a417d2766f0e17c653ae5ac1dfcb188aaa01cd6042fae0db78983', 16),
+                    gmp_init('0x205a9fd9fa651d68eb6d792b8323ca61d7c7ebd19865bb8dfad381eebd8e24325c4f46457f42243e54f7bf9da18da933', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x528f928dba36b838e8b3482bff815da6c37981fa23b53b56e0a449ea96575297b6c487db78f2f376e673cd7c768dc0da', 16),
+                    gmp_init('0xf0f8ebe701a6711be73818a4ffc2781b74af31bc3ccea30d5de9a551470e50230d6c084c5d07a599fe306181aa818ead', 16),
+                    gmp_init('0x4a0c7e130c8f867cbb94460951c57bc08b20afe2525a564d66c266da09606e2e3d586bf7ad12432b075ecb44621beeca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xab02aa392aecda89e96ea6bb71057b70355dc80488149c0473a757a9d1d48ebe81788af4dbe6a0ac9395945f5b5d7a34', 16),
+                    gmp_init('0xc14555be3ddbd20943653a07552efd4029b43c8a4a75d2bbe358d4de5cd380104fc4e100146169d611a8ecd22943dd43', 16),
+                    gmp_init('0x350626565827c8828e9265bbe27612de6a42b297864769ef71c20711fabd404b6afc8885ecbf4bf6ccb490461e2d853b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xab3f62489960432b5095b1c44f5546e84e87b12d1aaf920da06081952c7b495b783326aeeb413866e2b3d395b33b5aeb', 16),
+                    gmp_init('0xe87e0decd658469ed28e09dd7f555986da052ec29bb9aad8dbf5c07be93cbf82d71dee694a3d8df93f88db44bf71adc6', 16),
+                    gmp_init('0xd88f633225bdc5dcae5c59b7c3f16d11634afac84995e9e53a1bce04984a45621e7af36f6646d61551931fb41dec668c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaad5f8d573e959ca7372b161f849109a4bbe94cdd2b890b0c29659e485d38709c9d57995a152ee2facfe230868b8c968', 16),
+                    gmp_init('0xefbbdddeaca406900fd5a2108ea99ac241e6b08ae0d80ad9f2f4f18fd093182fd275b0b811245377ac186e9b54d815ca', 16),
+                    gmp_init('0x17cd74b88afc35aacd614432a6f8102e5db67e4d48fcc609c325e4347a2289463adfae015804f3272223ab13856a6e33', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc00b96ebae278af6fff961015b1eb52d7e646b37cfe704ae82ab1bb6c260640958d5a28e85ee9d06e51b2bec3db28acc', 16),
+                    gmp_init('0xefa360b61d6988fea43ba350d8bd0325cd287d7b60d5cbf2acd6be2b5ff837d62ea695cbd43f7636eadc6b3efd79877d', 16),
+                    gmp_init('0xb94cc8f4d4fd958e99b4e26347a42914df8c08b524cb730bf2b3db2b14b8e3e84d25af358f6fb74199c7fd81f2545216', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x974ac325ee3912c75eca157d822603dd6edddffaa258dadf2fad1ef8fd34b7f8adc0b73f1d035e714318fbd739f7761c', 16),
+                    gmp_init('0xd2a841feca30cdf1133c403d821c1b0de6c93a9b2da912093626d3b1e983895d1b8d794b153901b3ee95757da2ed05c6', 16),
+                    gmp_init('0xbac0c7803f7cd67965fbc6e9fa494c837e867c2fd3413de320cc267456582478f180cfaec11aa196802883917b0751e6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x873663d10712643c8713d15cb2c3ff217c4b481f044d63d869458452495a9eeb248f992e1b341b2008f87a80ba41b9ec', 16),
+                    gmp_init('0x59aa1dc8a4491475122e51ed4486f3dfd80d4a38486e4ae1243fe21e1a4e4a0a22e8cf09612a44ca36e7b6548892c441', 16),
+                    gmp_init('0xc1ea4b30091997de20e7929805d4a04307b794b7127512449996315f7f5608819e84dd6647db22a1685446369014dda0', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xeaed77c9149ce95a5b7e20e7eaf292d05d66ee4187f5e343fabb5197414597b22fa1b373a05b74151c3f7709b8bf9e7d', 16),
+                    gmp_init('0xbc8b55690c9bf79489dbe2238ae1f8c50eca56d26786dc07f1e36864b8b870a3224eb855d7adab093b7722d285846bb6', 16),
+                    gmp_init('0x39ee4a88eb8435f6ec5655ff90ea0d3e435bc146a9f509add47726617c5dc44d1f11ae2def8423bbcbf6ea6cdd8b0b9c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb3a598d68660c90811ff1a052ed7e8402bb55b4a4a2436c234176664640b2aa3dc17c3db2e6ad6ab44041bcfda170ab2', 16),
+                    gmp_init('0xac50da73e0c616b7fb1cd2425ad4fb5f9a6fe07f2d9ef1a077a696da6ce6d7742731516e6eed5b89fd9fe6d4277f608e', 16),
+                    gmp_init('0xc186acfa9ff3a4e55f5ee6d623bbcaca1cc14be550c9e93cba3c09bbd8662d3accbfa60f3c7d3f79101927815fc26a90', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x14e0c715ae4b8d30d593b8a10ee96a4c66e695fd997f982f930ef621410ec28e4518a50b55b92b7a1651d21b7fa1af8f', 16),
+                    gmp_init('0x6f7b930aaf111f402828ca9620823b9879b0c9c6ae7a67c1125620493ed8c994f9fa3aeede81e9af6f9b60a703c31a49', 16),
+                    gmp_init('0xe13d8e2affe100d7da242e59a129566369734e63d953dec55bba5d43737eb168cc20d42cc948731ab0cf753739b0eaa0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf43c2033cadda1e889afb322d7183b245a085dc99fcd5fa287b319aad0ca8ecc23c6af5fae898d26588b5cabfc83ead', 16),
+                    gmp_init('0x705b7ee66fd6fb36ccab5692b5d09852fe301878e6549e8321d5d36255733596b699fbcb89d484f94ab4c3b86b8d2cad', 16),
+                    gmp_init('0xc64e3f562b1ad7761756fb98c2091363d37bac17308700f5a61d89e8896763e1627a45eddce3d40d715a37933125a449', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4b0fc7102cbb6aa90b272eae11e1041e682be00705e426ab88adeeddc0c36615b5af76935fa1f89c34f428543a49e82b', 16),
+                    gmp_init('0x62dffc8badea43a908fff875ec73d9f23582bb283a203f2854ec659420e56fbdcba8a8cd575c8ca8cdf839fb22b731bb', 16),
+                    gmp_init('0x29165596d9bf4af7fecc8b90fb2114fc4131f3b5b8f6fd3c18758c1bfcc78eb8115fb678d3039baf452e9729ca77a602', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x59242cd156ace736f63186191b5ee63830cc27f36978bd1a3a8cadeae9bf61977da144d7d02f2bd61330d22fee23caa6', 16),
+                    gmp_init('0x4e5872d64fb744c64a3b44a0f9f0c92f732b24ef261a58cea8ab5c5f052330edd11c4aeeea1d6b8225a4624a765331', 16),
+                    gmp_init('0xd1dbb54a4d4e1fcc2a323e1e51755ce9dadc9320dd6d2499b2096ad9978fe4e039b65dab3893d91f72814f8c8582407f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe7d1b2b3b94435213aa6010cd911f56e194b7d0b18ecacd4d14b835197ff058d52fb34507c09e9de1079cd0d38626f0b', 16),
+                    gmp_init('0x9685f6676fb03d6c48fca0cd70cac7177d2263c52d08a3f93a2819295d8843a6f615a5403374e5e22417ef9ed8395de', 16),
+                    gmp_init('0x44c66b4f1aa6daf3eeed6403a6e78073e1e3750ade2c73fbd2cfce04d21b6733f62c4921b5e2a41bdb8c9a65691dc6ad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x86379fe8a25bcd6d7fea5d5e2ec01c7b1bab5f67f7213a5861dccb00e08b75de75a9d3e32384c0236e6cfb5d41400df5', 16),
+                    gmp_init('0x3e9b1a04a4e189c0ce204bd1366a298d0ec05ec0ffa4c093ae5b7fd8e2a404b734ff6b5bb548ce5b03dac22dcf368219', 16),
+                    gmp_init('0x339e79baef095380d83496c9258fda9a032f8c548e1813f6173021b908d31041541037ff9cf7134e4765b63bfc1bd028', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca812e8991fc17223d6377d08377818baff366b3893c0ed954f9cb4410dadb50ee39eb89c132241a3f3db1fb7268a8ae', 16),
+                    gmp_init('0x975ab6cbe05c5e131d7f798a525527070ea049b8ace2a39f71b72afb840e9d286eda807d08d66ae4431db4788330b84f', 16),
+                    gmp_init('0x60faa4a8a8a2da2bd4f84e4bc2d85060884ead26033ef0f51cb456ece2f8bdb836a1ba1408b0c2d9075a89b662c12193', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdcdd0e6a30413a0dfb7b9e81b136ed245d42fa9f8d74ce6616e43c819e0bec99480c8fbbc20f2f0217f47e5483357811', 16),
+                    gmp_init('0xb4d9a0853ab35c0e99eb294567ae9450381f4db80a0ad842cc170536aaf5e56b3081ce9cf0271dfa738004b800b0ad8b', 16),
+                    gmp_init('0xdcd21f004846086745083c622770dc87e51a1e24e7d1dc1b20784f3f66b2e98260d70976bcc81a4bd4f52fc0480a0799', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf8d0583d011cdff8977345276862bb5cdbcb663bd566fb9dd73500b6e7a148ddc58997de0a310e0fc128804be595c177', 16),
+                    gmp_init('0x8110608e647204819f673476c07ac5200b60178af24d8a55cab2b9a0a072962991fca3b2208b6e2d58df0df45f22002f', 16),
+                    gmp_init('0x7257720683c0cf51f99b37e122fcbfa504ada7d242c36ed7dc76c90309bc82c04eb230ca271e13ec1d3c28df0a6d81eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfa88b350a6481cfa196bef8b534c79499ba481d043664e482ef39a5bd826b54590a41d88c81b9d6ad831e007ddd5ce43', 16),
+                    gmp_init('0x72dfcbd33ffc8eb72523654b85a8fe84a13a3a2240dd0b6051f3dab456886af9aa6696af61c3b6e9b0e97c6ee08caaeb', 16),
+                    gmp_init('0x22f307099d1c1d81fc6c3afb5709052746e3857716de7e45925d114b56d22e795dfd06a71cb3f64593f8fede27825ac4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8e33a1fe74c06a3e4e75f43488bc31d13b7664e259aa3c4c85db70ba8ec3cb6fbc3aaaafa7437978c0c6fa25dfae6f77', 16),
+                    gmp_init('0x84a5517497344465d312822c0bf872ff2e92d13ff4f25caaa18960e15cb1e2dd37ebcc4eb2d89d3c095b435233572c18', 16),
+                    gmp_init('0xaa3eacb17870bbab5fb754d5808adbbfc624db5fb6284aebb49ebf2b2224473b1587f4f170a4c71d6f37077b8dbaa29d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x476cbd36072be8bb57be0fb454eedb36217efcc5cf5e588d34affea70ffc65e87627d69d5e3185da58e139ab58901842', 16),
+                    gmp_init('0x463cd890008242d1b7ee258c57372f3ad5f9ae851799222a00019ee16f09673366f344f7820827dfeb550ec5f360f04', 16),
+                    gmp_init('0x144491928ab0cd76a49c48061f9d1daca422fbe78421dce7c4ecbfa1caaea3f131bd7b8300591b9c0dc478da381abed0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf2f0c9277c45676ebeb20c5fd9514d6ae728d6eac05c91df7a9b9e228c786831ce8c4d73f6b4815a18835b6574ef47a3', 16),
+                    gmp_init('0x936c02eabc4a3a4d5d09090e943b9cbd66c284f50801394c81132b9fb3a4201bb5d53130fcf7e4c56459e80ca558be52', 16),
+                    gmp_init('0x6c1d137b99599d3fd0a122407380d28b6eec9595aa984d59f5f044370b9ab55879378349dec745f8c853c0bac2789468', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xcd5ffb1dd58adc0144262cf9ebe9d1828aa61b2492a7387e9c767c15b14a81616d9dfc5d058319fa2f75ff5c2847d7e0', 16),
+                    gmp_init('0x1ef1c1886ab572735dc1264caf133b3443cc0c1592744a0e8a22d8ea6afe26c6bfad2202c8677f48db979394c8b09c5d', 16),
+                    gmp_init('0x3dd7515b6e957a56e5ab2bd4eee451e8775ade27af11a1a535cbccfb53ccd43770ddf53bd02009214a9b2a1405bdba0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe709c23929344e4379b81f79d34c0c8167f0d5951cb4ee516198895015b1e094f3a97c329fcec9a6fcb6befb2c594fee', 16),
+                    gmp_init('0xc43ca937d71df5ab08a8687ce26527f610f78c181b6062898a4b2bf51cb4328ac523a15a8c47b1d64977e2e32baf2eee', 16),
+                    gmp_init('0x2643380aab095fa961bd84cbace9851f26b44eace6f3b6b9106727618aad7190b46827bad9ea550f8bb1921084bcdc9b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6c3cfeef58faa55ebec7e15d0f954896c0f87444cde4788214df01fe8632100f19c385487d737d6d2c4ccc6b8cbd7d9c', 16),
+                    gmp_init('0xe107d8367b8a8525aea9022921e2d336b9040a4f8cec6423d2d3d2b555b32bb27807b76876ce9e561cbb7810834d4e0e', 16),
+                    gmp_init('0x2be46d97c7c8e323f99ffbb9e3a121758e62c6b00e99dc6bd0f5b3bf76db95cb0e6a5d800e895cb65f1272c6a87fc197', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd69ef6707f9c5ed2b86d41de541000b7098517441fe18336bd0c8f1ec52e14d96d1ea6e9bbdc91bb9c1e7256e3a90911', 16),
+                    gmp_init('0xd87b1c6946f6b128d9bdf264dad882e524fb8be044216259b42d9ae1ba6fdee8a532cab46d722a418bbb1a529a3c4b52', 16),
+                    gmp_init('0x79f10c06ca7cfde01384d169e0a29e94997e75d12be6a7cba23a871b00c7c609de59c9c8100a296d00199278852fe4fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa3b7c3d1e3bdadcde298018d8af1ebb4dc47a789df11e528d72f942b881b9a6d82f8b9ae08b99a317cf32d4adf261b7c', 16),
+                    gmp_init('0x3441376cb28c3de5464b19c3875204f31c64a68a43b58c1a0446a18c5638d2f4ae27eabac2f548c700037da227c6df88', 16),
+                    gmp_init('0xd8d65391e2754be985a4e57c628c5862c3b5c5f29ea04edea52cc10957bccdd70cc2f030d29bb95bcc60837998ce7e18', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x915d7b96f71616a3179cfcc484d75e653b341b873da0d9a8cf97687b3cd361a63886cb6f320f99ab117515033a17af67', 16),
+                    gmp_init('0x2cc1eb1fb8e93dc9800054e15dc0119b482c5352220d302c738cf30d36614cc0d104f9df58fcd1de5c1c0f24fc166b8b', 16),
+                    gmp_init('0xa7a716698a9b7dc9c8035b65d0674bc72d5e4aba87ec163a963795a75b262049ce00197a0b0c3835d778176b321af9a8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x159ad25ecbb3ab11b4bf18d465949470ed6b69a6eaa727e513cc6662d4c4ffc63c6022ca093d67c7f7a18121a7242a6a', 16),
+                    gmp_init('0x7f96738d4ba203f75bdf81bec69386ab247fd55d307b489ea87460329813659132a2a3e80511fada45714d4c30610948', 16),
+                    gmp_init('0x9789e3c2490b23787d5a690e635474e279ee2c2a0f820b1b1990efdc8098a5ba433ae8ae4e3e9d2816398d9eab2bcbc6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x679272901b07f538cde2e7beaea94ba1678a59b6373656688cdaa6880109dc04a1396bbe1c6549cca7423df647834e4f', 16),
+                    gmp_init('0xf706158e6b4e36ca623bd159ef46373945943cbeefc43c7d62746cdf851c99ca549078d7aeacdb2970cff6f65d821071', 16),
+                    gmp_init('0x555e4ae79c8c3273a0304a0040d993ceeb8862448431adcb64e93d62175d4b1b80f0c23170660db9a174e680791afbbe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x33f16d415acf78006e3d163cb24e99edf749e81fa6a73dccd45ddbdb6a241751d50fad7b86aba78f5bf2afc87228ce15', 16),
+                    gmp_init('0x575dc47dfcd660e98de81053f5d1e8ee4f0b4da90dc61e4f63769f9b2d7fdd4ac5d8ec443e90680ed54746e6266ade8b', 16),
+                    gmp_init('0xd4d26d5fea130e6cbbff950923ada11dcd436c8d640003083e9c7474fe5510a51caad90ab080230c74402fd509407ba4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa9da0d421cb43c208f6a29568d41f644e2579cbbdd6c7264688e3a57f2da77f217642a916512d3b7f3a273123de7921b', 16),
+                    gmp_init('0xcd2fbcd57d62376e4f3b24aae240570ce1cd08c631e46b3894ea5d7561e3b2ed925486c22904ed023c851dbe334deed1', 16),
+                    gmp_init('0x8ffac0b3f305c4464e27c2b62cf9ecdf629fc521d98b4adea0bc0b518f1afec6d7ae8745f7ba5af5d5993560ae5fa023', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x608a7f2ba447e19022044928286e66d21cac7fd82802ed58100059f8d636326fe1963b0bef6c0b66ada865bba70c9b7', 16),
+                    gmp_init('0xa0c2b205e7a9252e055760100ecbb29bbaa2ea7e669bacf3c92bccf7d2dd588cc42034a8344559907f67baf03e799052', 16),
+                    gmp_init('0xd918444d3565a09e8206b6b153da03b6fad5a86bee76f4f10bc3337f4cfa7bac27db42f011e73c2aebc4d423377478ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3fb744486f6a8db038b732f8831801a0f8c8120e12546276774edccfcc7ea8687c87232dc4d9a6e394f9adde2eb94ed2', 16),
+                    gmp_init('0x7064645ddd3f7fd3961b5110db1961373bbdcf2fc762ffc43bf1e29e1b4aafc3d1d696d65fe4611c56feb07a91eda7b', 16),
+                    gmp_init('0xdc397cb020a36c5bff3480de5880bdc09c6a368e7189dab331f4940d1628f635650ca7cc8c472eabbfefee8f624acf82', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9d5b2957229fbe8634662e0f0ab582f0d0132336979b050280d47d5e5d04148f5bedfc1dac13ee6613c7780a172af4e', 16),
+                    gmp_init('0x52a2107770d0d10ba5a796f3861700f6624d19d239f641b9df0a64910fabfcb30bce61d91b981e78201facfe2a0c95c3', 16),
+                    gmp_init('0xcbd9fc3755734c3dab27b9a435c7e980f9c9ff7ece2e6f522c978658c3e845e251b3ea5ca14834fe29745e771d10c41f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae72efc0334201d3be2b3558773a459f1438e26e5bf436434d9ade368e0c24be5475408cda9f92a1a58291b4bb93d776', 16),
+                    gmp_init('0xdb4eec897e81b9483f80fb9d3517dcb624f4d4f0f060e31cbaaaaf76da44d629dd7fe04b7aa29958cf80afc186fc5185', 16),
+                    gmp_init('0x5b5cf74160de61a432e20a17e8234da403ae7d7f72ae56cf99adada47b07a1958b8fe41da0d85f2c4c4ff0c53a5279', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5c3e5865a76960f277e2b25ddd7d9458eadc4c2e1300a48e18c310c2fc86d83789a2d3b87a57d4534dabcb0000816aaf', 16),
+                    gmp_init('0xa551b6c78971090e241f43b574f2cd69a833b2a23de1f309f1804eeff693b9587da7d3ccfbc25f01f2e6184beed0c52a', 16),
+                    gmp_init('0xe62f8a17ef5188c7603c0e14dc795d83ddb432b1a564cb3465a67d5e6a1c2c78011155525c4a0ba43aeb3fe4335d52e0', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa071a9532d0151098632fe8808c7eb17b8dc06415952e0aa350cd439139729e85fb6be49850632e33198c432daae576a', 16),
+                    gmp_init('0xc8b3d2aa942d2ef61495b30bf01e2f28b27fe28a4a32f0c93ce09b4bf1cc1b3d3aa4f4249690b918920d8e59b5e0a650', 16),
+                    gmp_init('0x6b6a662a65065464b4de968d07a7d1004f1646a6af8fee581a8de7e0250e429d58da6e1b9fcf799a77632e82a8955fa9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xafe02a9801c83824781f3e2b0a3874f19b49d14b5f9ac933ebd2466442e468cc424774dffc9fbc3f09db6a14ae7f3541', 16),
+                    gmp_init('0xe61ced32c180e854012035c2d3be38e27f3469d6acd97bae14342b05c6b964efb267697e51f2df7b62cb0395660441ee', 16),
+                    gmp_init('0x11c9ece1d7d37b7045027d6773b5d7cf0ff04b221569cbfef3444867f2dcc3c1e1ff5c717bc8f7d876073bc540377c22', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf2e5bd3ad6c71675df310ab12434e25d4f5cdd52c1697fece20d4be146fe0cbf04e05cbd9e63e6f52efe8d3560045f6b', 16),
+                    gmp_init('0x624c64071ad770a1eb7e402ac76994bb76f3bc43ac0222f573bfdaa5d864f377009691d80f5c11f43b63680310f2c263', 16),
+                    gmp_init('0xdd1ab320b165915ae46f6cd96f5e9f8e8a77a3f91fcc5176397f791597c64acf5dbfb8013dc6949eadd1e4b62f3d705f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b420602e278f9bc7da475ae929f55f64398c4382c84c89ce537a61c030ecf007fe63abe09d9c04606a33fea5c1ba3cd', 16),
+                    gmp_init('0x295569a1466cbfe3bdae0e0639e215f82cb6af775564e02228d17f4c957dd7687067f433aaf59c608065e72ddf31a4a', 16),
+                    gmp_init('0xf46868f5283d0422477de058fa76ed524b307cf260f0ea28e2a0acaaf01a4b309d300c160aab18da9d7cf373878a86af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x460dbeec30b62c4a586a9bfeaa1e93c0e1348f57f03ba55c4fdecef5726fd7d0388390c8af59a7faaa4fc926fff5a7d2', 16),
+                    gmp_init('0xa04a62cc6b57ac5e60b21c6e4b396160c287e22aebe4c3c4a92eff320fc6738bf0fc19aa06bf9e5bc59627e6e77a393e', 16),
+                    gmp_init('0xfeeded6a6fda3179731b98c78c8db13faaef709a9b45b760663d5dfe5c23e7bd4671cfa7f9f1a6173c5334ebb0ca4a75', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x96f6ed2e63e352acbb1e8b63ac50020ec15a131d86af8739c9c3cd746336d3929ddf1749e875a6f0cf998eb4f0730c70', 16),
+                    gmp_init('0x4cbb586df95a736e622bea22d4c40fc2421bd866dca842466c3a050248c707108d666597a72eb9c28786dbd743987341', 16),
+                    gmp_init('0x26898d1dd679700852d1260f28bc3238ecd2f970364a8ea06db3d4e9a8413606f353fcdcea4ae610ff69a6b9e64b8366', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xef10515943636fad73bff7836281bcbaa8300de598c6372e83203b8e5fba4932c9ea885a2b96c3e68d698826f93807a1', 16),
+                    gmp_init('0xc707919ba52a604857d2938e2acdcf5f1752d3d05f80816ce795f5cb7bef7f98656b736f56d2761c3c70204b3b7a833f', 16),
+                    gmp_init('0xeff2ec4e9ccd02568952cf9e97f6d55aa18e97398d1754ec2bc575d07925c199dac35c68da0ae1cc8674e023856defd4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x58d2d2ef545a09ce816e27d7204d4f9a29e53cf123506d72589e114f32bc754eb598ed5f770b3217195f1e2a9a1f0205', 16),
+                    gmp_init('0xb088c1e4329bfe033d4da612193f589a336b66798faa86408d7cf3fa38490c3598f56fee02b978d43fac932efa4789c1', 16),
+                    gmp_init('0x36a04ac7bfe248049b3731426fd13ad3ccadb6d0fe20c9e7c438ef150975427814421e603428470f7e893fe8f1036488', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82c5704f663faca31eafc5bd0de44e17084286e64846ac6341d1ce8aad30c4fb476aafa376ab91de78114f1b118088b2', 16),
+                    gmp_init('0x60cfb099afc0f60990dd352ecdf777e2aac6ea1bf3ee638c81a320caa9a06e1a17c26a52211be83d54b18dfca0325ddd', 16),
+                    gmp_init('0xce8482ca184b9c40b46aed27dbd2faf4b90924c221a08023f4babe1340b782cd6cb93eb5b59bc2f8d9aa9799b9f29fc5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb047669ab6b640507e7946766a90a92fde6bd6eb5946bbf4374551aa96f96e7ddbf7d3da777dfe7811e069107def0d16', 16),
+                    gmp_init('0x4091209f9b81b3fa1f7d0cc7ff4c58a80c1a65ac246d923d464f900c8e2a8fc610ff7d6cf17671c7eb394df209a05c25', 16),
+                    gmp_init('0xf88c3e2f9c20e18ab2ab78b625e9221836c6de122da71518a1b9335dbf987e2acdaf24a10d9cc328290743d46cc220d8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3cf3b41b066b3ca7fdcd120cd136414b692203f75812f169496ad255ee0cdff3aa9da2cfa2d51e95c2d72c3f84b0a1b', 16),
+                    gmp_init('0x25e8662278097d2167aca5596db93a93cb99e98e63cb2be16c4c58a2b45c6cbd5943baef4423716d4b42e83f3bd67d43', 16),
+                    gmp_init('0x7e5f7fee4ed81fab08afa8d395c9e2a2a4b71d2246d911c9fa98851bc68d4145d1622c8918096a500cb95396b65d60ef', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x723e602091e874a4a8623861ed93712a41e3d7af64b9a58136085918fcd6e069f6be065095d64c8808e11c0561bc65a7', 16),
+                    gmp_init('0xd9f731823ff3ba3f6ff582e3ec4bf82d83bebb3229d1685a1b523c4570f6b18cc56e511498cf34a39def3d4e0609bbc3', 16),
+                    gmp_init('0xb7041f156a4404e68f194ca2acb9435a802d10672fd4eac5adddc957e2964323170a4178e5dc20be8f5720942d6ab284', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x14c920c05b56278d653c0d301d4463d03e50a15673f3bfa1a6cbdf82baa52a2867c7ee394332ff3611f63236fd020391', 16),
+                    gmp_init('0x602786630b9d0abe7d6ace0195431d52066bff415f1a4a50966ce46f6039506b73d532cc5feef87a9177f33fd7cc08bd', 16),
+                    gmp_init('0x543a64014f828c024c9a1aea9ac9beea1883496d055dadbe8a9533bb3799530dc6fc4c166b69ca27f7e1116c05c03471', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeb9125dafd7d362360a047297a56a0bb09c0b67272c139747064a8f6744bb854631b6172b6814e7d5c52ccd4fe7f59ab', 16),
+                    gmp_init('0x90ca988b18a76b16708251e968f1604963240f34ba321ffedebcba9e0b75e439720211c583756869e3c167af80b65cde', 16),
+                    gmp_init('0x5f1eebe360d78d791f414e0e74edf4b7e11af0cfd5a0e6fca0e9b095a3eba55775488ca8af9d2adec1efb082cb42904f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x135ecde3b5ea00e4d4cff7e3dbdf1823c6b7e27b8be28a952a7ba9bb25bb6a4c010c792c4b885a0c163ae1492e48618b', 16),
+                    gmp_init('0x46eaef17f459ef1954364ea05239bb1ff9793a6b5e2f42843fc1148aa64ae6bbf04d6eda0e77d7adc405241ca2a5f4f8', 16),
+                    gmp_init('0x812cd036d62ac3afe443d438b4b28d11fbe8d173d2af7e8d5d990d0211732e0386545ccd07915880732bd9ca27635e20', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x9357506c3532a39b3fb200b6e96b5a1f7949de970f955d9afbc447e9a4f7152d833ce39450ecf6e84c4a908e253f4561', 16),
+                    gmp_init('0x233b761ab99c105407068cb8428b728829e06b7bbf6fbfa25f27a67e9c10b0136697eb04664056669ea12994702e5345', 16),
+                    gmp_init('0x2a4daa27d90625de9d078a7c8461ed22e65be075f0195a969ad9d88fe2fb3e178eab893b6eaf4afe769af01478f53679', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x71b6d36c65396fbcc7492c33f41c10fbdf6b4a2c2323e90cd7e4d8aae3d59bce0cdd56dc9b01f13be89abfc96f15ced0', 16),
+                    gmp_init('0x9e5ec23762bd4bf0e03f5e08649819035d6bc8bd40fa972ed8e862ffb7cdffeea14355e7a8cfaa1c9ea56a5c59deb113', 16),
+                    gmp_init('0xf62a1a158e9a2f06b7a9c6acc18e1e9202bcf274bae613c772e3380399cc0c762dcfcd1bab96abd72973937b17bd9289', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4e254812da39ebe7e2ccfa9a96366892de63f0d148132876bac56d3fb3fc5b59d38e9dde3d9fa86396c5e11cb00a4e94', 16),
+                    gmp_init('0x98a5a89ecb4b5dc1d1b2dfbe9693b470f97dfdb8dc639970efaad797b5464438a9c60039c0ed798ef60f9cae8aaada46', 16),
+                    gmp_init('0x91cc40ad04c16e2432272551e7fc67e9d947e4abc1c5fee1d7541c32d847aa3e211547e1dfabd1b7e407c1a429c31524', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xacdfff25793e2f3bf1bc995bf6d20c429cd9489e971d21b1d9898aa969e34a4dafbd1171357987ca2623fbcfe1176473', 16),
+                    gmp_init('0xa2029a5e31ebbe6128e8762c96147204e9075e1887a7f1acaf82f2073325cb78afee132adafed8e13137c60d9760815e', 16),
+                    gmp_init('0x80d183d9fd512951b7e356a8eb9316c8ad9237d760ad4033fca7f7a07adcf991f4b3f7d2a13bd7c96626e889150f8964', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x557307541cfa943b1544666cec123b1dcfb042468f5d4be3a8668a2d47f1a4763af1f1660284b43c0f54ff248b57a05b', 16),
+                    gmp_init('0x5e3b5a164ed092f8d230ff74acf10d9d1c23fdf649784aff4c7483eed60fa35c1fd9454b6dea2274bce760c0a59b4fbf', 16),
+                    gmp_init('0x256d9a711594b81766a51dd9a205d9d4e51edc998f9adf1144bb6ad7211db1980a83f7ef028921f485c0d16ffbff509f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcfd95b4d38af97342fa7ea403cd2fdfeb62afaea7b4d7f4dbbd4488d388a5039bea5e4f8070418a3cf364aa378da6aff', 16),
+                    gmp_init('0xb37ddabdd4c4c539f6dec37a2b07556dae37ca14b32dcab0f415d63f4376b5e5583b1783102f9285956a916914ce5bcd', 16),
+                    gmp_init('0x76c7a7c3fe15e3a1d42f6628d10b3cfdc6eccf52602563d8ca818ca62e86c7f10d0f2a9ee2981073e366d4fce65f1d65', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7ce64bc62f79f7372614fd223c47e9b227b4ee746b9152ea247618d21e18a98bd37d65613b6493054852ac0c0c9506b4', 16),
+                    gmp_init('0x4f77219bab1ac57e231a35ab3bc06161b2ced3e46179436e2adf9f5b9c94a4875ddefaed45b6b48c3287be953df1fec6', 16),
+                    gmp_init('0x39efa864fa4cf7433a7c2f481218a53348d85d50c967b2f769c6fbba25a7f3e6f9a21fd938c21992ac28b0d969744057', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xed99d81f197843b3a2f83a6d7ddf3ae4dd3f883ebe7ab02dd85ffda336c264f7b79826178f7c4e629e333128659c4311', 16),
+                    gmp_init('0xc8aa803814f1614572de068ba2a333f1f9cf4e93ff69e078c89e65ad8ff82430224899b31c31c6f36037d50a921c39b6', 16),
+                    gmp_init('0xc7b98c49f984621b766e717dd6e702d54cfa931cb00e30b2c0410e6991c21a39ee75834528ce08a8b320dbde1cd886e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c2f9359d6d74f88d577b0e4b4c9dcdd4cacee7f0639447a26d9bb9ea8dc378dc006a8e07f42bcdfff0527a2702ba7a7', 16),
+                    gmp_init('0x55b674760c5dbfc96fc04117278216224ddd235bc604a721e6029e94d5afc5c95113a233b366456a1c567f565349b5e3', 16),
+                    gmp_init('0x621e0f3d47fe4154800e0edc86c1719e8369779a54b2701a8ddfbf87120e406df8677375371c12ef1da018b1fd816b7d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd09cd22ab1f57deea614332b17f8aa201d7377d15212bd734b3bfab9225287469f93fcd96bf9c7a26f83ee5869ee82fb', 16),
+                    gmp_init('0x476121217619b9fbc9c61ef3b36ce219fd3024328ae0904c32c50e68f8d0fef361719a506d6f4f86f89712b64e59ac63', 16),
+                    gmp_init('0x9a325a5c6e191dae2c6f09eba6b067bf3b011f9461a410d9cef9aca952e2d144278690d40d40b08b1e7fefa7e409ab9f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe566f1194eeb42ff880541df5149a7bd7d3fca38d3a9194a5d6b870252ffd4f2c5d76b732e74bacca40b274533c8e71', 16),
+                    gmp_init('0xff8efb4aa2dce67ddbf255dcde75fa119e9b8a9541af7b45b6bdc505dd1d4fbf242c20c597d70d5a0967ba16b7f994a6', 16),
+                    gmp_init('0x6184819abededd91ecbee612102fd7dba976119a7a556647aaa48dffb21b69e788261196952fd8c01f1eee7e836b899c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x864425edec4a4b82ec27f6cca13efba92def92551578cab812132944e8a5aabc6d84ce8d1c8dc01827c9bd3c28c48aaa', 16),
+                    gmp_init('0x32050d570ce67c692b8fbafafff3cbe5ad90a8e954e5e4d43276fac258ff7187f484683156019af80c9ac80a5acdabe7', 16),
+                    gmp_init('0x45cfd9e188fa861269f5ddc090989df74af98e2b9d4fe6f53b80f3609d0e88d1b9f5e73dfc8b4b52efefb47419f1abd5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeb175470a995c38700a8cafbaa4cfd58fc2a5c38d5dfb82ad86b5e2e89e7317948bfd2b1a5e69af1041a1031a11aa343', 16),
+                    gmp_init('0xdf45c3c63807fe3c1a675588f13056cefa6bc0f28572d1571fa8b9f4f9d9471a28f6300ad709acd41cadd727468c713a', 16),
+                    gmp_init('0x2adeb65fbd4c00c7e9a786df0b5091df80f75ed8174e3a6be0e24a379f32db9b7b77b753647128a5aa85e52406207725', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3d07fe7222d094ba3937349b71472f99673641c41d6931fd46b8beb56eab6925dd5b14e9fcc2e34e62902dd0dd940287', 16),
+                    gmp_init('0xe452b9169d1c2e38da105901fbe913a2ca5cb7bd5982943cb6d1c6d144d08cd5018090f6a251b5d5fe2d853b3760eb6f', 16),
+                    gmp_init('0x24ca690ba822dd02928978bf940da22d58947675e9cecafc670974a08c5ef0757e44557884c42b131ee35fb88dd5a778', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe78c792cc288eb1be61116ecff9a1bc0af3e0c1812282d26d4799d18f6d82c3f8d7952ea8d820a9e40d225d7e52eb676', 16),
+                    gmp_init('0x155500e797380a08552afebf459bb26a286f2607e1034b805ddc51771ec190ab770e3ff048102ab70951a9891e8cb347', 16),
+                    gmp_init('0xc8a0616127e45f216114391dc9f896ff7b8f198c0cdff8c5e0ca1bf5274e51cc571adc95fdd9650eaeb04de87ba7d3a4', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xcb1c32c0e3d2cdc786f4babaa464b5fb42c0218065762bbd66abca5f9f75d83495632944988354869701c111f7b6ce32', 16),
+                    gmp_init('0x7587bb7c80efdcc0bb436c4d5e94321f086e881cb0762b425d06353e8139af01225b7dd290778a0155101f7dc463a38', 16),
+                    gmp_init('0x9ee01edb0852b2e8885544966205603130d7827679c4cd99c3301bbcbdabaf51f6c4e32690250c33c25e4988af7a5813', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdb19e6f574477cdff150496ffc62e586195b7778595b36a955bf9802851db73b50e0eee526608923b8d184dc573c4c0e', 16),
+                    gmp_init('0x4a325add21b203c123545fabbbf88fc8b03e52e33f1a1ab7e0b87392f1843a379edf211b07210e806638d0775b1fccdb', 16),
+                    gmp_init('0xb26773d3537cf03761550cfda8e9e5abe88caebe0628387556291fccec3dede4ab847291b679a5e129e3c833d01236f7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6a61ba7845c493f9136b8c9f9c79b9fb8bc06f18c6511e37687fc4b137c9540c14d95f6d6aa0fb2dc97eed11b98f6e2', 16),
+                    gmp_init('0xef8af02dbbdd2a11811c8116f20c80daf91ce6ec3641d0aad7042d4ef54dd1e1e2db5dd52df7b316053cc6c61e254ca2', 16),
+                    gmp_init('0xd1067d47763197b49885a28acaa00d63921d4c953b6de407ddeef4afd8feddb3c6030d9816c21e33df1827e284c9e6fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7579e0046a24b62067c6fcb6f6d78997ef2a683332b0a22f91b32168b532efaa7b9d552fac75d4fbfdb4d033b9594619', 16),
+                    gmp_init('0x2ed8a9633c661e5e2b73a31093f3414d289458faae6b4b6e760f755c5837afe0551d2d200ff2a18544518bcfa8021b43', 16),
+                    gmp_init('0xddf52f4050f9560ec34a9115dd0c45eafd5af81ea162591e29364d7df9bfbbdac8cf8408f80207a3918949ca82761b6a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e53aa2e88a25fcc0e8d10f196ac8f2edc5a971cd5f27e41d49bcd1fe144a6b7fe3fc975cbcd34be955f5fad1c5915e0', 16),
+                    gmp_init('0x99e7f92ea206db0063be2f5fcc8ee3a83b5c3b4841c870c58394b8ccdaf6646362f6cdb90f070e862417d69d9f790d5e', 16),
+                    gmp_init('0x5740d2dfb47ec6300b1c15813ba3f2d3d8bd79ab3eaa818acdf2f78936ccbd4bf22ad3f27d2977d59696e71e50df9ed7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x423868c3d7a9b0a8410d9588d5059bb053d5299f7c09e33666645bb1fa1a5cdb1d22a703f1e8adcfd1bba8f5b1c9cf0b', 16),
+                    gmp_init('0x3a6f1728ffd7d7fb21f6ebfff175a86a6e99acf3552f7843ce86f363659df7f7c0939210b7729fa2d9c3d7bb85191e9f', 16),
+                    gmp_init('0xe5d9e9a0bfef5023e3095ada3989da4d1c150f7b9454ce6ab8352cf3609dc8e9fc952f596b40f3140c39c5cbbfcdff90', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda490621574cb9ffabacc435ba3a90439f47e29f82d740f34e5301bfbb858f74f44ab6e06a859fa2861bef6b812de2eb', 16),
+                    gmp_init('0xadb0f489a227e0c89f92ca889c72d5a9ef912040aba7c3f3b846e20e2615f19a4c6d77ee0566f8b35202054b15b51065', 16),
+                    gmp_init('0x4fd4dd5ef52c16e7c1640a8bacb414a63c467da4075e603c3dd73f9cd550d4d22c04927e6c694175ce489a7bd2793d13', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7b16050517c231976d405f9b7b0f0f9f26ac37f930bf6279a0cbdb88b6d621e0abd924ef4d91ba38203a2853c622cd56', 16),
+                    gmp_init('0x527041b905b9022c8e7273bac9eb987b8b2def1ac553e7612dfd644f7e60da556543aa5c2ca8fb8dae0a7b8fc10b927a', 16),
+                    gmp_init('0xc485025e0aea0a88c4580aee945edf71caac0389909bd16419375963c7342447479fea2cd04262058e6c25ec66cbaca6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x932c354818e2d786d9cc0fece73885db1a1389a818b4d132f029fb94805fed96340bd9993b0e2682d655e9554d7dfd18', 16),
+                    gmp_init('0xf497f8a62999d695786535f0723b3b22aee0a8eca12833cef8883805caed61893fdac8e8ac4793af0df892b9491c7999', 16),
+                    gmp_init('0x8c22740dfc7dae7944bde2bbcee84b67c498da29c1a8341d28bf473ff2676870da0e215201195f041c1f14c7e6a5e3c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x32dfb95c45731281b0ddc8408d3a3586ed4b6f7d29558b8cfe78584e2bfce5b7974eb8dc260ba931facbfa8f273a45ec', 16),
+                    gmp_init('0xb01a6aad2ec1c549c2a862cf54ca4139f89cadd964f06cd810e9dcf3e66ef0c18fb452c475b2ce5ae0ad88bfa73ec343', 16),
+                    gmp_init('0xb5cd6b0b821979aaa4bce8937e364ada9aaa3aafc1b5afe795b7f978014923c652f9e77b0ee0d5536a254a548323ec3d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc3c32a3cd94c394ed69b801e479e098c00056630f8f7a202335f07526c6d39ac406d3bbd97137d5838379962a2304365', 16),
+                    gmp_init('0xb41e3abc6bc4e9ffdf07a6f2752e327c6f0f09ec0a9930d8e24d619e97e4473a2b6b481ba00f5686b975afd9a80b8e8a', 16),
+                    gmp_init('0x4303099287c204665e966921a1ddf7a94e3b911baa931983bfac46dbe83d529b378cb115667998ac71bc8b61743a3b72', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce79d178b3760ea6e6f4e5f06d031c9e644c249167847405032a507fe51d7f71dd915444c7d5c267f16f635d36ba7966', 16),
+                    gmp_init('0xdc5082bbb4811b9a494cd88f7d8e889f0ab2d6a2f6810044cb5ebe0af062bb0f93d9a5351140f3e1eabc22f4a2f40401', 16),
+                    gmp_init('0xad941a01fd4ca3d5d52e1b270cfc695f2d4981159a149e6490d2dbad5dfedf7e9feb3c251a803938aaad21b607d1ca1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7c321e8a9b0035531dec0962ae69c26802245305fe1f19567074578fcf19a55ceb5ee9d7c7f7dc29ca1842b9dc709d62', 16),
+                    gmp_init('0x4db001254c7be3c79902f473cb61e815e0b5b69b26783979421e00e2522982307dbd3bb5269a690964dd3956ba02dceb', 16),
+                    gmp_init('0xe6ac55509cbd4d6b3f9402b5dc41480d196c15c5314916c983fcbc11fe834f6a1e06588bea427b91d04b36750565ed75', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa4c44a5edd1fc2c7a1d56d5da9eec6845eff8daf4830ae02f1ba4ddc38b1d9e57a5468ed3ec4e17a8da14f3b0ce0a4c', 16),
+                    gmp_init('0x86ff6fb9606b783d4f2572fb68cd07f4f36c5e360c144eaebed6ac1f384bd9162107535f3108aebc88c36f7df154e20a', 16),
+                    gmp_init('0x67dceb3365b06191cf5542e2054e011b995281d6093c663c5f56daa0dbda74b7fc3aaa01834ebf5ab1bca78e2a1eed26', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2da9b7b69266a7393966534b5840a668de5a839802f069420ab29a236e847aafc6b13395d5fe14f3a783fb32051e7ccc', 16),
+                    gmp_init('0x4c26558dba9a9af6bf0dd36fa78b509146a0ea64e9130a18f02965b5caecae8043e5fef2e3e700673692fec7614e7c92', 16),
+                    gmp_init('0x98ab28e2570a0874ca435678c04f33b3fa4ea61bc4b5ed7445a18242908ba60e1e20ec5f7a0411a17b8611badf3f0321', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x792ca82d42e0f0bef48da03db5647950180e74f7e08a7abb7ac6419369b296ea93dd2687a4c5cd51e34d8c1cef5377ff', 16),
+                    gmp_init('0x3ba8aa3df98912fb8117bf93ce084907abf561fce6333dcb2fef9a36daa942f993ee315f9771271c34fbd7d931001b5f', 16),
+                    gmp_init('0xd094c047e60d53ab4eefbe92e4698d7db372f30b1f11e10a072d564d33ed4b065d62483d5da6d5d401bb30ff6b58ea66', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x51f34bcf72ece75222baf001bab56937b453a8c86c97b44a38113cf7dbe25273f1e15a4d6ddbd7d65091e08375c196b4', 16),
+                    gmp_init('0x1dbe0219e4668e47b0c5d4825533a95edee1c1fb6e3a4e7346417472bfa2127e627bfcdbf5ad261fd93911e780d7e923', 16),
+                    gmp_init('0xacd1f6fd087915b5c748d09111f5fa0fbd14daada7e731cd272c2456e5dc1857a851387971d4064acf14bf8b232a5f97', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x52dd13c81396ed71def5ae7c37e8829772c674410d78eeec4152d6f493a7352e6f0f28a90d6a85eacf2f9a93fe0d173', 16),
+                    gmp_init('0xe6089d97ec9d10f3ca336dfc3c51c055d95ded2a88d9d8d59d3885f6fbd4da279006106f0791eb9306be3daaf664d333', 16),
+                    gmp_init('0x2567aef1131259e014570562f82543f03c6f9dc3899b4810370e4dc4a013c7a1baefbf0ddf1b3ee2a9cb349be0a1d3f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x731bd9a5ef3d77631ce4079cd806e8440b6ab448bdf6f00253ff27e04b224177dd55438fb83801f27fd384b0525ca1f2', 16),
+                    gmp_init('0x12f1e134a156436da80bcacb70043e2e91787333d702eb39744d677a6e8f996b1212b47b9a1e8c26fa0d5f5d1e6ae1a9', 16),
+                    gmp_init('0x9107dc7f74dae5843c8cb323a9b3dca11c436882472708354d63ac5226c960307f7c0a06abfcdd488cb782bb89d89b12', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x94279159dcb08bf28e66bea47ea530ecd2fc03178c52d95367a7f0e4a9e8ae71e5412b1e997eab5d5eb99be6953bc17e', 16),
+                    gmp_init('0x210f72fef1464370970c95868e3f959df8930c889a7fdb775254847e1fb74d725bddb16e4ccdf612b058d036b2cb08b5', 16),
+                    gmp_init('0xbb4c816a3315bc2811b91eb81a784af6c13761233ab32ff1e41d17d54dbf0d5e509482fecdde74bf9652c8341af40d33', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7f13c2a00f1a7444585f5aab59a04f3adedeb79d3a89933f2758165f98886cf8d82d514a760c0874f587b4e026afada', 16),
+                    gmp_init('0x410e74ace8e395c2dcc0fa6e88f72d126c64228ed34c08a0c7c6586d472353911b3eb3178de9b4fd2afd7bf73b74efd4', 16),
+                    gmp_init('0x81b4fd0edd41a2358ca362c7d899fae27f425ec020553b963562ebb19f7a809d2820302532c63da6dbed911fd6d320f4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb33eb8ba6f0caad3ab40b7b94db83b1652696696a1739f3cd1b6d4c27c3275e557b2f79d6a3bb04a5d4ba1b0100f7db', 16),
+                    gmp_init('0x98c2931e3a88e18308e5b3640133c550882921e807f510d70582bf9acaa5a2bee29d84232220d1403ca320d825ce1d6f', 16),
+                    gmp_init('0xfcaff99eda6df95281a6d8335d26fc2724182cafcb6c8ebcd08fd0edd6b3c8ef28a6ac44714182a7b4b43e7c86e417ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfe41b2052d5cbda7f316ebd0be1c3835add6b2386bdff0470ea7e1e0d1308ac355fc571b108c25ce5388e5eb24062954', 16),
+                    gmp_init('0x6e1e8c04e318a45b50665e9f8342563a51004e7bc4e47d3f20a8081118a24f83e60735e31bb13375656f9a217b92e8e2', 16),
+                    gmp_init('0xdd2f135c8adedf406bc6b2329e16082767161d4f84b9deb9545cd0037bb8008ca09138972faaeb02d361a66310a4ee88', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf9bdf1a01731f3b4030d7550651e83cb36707684ca94dac18deef4d436f6d939bd610fed80f915f70305db4165b124cd', 16),
+                    gmp_init('0x828be5a24fac879177868207921cdb6e22fa3c64b72bb3ce0f3a5bdf1077121d51c4ed4506faf6d8028e18a25517ea50', 16),
+                    gmp_init('0x31c0791b18498385a8e57ef0171f8456a615e861ed0f94daaf856e320c39e1532f136f33e4ae9c69c7b3e056eb095eac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa7007028afbf6f02e767076c65b05d46408073037c94825b5cfa2c5c2dfd1e2a409b820ba49b83c854f7db4fd875f1d2', 16),
+                    gmp_init('0xc39ec665539695814d51104688b851e1ae9b8a9af32b1fbbc6412964172b72580990958b695443519cd0d0b803760657', 16),
+                    gmp_init('0x8d8f3872a2b91ae73ac16acd11670a58b533835c36dc5044b55a14eb65153905a058985ac94fe6d27973878afce055f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7144f7139391e5b794dc3fe254f25e55fac7a3f3d10d446d6fb33dd11255a8a7a945b241ac02a7d57ee46f4ec096d710', 16),
+                    gmp_init('0x7bbf8742666a12257b46d0e4428bf50d21502695940bcaa52a6707b499de655876d50a29b2a1171af5841f205902b5aa', 16),
+                    gmp_init('0xae00ee179c1c62969f37d3ef6aec1cfe2f6992ce04465d17eeea9584ef486f83e1f220b8ad4004a1bd7ff3dcb45316a0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb57211aeccf263f0e8a7025d32e51f057edffe53242ea7820b55c124cdf03a252abbcd55d9b4621a3769d1b50a5b3293', 16),
+                    gmp_init('0x752ab0b286ae94b256589994a7013f5dd412776d00645692fe4aeb21dfb03aab60feb7c2bb1b5c586f4586d52ecd05ad', 16),
+                    gmp_init('0x95b5deab892d44a24f64fd45e4b21cb99b408fd6eeadb76afd2df316159c1c6d15c89c4f2ba7104c927fc25a477dfa67', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6923cd3cf34697d96873481dbc715127bc8685d72d86f8a50af4d074af53cb1363cb194ac4d66e7b339ba3fe74fa03e7', 16),
+                    gmp_init('0x5b4f80453e260ed2f121a32bf6f8cbc1a52b604229afd785555a54263bb3196dad132340d548eaa1f3b42f24f77ee062', 16),
+                    gmp_init('0xd9101540ec917ecc0467566a8e0894b46994c86ab167d4dbcf4cae2e6898cfbb0c26460a880e5ae037468de193638dd1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3e0fa48a3cb14c967d9fa05160af771b520473866e8f232c178d39beddb3efe56c11318023b26640e6c35365e53240dd', 16),
+                    gmp_init('0x32f22d3daad38c1f10bdb30d2e8c0d8dda7725455e17ef9aa8d6ab82b61cf0ac428276788a2341332ccfd141dfed3f45', 16),
+                    gmp_init('0x4f99455867bb39806d886903b7392a67e2ec8807ce9829519f857e512152f54ad227c6f734d39983d5169e1fc6e26d0b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9bfee1a70a7aa4433bcc631d69e63786815794750472446056522c4c41c658f9f8fd8f7456b789bd534e776cd8b1de4b', 16),
+                    gmp_init('0x40cc7de9626dec1ad3b2518360278f73beedbdd1071628c3f1c1ec2c402f0f75518d02bf10b6ecd0a7aa51dfd6414ca4', 16),
+                    gmp_init('0x3c6d2f19f97268137e0c1e4b80244ce5d1826d9255b310a3776fac3a24688780bbd734a00efe8c3bed68b99da11a81a3', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xbec311044cf4497c59928b3a88660a9d06f1bc935cf3a62c9433606efee5d9d8833ff81bc3e1551c657b56683730de14', 16),
+                    gmp_init('0x77e623e73459fece8eb333758872d5df6fb3459faeda16ef3b7b212529754a2578c4f025119332e210d788d8a984c12c', 16),
+                    gmp_init('0x8f8bed3be92b449108057255181bc510eecd9f19b38c675005f2ca1b5ec41eb7b88832985f8d5e9000a2a98444885d1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2ffd52ef10a742fcc7d7296cad35d31a20778244cef065c2c0355c91e15b8c110f94e5bc2db4f15d3b3b2c45df754d0a', 16),
+                    gmp_init('0x2757652760ef39a84bcc07dee3f35488f9e13f72fa5e27df7c4ccf5a9dbe297e06ff739029af22241bf4f1dec8648fb6', 16),
+                    gmp_init('0x6f8199fdafdf956943ab3856b71cd131bd8eeca5811ed203938e9f498adf74e87ef18c8909b5e53b8291c37aeb5e252a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1b8116bb72bd7ca05281647516e99b9e10ecaf0f8b40ebe5a4a4f0286976b09ce87d64d7bb3d8159de2121097a9f67f1', 16),
+                    gmp_init('0x7bcdb6027efd891ac235136e35b013689d0d01a4c870aced529167dd807c7dc1404cd91e78ac5daba885fe81d691640c', 16),
+                    gmp_init('0x9ebf9a3a0517dc269fb41cf9ed90ce8c4f45fbcae4fadfc720f64436a5270cb823e5a16e62e647a083a1909d5768415d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x84354cfe41c5ea6185749db81a1e3d44ac9ba4f0db1378cc0f8f50a30f9229cc2d1303064a9d717f2d569ac01598b2c0', 16),
+                    gmp_init('0x7aa5d12e523e0a2d19ecc6400bf5d88e4c93f6a0e680d47dd19fb4a730ddafb8de4810a7bbeb82ada43ee05389974c95', 16),
+                    gmp_init('0xb457a00110f94f9194b7205f69ed0320bfb319024d35f0563ebe79d51eb54acd89421c685c874da62572dbc947447623', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xff701d075e927fe57dd202eb1a334605fd9f0f3efb688bf31cf191bbf9fb72a6acba084109af67835d1ff5b5e45a5227', 16),
+                    gmp_init('0x7d1a60ec40188e61953d63d6cc4f9b748d1f951996195375ee0294aee1a0cbac3f3c08a509d942e81d6e4ce4c45c421', 16),
+                    gmp_init('0x3342f991a2269e9e08111909f5eff9c0be0f921f267ba97907d4f3dc6080fe6c8870f707f1d63c52c114eb9dcb6b0692', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xacd50783619339d862694eb753ae64aa667605eed632d69d3a580e68741ff0619c563dd9b3a57d0ceffcc8bbb3778791', 16),
+                    gmp_init('0xcbc0446c4d595ca071a885f8e0cc710f2b8f95b50e2ff6751879fee4867bad72274e74194f58041b10659031ea20455d', 16),
+                    gmp_init('0xbdc99fd445fb6739247eafd4a911e41f3e4f190b849f7fbf00bc9f2494269cb7d63f3ed1c47bfdb04534291e4f90910', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa28985572d95038cb48f6ddda965e7160c421a2ca57e4a18214c3ebf11d578f7c6e83d0334ba1de298edfd1a8533356e', 16),
+                    gmp_init('0x5d64d77bf4edb4ddebdaa290deac4fb90387ed6467d9320b843a6057550b04b58383743db846fbfc4e50b58624f773a0', 16),
+                    gmp_init('0x345d896d27e58d8166fae0e5c34c65ca046949f93672f6d53c4f4017f64d03ce00af32c3f9f8f70414ce752451812e56', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe282b9dd15209d9166a3ed13a0f539168199c1264dbdbcbc929660ccf6485a5ef23879b3e629fe5e04c3b32145878aad', 16),
+                    gmp_init('0x3248040341b67d99b258ced4e12c1a0d421777e115dc87b0082643c1098a97b5872f4e91356555e311dcd074f58db14a', 16),
+                    gmp_init('0xad2e8e4d169ac6313f3147caff8dbedfdf3b57a555bae101b88bf6b3f9ebce984b22a5ce587db7929aec1519d2ef7fb9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x782eff504cd96a4994a68ab837fdda22fa964f0643263cda72fcf38c62114ab7e6bc1cb0d870896092f350f03d454aa8', 16),
+                    gmp_init('0x8b9c15cbea4ccfd8869a166e30e1ec34018e15c614d3da7e87832540c6bb43e61deac037f0f7208ea8f8b488fd8a0724', 16),
+                    gmp_init('0x4f78d223e7deabf8914c94d7dae084ac41c00d9d76a3ec9a837412e6fa3b2e89f7b5f639959f6366dcb37716475a7074', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x61bfc9d9a0307e6d5321aa1dbf39527458ebfa5098562db865aa35442bea6e1f16a1594e8ea6d55bb6055591c3a91216', 16),
+                    gmp_init('0x2250397acee76c90a41aab41ac4410c9fafd02355f8dda39da278f35fbcfc6cade37959dd3b8d296d43698c9564e1ae0', 16),
+                    gmp_init('0x64f95a4cfd424ae89d8ddc4580ccad387d06ad7318dac2cd7b2e6a89be340310c6946762cd4d845d56d649d8f9cecbd6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x820f8376ffdb02f424dd268a3767a6a2e253363990240b528d3fce1989ac9a1c997e878dbe16b01307844c399620e955', 16),
+                    gmp_init('0x3e40604b71df8bfe54765ebd6ac7f6e4e4bec0e71c0ea69a2bcc24df9cf16a4d1ea9f50b998993eccf99943b732f3757', 16),
+                    gmp_init('0xeab8aa9d4584f2179b154995cf954afc8dbbae2a1904b1f3df8ca27984d0c398b2e6341bd7a7cd3cf72e2aaff16f7a41', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x51271b786201ab05912484634ff95f7f5c63fbca0c997e58aca8ae29019b875b1ac5f41e845acedf4d56104b9e9e223', 16),
+                    gmp_init('0xa870535b949c98a908c4d90cb4866217ce4ac898c619d06c296217b5cad9ca7d90d7cea668382c40638b28ae1cec2d9f', 16),
+                    gmp_init('0x5a429fdd7690dfa9460dd8743a3049d5505eebe6065e3005078cb278c2f6d550b9ce577da26a8809eca031eba54496dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa2db3170408a5360f64ec60acddb551906259be9c66d2e1575d278059b1c56ec7fe107758e3eb098b7767332e7d5b707', 16),
+                    gmp_init('0xe98cbecf22c0855834ca53a1c37ace3a7620b4d1ddd0f17b380506f3e59b55d38b86ba8a58534998dbec11e5f4d567f', 16),
+                    gmp_init('0xe2d610ba0dd091b92af27ca93d7bc848d6b383ed926415fa8a156b22848a58987f535566cccbe264dbfc375c253b451e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x876ee561e744fdedda5a6e01f33581da371585a435c235b289fa23f7b1343be0c0b25df68def6212bfcec2481686d572', 16),
+                    gmp_init('0x8551060c2e2c7f705c698460aa25863840314fe26350e991c851e300e86a98c25c256b18d254145fff2d4e2f4b94c989', 16),
+                    gmp_init('0xc78ac0340a0fb93c1d545a9f81ed0c8368d9c9c44478715a26e8d5827201249b41d99ef11e61e9a7ae6aff523623eb92', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc104b83a573a65aa2f61de1d0a7780a96e66d46c60160d53650df2d921f9bd69752b2a0d376ed2a804661aa4cfc58698', 16),
+                    gmp_init('0x4873715d5a99a80435940b0ca35abfc52ed0a56e36d0ab08f9ffbb7f61bc899f93840d67581f14a68fb990520056b6b9', 16),
+                    gmp_init('0x5963f8082e53f293f0cd078ddf6508b83a1e7cbf084ed83dceb2b8a2f598272080e27e17797066ea7f54552cb6c17848', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xe156d3b3f1edb5c6a6bfbccb034fbbecd9126999d270768dcb3d6ba56102592a7b360671199f989e5a380a7058b2ff26', 16),
+                    gmp_init('0xd4a68088c0e4c4da6558dc3a2848c5e036fc15cd2047bb32c9ce61e20a5b71dbf070ef85d02d5b3fd10b5b784b727d66', 16),
+                    gmp_init('0x9e706df63b6b627d9d6f35743f9284a9fce77625ec24b55cb4bbe0e7029139e2fb5a625939b717c24681034d2b247ca5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5def383874183660844bc8d7e7bd5579188e029789e69417d88825edada837b6acd5bfcc17ab962a0f69559390b7329c', 16),
+                    gmp_init('0x27a279fb8d4e15ce706bd3c49c65ccc15e47266c78604fa9193d748adc0730422d5ea2a79397e3d5fa861a7dd91507ee', 16),
+                    gmp_init('0xe7de4cbaedfc7f3fe41ef20e3ad72cab3820e32b05791b3b0ce42592d5e72ba202e782f7fa3c71d7d4b34cf61bc8aba6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa295407230646e8251d20316803cb79407ebc1fd04b1d647a8bbd208bbbf413867ab46fb0d8f79236bf141169cc5601c', 16),
+                    gmp_init('0x6f4a681f7e3fb4526a8f0163d69250d992d9fd54c60ec7048a691fffc1a330d6ee38e22a7c1d6602f4edc46a3baa1845', 16),
+                    gmp_init('0x71bec8c7914c4fae07278d866a35d87d6403b51b0dc983b4d9e16d43eca10fdd4be4b55461841737438d71793da4d09c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4e5bdee33b865c493718110e00ec54076f55dd9465bfd81ae61decf20e94e4804743a8f264514fc622c59af841a9c6', 16),
+                    gmp_init('0xd6286329e14c18646b2f277ce720cbd6029c0ee2f857c43a5c9a36f08cc6ee656401b47283d2e267427b198492099626', 16),
+                    gmp_init('0x690bf9fcdc288d496322e61dd4e280672c423a15f4f99f0bcb3374ad249aec29ee25dd83e3f2a6d7e9853e2a3831f77', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf796bfcdf2b384419a0dc4cc240915f0d65a69ad2e0f76512c92192e59b46e6a78d9f81436fda7a15396d66faa314324', 16),
+                    gmp_init('0x8c1b73353accef0b1555d05a51e742efa5e39e42dd7b8805bd2fa0bf1be54d6c7fef4ee8ae2a9f3537a6cfdacc5a600a', 16),
+                    gmp_init('0x797086c27968b43d303792f0cfa4cbb9eece4e847964c127f7b186878148dbdf04b23001e8b6ee63d6d578f1af1771ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb792bcad61a361ff969bb270d4fe705a1604cc35b90b8b59aa4dacece05ae99a3cfb33cc0ae4fdf2a87d96c52b8bde08', 16),
+                    gmp_init('0xa0de466daa39465f57fbde43e8f30b26acb44f737e8b65d6fb835808a6848ee345026696e8159355d9e25d585f18712e', 16),
+                    gmp_init('0x1a65095c8b3c6564fb3fddf580d0a4cc17d5697edc450260f716a01a641bccf7c40be6f65f2d1e70e3913341bb3a84fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x535baead48a4fbf27eca4b10a5d41471f2ea503e665f0979107e333199551c487f82f1e2872e4978c89ecb1224089e3a', 16),
+                    gmp_init('0x300b98199dafad6f04393cfc872a4e4af9fe64d9a0539af83ed58c2e33fcac26d0b4d3fe68084769053551e947366435', 16),
+                    gmp_init('0x59a0db3aa3608b7175b097eac0c6b179790d7d7074556e40f53502daf2ee9bac6c4b620ca3920881cab88885ddef4d16', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd50a8d9f8e31fc350572616a77161cec257a3cc86a935cc93d369f4c4c103587b2ab14dad3e8cb88cb894b2a51c121a7', 16),
+                    gmp_init('0x8e56533311eae856abc9040179558bed5161e3692f077a6cb90c2cf24a8441c213bcc8613228ee35be15185ccb9a6e75', 16),
+                    gmp_init('0xb3361622f40c799a8b7e66aa112a9752f343b266c98464b4fa9bfa859d060cc352a4ce0077c3d728cd7a9bc3b77be60c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda1cf722cd04f94b533d8a68a95a426bb2aa23759dd739d00ad7accc25b2c4a4176f825ef32231813d6cbc290fdc4c9a', 16),
+                    gmp_init('0x2c6923754e2ae90ff8e3e6d69878def45d91b5939fb17315ec97c744d73b4570c1efe5d210d605bdd22c3e2f36fc4b34', 16),
+                    gmp_init('0x325a4bbe74737cbd3391453c49f489bb964afe6e1ec159a414bedaedbd7b89bead62c1d36ee2a1b174d8071c936614ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1143b860ddd239a0b8c2777296dfec69b6224d73880003ac9a2ce9885d442e232ad34f03fd5027607f652d4cf5f3568d', 16),
+                    gmp_init('0x7073afa85a616750d732e2935284c44392cbf1b75e228e2a5886381bc26c7df886c21c6bda7f33a069788aae820650fe', 16),
+                    gmp_init('0xcbf7992d209e71cac740f1884a2a9aca23f1ceb04b050372ddd490686b7ccd565d9aae2802da62d0a86271a9f45409ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x90439959ac0dffb27ddefe48c1f2ab4dca82fdee3b47690a4bb89a57131b970e1f8bf764fce70bbc97173439a055ccaf', 16),
+                    gmp_init('0xe60dcddd6d464931a4e44a1e03df01083f5d7ce6670654839b0f9f656d238504e4a87f483942432905888ab1600a00f1', 16),
+                    gmp_init('0xe0b0f4db07473b46408c49b5510eabb89a9b9eb68f907375ccfcfdf0531728b7e073e2a947f61b77181aeb8f7471c702', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x15ccef3de5c41231914f7f0b9e2c2743b32afe5e9c77964ac7d811e19a9c21083823eecb65ef892a946c2715bf3eaaca', 16),
+                    gmp_init('0x83de8a0ce34c0e0fbe592c904fc1319420ca425db7ab750f672c1da2183079a0ac6213e971af6d2a5ab33891923048d4', 16),
+                    gmp_init('0x8be1ee3e3accaeef85ed6cc7abc75377102b08523d0c20fe3ed4887808c20248cec073ee1f16ddf74d18e5b36a4bdf69', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x15e62718fc7eb979bd80da1ad1910a5d0646b124e968556b184407f5be47ce1980dcaccbfb050dacc759c1fc017643f6', 16),
+                    gmp_init('0x2deb548b18db3c73676ec75c913c20650ced8188b1db042b2bc1aa0310eaa5b82a8024964fa4f18bb46979f020621e6f', 16),
+                    gmp_init('0x66a48f8f10faa2565037b6043d4970d9c0d94cd102680b9cb7cbd703037cc548b1b0b29038474da4c86a83600508871b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x72343efa647742cb41ada2e643c5191054dd8f5bbf349f734a4a525bd2ded5c1f5327d4d2bd74217f21ecae9a2f5a86b', 16),
+                    gmp_init('0x3ec69befd4cc93d012df328d46bab899ba6def13c6a74ebbd1f8edb65a68a9f6c5bebe237560728c9864501706a130e0', 16),
+                    gmp_init('0x270d545e71ac293d647ae50674efd8865c823d7d7a3a1cc3f3082c6e8c331045f3954f0d522f19dffc7eb4c0adc4ac18', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb808b85a2d5642b7f2eed33a12ff40888eae0a5755f0b3ca653f5ba61c25e3ffc49b1bda73a26ff460ef3fd06f99e428', 16),
+                    gmp_init('0x14ae179bf256a45e2b083a7c274193e12dcfa2cc786624817e990057e4365a64b8218fba36dc17bbd3d64b08151f9a8e', 16),
+                    gmp_init('0xda02f2290bd2b13099324be1433ed2cf90dffb6b3b947702dc0d177e68703c0ca53bf210a1599f0fd181b4faf43ea85d', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x1282cd64061b16aac2ba830c18d85b9ffbc9888560b1871b50cd2fa164169acb3afd734bfc729e9d1afb5da6661f7e29', 16),
+                    gmp_init('0x29886f284c4d468f36b6afa7463abd614d29fe45c48c4b96b26997a44e5267e735aceb636444a3b892b36daaa238a593', 16),
+                    gmp_init('0xc9d1cd7b98a6a68a883b304786edc53cadf6d205c8174042b7d436b8c86f4b5bef069d0c0a06a1c587c192d0a7d1ce97', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd1569716f706416e3999e0b1e2d50fb428db894045843a63479e1d08eb9e92708cd74af3366c260bef7a00f1206ae5cc', 16),
+                    gmp_init('0xf226d20e9515b305d25c1a933ebe0310b1f93652997ec9521605065362200e89bfb167738d34d8be0bd2df11fe717abe', 16),
+                    gmp_init('0xf0ea00d2859a199e8c0c944a231524cf1a488e70ccaad0c210da8fc46846aa07a441551287cda2d8080130b274e43685', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xebecb8bb57554d9566e1c1f09204b96c7ecfb8b803be4ec4cdf54d773ea642955832da95d8f84ac6f6673bcf6f83b8aa', 16),
+                    gmp_init('0x96b8d26072644fef90902666fc2702a929e46588545ec29daa392ac3298d1a276373037b63b98a4385366a09b9592066', 16),
+                    gmp_init('0x91965fd3c10ad5f29f48f97b7f14276ed90fa9bdefae306f9a4afadf75455212beebce13967a91e42ebe78dac55dffbf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb0fb01898b301c17058181372ff6c6d5c7ee6c869032e99c428b54ff6879b5e7ca7cba729408b7feb57a4528044bed9a', 16),
+                    gmp_init('0xa6d2ded60969c09410a7778802cad5ee5d292e7f2f680668127a24dc6f12a0ea2865c59f054d34b69d6e6d7d706935ca', 16),
+                    gmp_init('0x2c2a8550cb6c35bf22d1dda9a32fec4dee5c94397f8a6b3ddff7b66e452b0ec06fac2e9e96324946af20292bdb2bbe9d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xba7940a06f1b8344ba8193928f50b6594d89fb5b8f1664ae3eb63942570eea779855dd1d42730d830b14dd11676ff9f6', 16),
+                    gmp_init('0xb7133ce04dbfad8d90fe2680dc21519bfcdf4b63b368a7399b483879787c7cc2f42d566df595f2289fc5dc4a435901ba', 16),
+                    gmp_init('0x2057698be5d2acf3cc5485cc6db3bfa6b7434652f2b6c560ecf9dd3548625d472de18e0144a079fe997de548bf72b1d5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4ba504e1f559649c76618cd8312d5cd3bd2f87f53f9947509cb56a88f91707f3dc0a150cf98df6c20e3a11d8c760b715', 16),
+                    gmp_init('0xca2c5295c331b59c5cbeed82c549d8151efde59410f1614ce4d6bdac35f3e2dd7c6e9d750668bd409ed22c447f75a160', 16),
+                    gmp_init('0xa7c25372d29f8974e264a22b6527679a9086f448e001a40073ca3bb38424cccfb13f6a7701f8b23fa389200f3f6585d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5bf19d64a561ffe286fcfa444900dc43efb9cd8ed3bf609ba8dabf588927e17ba114c733707b2ae53d1efffdc77ba38f', 16),
+                    gmp_init('0x7dbefa551b78f05bae189dfa18dd3c82fa5fb34f314c759caef00d393f0b351ed7184234d283facf82fa0ca391b646c5', 16),
+                    gmp_init('0x6bcd27d59094784fa42083209c85ae71c5db12e92a1b62a1fd6190994c78153cc063eb61064f0e6271c0c11a6b4ca418', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa0bdf6aa7450449e3712a9ef2fd83d4c86537f46bcb5379357a7f7014be05e72b38ee7b4dbbb2e11201d88f249b68171', 16),
+                    gmp_init('0x62c968b887a9024bbea0154c8fa984e8e879ca7b18c9bf0fb7b7fb236a6135411421d677177edd663252d54405ba7c4b', 16),
+                    gmp_init('0x2a119e57a5935f4f8a110735d653713110e0979059c8294c67bbc80bcd8ac52e0eaf2f959508604dab29f9d47b3ee453', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x10867db12849597fd4ac1a83de1249546b736f014122ee0d4adf7a2eb0bac8b994c68b9a841c1bd97c2265063472de31', 16),
+                    gmp_init('0x6b7e48bb9a69bf88e539b396537f061b00ac1bd3d31d8bca42172440ed24005778e926df01fdd2ca5e7d55f6e6039b40', 16),
+                    gmp_init('0x5c37b61b8b8c8d09fd46376245a5da554321bd6a5b6d011a368a8c561de05a59b28fb11798546232dda8310a8aacd42a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6313eea44351ed9a8a3075b6ec0ebd2f97f3883ab2d49fc6d1e7f21bc5e9be17abf9ce61eada0ff58753f44964133cc6', 16),
+                    gmp_init('0x108d3ec77b5126b77371a96b04ca67e170712228b291ef1512cf6ee9e9adfce5b42a0217db89cd92623887ba5c64165c', 16),
+                    gmp_init('0xe7945d09d5a7b5f279e5e5125939ada1df2e63ae1e5605ed7d7604ec88c1b8df4b7a922ccf923956e3712480655ceae9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x74c237f276e234a2e1a527f7f78f6464bdf77c69d8cacbe501fa88a796b8cbaf9829a5ff91c83b6e2c859dcf79e2d36c', 16),
+                    gmp_init('0xf31218c6dee2853f11de581abc538aa574c2d14c8f5d0fd80580d0eedd4f408ab2c70b384ace08aac80db3c6122efc4b', 16),
+                    gmp_init('0xbb13d3a3f2e0979b1a4cbdea5b75bcddd38bf9fb343863f4f139d718ad71fef4d797fc13c25f021f6b6eb7219522c437', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x63ad44d4e3455a3f4d03390a7bc0d71b7e491d6f89129985284b06bb40d2b394fa968c99d3fc3103b0c6263587d94fe', 16),
+                    gmp_init('0xc82b04a07a65952522c326f1d06c3e6699a78faca3fb810a8db78a612efd8cf9c1ec3943c24e01c70983df719a080b2f', 16),
+                    gmp_init('0x2839a5c6b75625a51b0dd3273172a290b11c239570ac1a73bf29b81da60fc4681037c4861ddb98d54bc43329227a0f9a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb8a0b4413792b13127e4fe5dcfa34b9b34c9c7f6d86f7461a26f405f68b5df722e737c057d3743368ef300c027175840', 16),
+                    gmp_init('0x73baea7b55f9e6bc355c7e6ac6f0e9d060416da2e26ae9b02e7c8084fd8fdf04304af96d86e851b4b48b7369824627b2', 16),
+                    gmp_init('0x7df59506c4e029b162e486ff71278ae1b9a5136077d906dda30ec240721b568aa047fbee34da3c1fbdde4d858243b1fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x409fbada8946a183b6b2a3fd1b38b3f3f076c9e4fa21e2090c12d66e6457108039f0a625fd98e44dbac3e83f5d286ba5', 16),
+                    gmp_init('0x1c483594a63d1c5b5bfa267754dcf73b1a0f3812e4d63b66be25870eb68ffd6d96c505c33c3b01a894b661eb212751c8', 16),
+                    gmp_init('0x9fc0e5f8ca307bd690dfcf71fb398c837df95f76f9ccee38de98ed2ca1f0427658e8fe9e14177b49a310cfdde171260c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x238eb5bf476cb63e6054811320dc227be56af05e821db52be2d14e05809ed23305de9ecd008a658e291ff62a505dc78c', 16),
+                    gmp_init('0xabc79d7581853204bc4f270ac4a75f12d49690d82cad9709a8c82980a7f59fe9a076861798cf1a2634805cdfe408dfbd', 16),
+                    gmp_init('0x41e72fb9dfc285e32bc284a7d5bb9e6960b2c8f90502dc52e12bac7521f306ab5f9ef46862869d9184e93e61fa77c922', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x27cc2b4515629ba5a7f83b6dbc6fa69fc3c410606de7ef2b49969e67c255e48fa9e7b23de64c98791af805299de1de0f', 16),
+                    gmp_init('0x99f76ea6b902d2a4a0b0f99f3fc762878703b93fee9cf047506c84bab6ac8af269449668b730dc572f625ac6f03f4769', 16),
+                    gmp_init('0xba40ae9462f040835749f3285b0dbb553de55b2d21131742b7f6511e5206e50688275b1ac9a8bcab192354055dff3fab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4595b15ae1064e753d42915352687a5b6a6facdd0de9835b83591339063e2a27bd61183c90965a4d56ab2386e22d168d', 16),
+                    gmp_init('0x7c7cbb762d4727edefd0d46e220c37b61b1c0276b1faa4e267fdc274f954ab6d2074c535d9c514584cae22c8f64e6057', 16),
+                    gmp_init('0x8ba91420787376e30715548bc7a5f701898b69e7f602403272e34b82171ca9584d5839cf92f963363e25a349c8c1cf00', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x102ecff126733183779d73b8daf8693bc6186270dda7d964e71c22581b5ae64f5893580277b5163ac43ec6d48d235871', 16),
+                    gmp_init('0x4a1c87103c734c45dcb7066132ba9a07affafbee70c1224bb46609c7752ae6dff5249cafd6635e0d1f38831513a90df3', 16),
+                    gmp_init('0x914da7fa8eb3c13fd73a099eeeadf661d5097361d13eb1522943a4d3de1c3014bbb8c6ca37b26dd9d463ba166bf1d911', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5c43f9a62f942c66cc8ec81958293c4fe3d05ecf1ada9b9c3df6ce590fc413f5950026ebd1988ebccbe664f06241d581', 16),
+                    gmp_init('0xab83f43b76ed62a921d4b753fbd286d43c93589589c24d8a5661c4f6816dbccb6358a9ff0c2fb60260cb5203123b8c2c', 16),
+                    gmp_init('0x10924924147596499ce8fb58c389e3ddb4d418bb1a8ea7bcfe2be5ec0c5ad41cc1ab4e85599b8a602e02c9bd4ce50e12', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc412d58d44c77e3f7c06e0f771e6d2f50d34b004e144ddc8507e8b3376141fb6dfa511025ea5a249159e0f594b7f5e4d', 16),
+                    gmp_init('0x1e03ce72fe9c6ec55fd1d2c5018b6e3c1c487a76555c0346888cb946c913af432154721d2fc5bf807559ecdc09048086', 16),
+                    gmp_init('0x53f3d7e66a27a16ddb6b56f544d995a0eb0e0827935e5b35aa89124cc3db1805c1a19df10b2abba74afc035a65fdcd2a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27d6785ee9e346b588339e7c4039e906b92182c9447506ba02a07526481d413df66c1d9c4cead6406d2de7eb20facd91', 16),
+                    gmp_init('0xc567ef6d150507b20785a9dac96002f573273ebfd045a64aacf4530a7ff7fab1424db4af31b2ace75a7852d60b622b22', 16),
+                    gmp_init('0xed3e0bd2bd08009f5c51617f00d1e7da1346243d9847d29fd856013bfe9b53ace704fffc33d88e52f7fdf40763d1f7e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6ef31e4572e07b97ca2e736d40428bbc894f9b0d824f401d420bdaf3b04e57a6d3621e72af5a4126af0e3b955e76467e', 16),
+                    gmp_init('0x5ada8677eaf8a557bf693aa2e671540a0277b5cfe441f2b3932c5d0a7860e44b08f6a11593f492a6d235c786de40ab91', 16),
+                    gmp_init('0x18330c8c9ad4f90e73a4efdc16e721a182f0db7c953de4035df5a0f70037495fb50ca17ab5f4a93782f2fea2e641bb5e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfc1c9e87ecadb747e5b7923514885d65be519b57b748e53f97295ebf621c82bdf860b0b0099741dce303716f15b70c77', 16),
+                    gmp_init('0x541e440e2bd3fc00a4097c7ddf9a7a6d1fdf1f0ac3c7300219db8099d6033aa22ac01ff205fd2cfe11ac7b34379465ae', 16),
+                    gmp_init('0xb97fd4e7ec25d0cdd61bb313be3bd0f60e30d97635ce381fa1bdc89e3b45420b88d40117359c816f96b76dfc6327f4d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfc1bce962fd8d505d1b8020d4874966cd75482d9049a8f29c42605db6ccce26435b6473c3139f6a0cd68f3bfd1744638', 16),
+                    gmp_init('0x5102838e857540b1bd06c48c076b8d6d5b7aeb765dedda0ee5f2f95e50ffcc2fd9d5e90e4e325ecda36e30bc53549ed9', 16),
+                    gmp_init('0x96e168734a103ed187c30fd28950c39ce59bf189f60ee19e3b1c7883b63e7b6b7faf7fbe534d67beffd77d7cdc35cab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaaeeefbe11e97db2506720c52e15372bc29a4736e5b6728bb0aa7a718c8c0297430fc06bb50366f1701041d1628aa905', 16),
+                    gmp_init('0x7b19918fd90581682822a843ca66ef36ddb93a9d2c1fa4c1f439065279ffeeefa71430ef0b17789fe2b5363525a11fce', 16),
+                    gmp_init('0x578c768c17c89f8fb88ffb66d358e28fe0ee3f74d9693930995b3f2b234e8b709eba958e5835dc1337cf6261fa79eabc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe416233611157e0a6cbc067f38ef6ea3ee0847438b2be9e24cf34cb1302061e4f95551d26525b12b5759f4fe623fc417', 16),
+                    gmp_init('0xf6c5976f836260f6eb79bb1ed3d5725305821f88e072aded09370dfe006ee1801ae60334211b0eed4a2bcc15ec5fea72', 16),
+                    gmp_init('0xcf0d8ae379e10bdc0f75e3b3cfa4358f2bdb645187cfb59d820bfae22cd66a4cd69290967a6aa12052b5e06e688a5022', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x70dbb5fecc177ef680681acadd029340c36e6f84eff963c1d1e47b12b3926328440dd684cd08c980403a183cab84e1c1', 16),
+                    gmp_init('0xa84b1bee61d4e357aae68e7b35db1ec0d63bf968d2de847ad1e511f92f58c9b11c1f08a5b3abf722b00dd14b4c8c161b', 16),
+                    gmp_init('0x79ac093e937c92921144ad990612f5bf7fff5297398f821e2f9e8518ddfa221873fc07099e4e78dea4b20c9082f34ae4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd4d7a2b2640defff8d2b6d881171dc3f2ec70c4acb57891a144b382550730c9316581479557ef795c9aa1d62c54027b6', 16),
+                    gmp_init('0x9f28a8b9a3030c260cfdfc108aeb8ff687dde6a20018685cb10b48fbc25dc4ba5918a2ff8efdb2b37434bf189b910236', 16),
+                    gmp_init('0x4744da3ea812a463e71f60a33f854fee9e2c6908e6efe39c62f02696868567e782cb67829711a2501c63fabd1b250667', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd883a06fdae7a2911e82e9ce2741ce28d96098d4c4f2a7a12afdb2252d60e5d8dacd44173a963ac1186c4f630e36ac5e', 16),
+                    gmp_init('0x3fd2d3f7e61eadb359b75b3be29d329848334dd2f4dfd894e2b157fd28ade412434f8ace23b410145ddacd69a470307d', 16),
+                    gmp_init('0x4db25ded642e852f925b281190c6ac232653a581c96c83085bccde3ce1629ae0d13b5a1ace8aa110a394b72b1c4d2393', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc67b155dba60a51279596a6c91fe479318015c6148f1e566adb7be9bb42365f743c1c794f843cfb6b49291d0b61cf663', 16),
+                    gmp_init('0x2972ce739c305ccc7ba3a1bb43f5b2cfdff756849ad367fc4c62f6504dc1b68a1a28a779571b6ce5800f09e0fa9019dc', 16),
+                    gmp_init('0xcfc650240e244df864a719389898d7dd2d37eb760f2dc27db3f86190ae7b1b10639a512b9768fe21c29e062f31800414', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x9b5f7603f9d3236596cf8fe7dfb56036cc36f90920a0f5ee4bd392700475a2e292b416a2cfac8166a14b45531428664f', 16),
+                    gmp_init('0x5faecdb531d0e76f5440ae7aae6a32090c360016d6494f07bfe6ab296b329a2587e41840c847b6a75a7ae0d5f71a47fe', 16),
+                    gmp_init('0x19acdb02b9caa7d1a4b5fcd05142f4473f0a8cdc81b1e6636c8549d2abe398cf1d2d0b273c4981e3e3549329033e9bdc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x993e3ccd99c1aebfae8975ecf929880466966df5a1039e566b723949f0891237e113e375f7f88ff36f50c33c9e9f0844', 16),
+                    gmp_init('0x31645c72824f28f21d3a2235b33d8da861619a1859113227dcadacfeba7771372ac23714bb536273d5fd1b0e10d93881', 16),
+                    gmp_init('0x8c5657f1d090a9e557ccf4a278cac8ce230b036f6206fcabc7415c70a6e2b4e2af1647c9aa61016b0130df3a1c16aef8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7384e46abf284cd8a954ab02405ac44976c82d8da68829eb6a1368d5153f68dd1f442683f0524445acc23ff4b991bb0a', 16),
+                    gmp_init('0x9676a0ed2eac33449a62da1997b9685761871ce080649f09a749061c16b95faf852be3049d0ef4433eed6d3a6f3dd14a', 16),
+                    gmp_init('0x373f3c0269f70e902e3ffc6a78bf721ed53c6b4837e0e81a1dcf896ef5c387063fa50208f3ec86249c1ac873c9b96fb3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd5c3d66a94e8ccfb2040e6c5fe3d91d9947796d4ed255c2c87d748b1bae1ae832ec3d19e182bd102718f1fabc3ea233f', 16),
+                    gmp_init('0x11b5eda8956e71c4851b2076b8db92fea54d57806d1ba7061a69d907a4d569290d0d7f7355c42b92d4d3f2e200c0a98d', 16),
+                    gmp_init('0xaf403457c267dfd6effa5ac009ce152155c5f1964ef24a489f1d5e90c4614bb2b49c664c1d10e847c6e0fc26eb9f6606', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa5c02099348ad3f0076d431e3cdfadbc99523baa5378de86239a6f55911779e66ce64962f264ffa8eab02ea9e88997', 16),
+                    gmp_init('0x518412b405b07e3d0028f6d2db1ff88a007571eee57a6e0be284013dacfe87ba54bfa4aaef1bdeb5afce620f93de0001', 16),
+                    gmp_init('0xd02f14e5d0ccef525941391a7b783d579f198c6adefda23a0b57981461d41ace8ce44ae9a40ee174807b2e58f99dde3c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x778c46ea5423fad9a8fd90f92b05c9612819cb5b136eeec186338b269c6aaecbb7f078a1b334e202110137cc81fc86db', 16),
+                    gmp_init('0xffc7f2e3f393474635d1eec55158a74a4eb16a7e06334fd08bb61dbf3c7285cdafb8f5e4b754ed48aca9ccbae5cf71c2', 16),
+                    gmp_init('0xfa2e10de28826b77a35343dcded4de8502c75f74a5292796629daf61f682232ce5e1473505e1fa0069e16413cb578067', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x51c302abf0db580ea7c37f68a83b708a40f5a1958a100c4661236e0d50a1629b5315ac6d25f127084b0bee611c4f4d3', 16),
+                    gmp_init('0x322c7c40001807ec4d6dbfcd9ad75fb1593648757274a2a7bced4068260b5785feb3205033a9ce35134c9b60ac1c70cb', 16),
+                    gmp_init('0x1e43dd184676a9677ca075c303f8d19fd7c35242238e7659ff6ef00ac6c4f478a1643f3eb8b759c667a12a746171e573', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xedfc9eb51a37d790ee18aaf3641e8f698e408439c037c8022c6763ac7150d80104960202695efe29845cfc6c0207ed9f', 16),
+                    gmp_init('0x4315b89d3656c2b2c34cdff1eb5880a7a7a08e3cd5f5883e577de5459ee90aac3f71f37967f58b5d978480b45be979ec', 16),
+                    gmp_init('0xca4abb8d04f67d411e6353ba2d643b63980bccc9b0896ea4819573ea2958136cc8ab6f1839977215c5356b6668ae8e36', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3fde7fa0906e431e3a7d6d988077106080a3be1b783d48e86545867978db0278aa68b4fcb43514cd97badd347f3d6301', 16),
+                    gmp_init('0x76d0a8299c93295b721156ce2e28c05906ff8060149029d6ea9fe2fbcc7bcd34166f6eb56f298f4471465d34446631e0', 16),
+                    gmp_init('0xf46631f45dc706de5e3fcc20b176d5299628697371be5fd5e1d480c4115489cd2f17c2e6cea8be839e9a06a2427fcbb4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xde7a72e87c5bec3b11f323dfc0cdf1e7a2e0284e06c978f6c029ed999a7e7df3500080597b409c6eef31437ad14af7c4', 16),
+                    gmp_init('0x21738a017f0a45d1b64e485f3c2850d8562fbd5abcb4a26a201b5cf76d071766209e37515b896f2cc2410984ce83c9aa', 16),
+                    gmp_init('0x8e7eb249cd2b845d7d910e066aa036347de8a956afe8f2deb443f5e39fe392a71f2caafc189021b90493a31cbe81d901', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe7de9ddbca16bfc06e85bc94fa02e6155da1d96bab2bc3d8f9cf79f56475e67adf4bea772859affd1c7e4339eaa70f51', 16),
+                    gmp_init('0xf9e3602f027a8c25cbe94b85bf916e8acfd4719786b65fd3c1b1c7b85b2a1ffec274593a843f0894ccd28f347876bc0', 16),
+                    gmp_init('0x46f4e53850563219c8188515c79055a71cf2c5d27916b7a4c1d5f4b619c9d1122797281da52128e618e7ff8f777b5811', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2144c458ad47a9a75c7de2c90970519955b793b8472057db34428cf51fae6ae3183a0db86adf64fffc3c2939d4801c50', 16),
+                    gmp_init('0x9534689236117555040de584016e969ba70a37d45e2fa75acedb7dc08053f315bd51e712022819aeca6d518b2c305b2f', 16),
+                    gmp_init('0xbe037bab6d7239d51ba78950b6c33874e1a2767ec7e7a668952b9afb9f5e923b64863d2b51e10d5c87a3615fd4a93505', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc87a74f10d0f7d9e69314ccf3c00bbf39be219d1850ed760de41935534cfec327dd970a4f87940ea9c2f3d7e1b5096a3', 16),
+                    gmp_init('0x1f1b3c7c4110b96fe66ec5ed8586cfecf23eba583cf69a5ad2273b1cca45e0b509182eb7e1f0a066ade7e84d7d7c9900', 16),
+                    gmp_init('0x3a5c690672349476f2fbb0ff9baeab6c24a85031fab71d87a59096fd635f0325f77655672bc82b799a9caa6830cf8a38', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35bf8ab39d60ade0172597577d06c42b90ec87d250c65e5e2fa1634de0e0cba1d98419cdcd2fff133c917a1f05c5c91f', 16),
+                    gmp_init('0x2b98c2098ec1d09c2e3c030a6ef9fc3f3f64c3e85d4ff626dc03230b0abf69b835f4281e18c304c4f2cb4ed9347754d7', 16),
+                    gmp_init('0x440762b968de5d9f9968d1a542d253d4f3cb9baa208f34292fafbaa93292d9ae747c8cb7584186cc75246c3a8b77c1c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9612248a32481a07edcec6fa3fe09d82f52c1c9f92fe367526538897a015a9e8a7f1cc2e7c7a79ba475e02863feee7dc', 16),
+                    gmp_init('0x269eb0bf88e03aff30ee4e9aea6925e8ec5d394d8c4a98c2c6b3fcb218e7b914656ec0b2da4c1786bd68da942a1d033d', 16),
+                    gmp_init('0x7ce5fa26635c3207ab481e19d02cbd8b31d19c357ffa4270449a16a6032251143bee90a915e4d319c0a695bed28be95a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x81740daa57a34b5b6d3cb5237afd89cc307b40a6f4b86af86ecd1fcec08606e65f050a375b0b7e76e4978cbc1c9356c3', 16),
+                    gmp_init('0xb10a0df194c8f90fc80cbd4195e3053229b316ddd5125bf94658b1a7101ff95133299232ac7182ef9bd0d99c40dc79d3', 16),
+                    gmp_init('0x83f8166e32d2a79d19ab0670d76a3eb874be15c8fdc4ae82d58bba9afb9c7741a307cbcc0a69fe982815e47064b6a7ea', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x18af9672d65c445fe6668144571d7e64bfefac90bcc9b77704d0fc026d52b6b16c93933a22605e90c5b36844846d6e2d', 16),
+                    gmp_init('0x1a88af8b6956df8205c90ae034efd3f9403ad7c66dcc12973c92f4d53f583af68bbb1185f4ac6f403be714c3c4a506ad', 16),
+                    gmp_init('0x680907b3ad87b4f72a48dd1c775c530940b1ac2b9949fb8a545c1f8c02f8b46eaa5d48801c311a590aaec4718bad3d53', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3e3f03cc6f909ea166328bc12b33bdbb209d65b4152807a25ff666cf70d99d210d0a44d3f5b78618ff523c6b70dc164', 16),
+                    gmp_init('0xc99f0210d793bbdd657baa00417f441cb72b542663fedd60a0111a94e849a11decade277d4ef95e5b56c9aecefe48060', 16),
+                    gmp_init('0xc1fce3e206ed267ff135793c1274fcf8b5cfa8aa1f9d9d76d4050fe4cb7829a311c24b4a57fb6f6ea6ab4d787021b0ba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6dddad35ed4c66ae709e6ab667470b58bc99975139b8f4b699eba2fa01f04161f80a1104f6bc70edb3f6f3d5975da057', 16),
+                    gmp_init('0x5f9713f78d1c6166bf4c77500bbfe59e102045ee1a226e7b48918a623c026f8f102741705a930bb37ade58bd3d2b1995', 16),
+                    gmp_init('0xfeff987df486915c12d9438918856a571215e08ce8f98919ee128c5095fc584c3802b2afd6ce89bcbf3fed3514074b4d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe90e1500725bcd75a9e63cfb6162b35c63b7ea15721bc5a23137b9c98bff256ea2e9c74b7e535a7063f4781cfa5aa28c', 16),
+                    gmp_init('0x9ee0ff3b1ba16f212f751539d84a069a69a4295d7fda107e294f54ef967da00087d245eb507152cb7381f143fdc8547b', 16),
+                    gmp_init('0xa7e812893929fadfc1fc152e01d9aec9fb0e9e50fd684b07f39171acb2af73d9e5abb19166c2d99beee7a09fef890533', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfb2fc7105abe9ef779c72569fb44dd38e64760c18d56cda5fda19674948392cceae348c3512dae4cc711198e3ee58ef3', 16),
+                    gmp_init('0xd087b8e29e78fc33e05e69951df33c83ad1d128da03c12de8c2217774900cb62d9edcedacb970fda48ef8f46351dd078', 16),
+                    gmp_init('0x8410535e1411fbd4b97bfac53d2152824a3b5dc4a8fc704ac966fdffe0eb23d1ab20e8490be2e62e3bd1e1a2e7546312', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x94a3d4cde2e8db5692eabb4f1ed3f51222325c15c9397f91c589fb3b7bb761a60492604a005577139373cf5017a3899d', 16),
+                    gmp_init('0x5772c5ea5d6713819b008d715fe9c9f66ede3fc19abb087df5574f2886daf2c10c55bda44e0a22acb506819a7439fa71', 16),
+                    gmp_init('0x29010af53d587d1e0f066192cdad05e95218e3b5bd6c2c2e4a9cd3824b4f00448a9a745105462f9f46c7b3733b3464c9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1fd249238775b2f4a6bb1bf3c0a5a2bc069c5b80c9ae0adc29e8f4754bfee20d960341a3701ee4f4798f9ec3691d99a4', 16),
+                    gmp_init('0xd12ac17f671df3df90bfbdb682f297fe1c4b179d485dc8b32a6e109118a488a9f06d9563c27a72324fced0e2a20c9eb8', 16),
+                    gmp_init('0xf437f1eecb3c8ec842f029e18f94a66eed4ca589494a0c0dcf176ac0cad96742e18fb8aad10287be319eb7a4690b47d8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc6a12b0dd5d94ff0bc1140073c72d0fb561305d3e99d601c8d133b1a6c1794bb52b479d1f66f76ba15d371d38c0536b5', 16),
+                    gmp_init('0x598dd4551692b3159a04914bddda41d022bb1111620af6ec970373c0895292b20ebcd63786de597e81f6b3cf9337f1e8', 16),
+                    gmp_init('0x6da38a70b99b3a6909da569e9e0b2c1f455f7f692bf0aafa345db0496eff59b93ef0c336919ceaeb78b34a26757916f8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa36c0b8008583610964b4e52813f35a599753572389445dcccf3a42a7e3ed064eb6079b6ae77024d5bd22c3513047b23', 16),
+                    gmp_init('0xe638b4debc4e771fd2f5fa5bc5a8ff0e99753fd2b1ad5741509f119395a1c73fd81c3465d935cc3603edd8fde4cc196a', 16),
+                    gmp_init('0x4281bde8351a2b2401ef7367bb13d0c2a435d24ddcaea8ba06fc7539d9e56c8b0a3a91119f6a736292f0da01c9b1947a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d0069aefc97f9d5f76988e84fda4697144fb4c7ce1824bca3a5bc689f0a4339556de90825a7c7d659e6e7f2613e42d', 16),
+                    gmp_init('0x226e627336c232e283de9c0ed9118cedbafdcb9a4ef6f522bd65d17af87689236009fb33df6476b4657c70580f6ff67a', 16),
+                    gmp_init('0xf278248aa53175183ffe86028ce0781bd369d53f1ed9cc9946101b8013c691a8fa046f672c73d387968703f3066c4370', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x45f403c661c385deaf7f497a3ce959d53545a1ab14231dcd46f76da0b115e3ea65a166f194f0b591ab2c9a2470c029bc', 16),
+                    gmp_init('0xd6d9c7c867d26fdf40aaf6004405c88b44c1479f5f099ebacec18d173ee5e7a31c92e41cdeb8edc257ba4adde3516208', 16),
+                    gmp_init('0x9a8377b32f779299233008e360eb1d9417f049b14fda94765ed3c1f177458731d36bfa6b0e2d5b876462ff56d678a9a2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8c584d5e745bde30139217db223f9824875d264e43c1392a1f7cd38c70b85105d1f1042e4019b2bedae49227bc51ef46', 16),
+                    gmp_init('0x56b562508f13ab07397300b95b384264bb38b47017ed5fc9092dd4fa11191da23d0dac3d7dd3dbc20bd3a7e39e817caf', 16),
+                    gmp_init('0xad72d1aa96e201e1a30f06b585531240d2f9f8ec876f453ea14292cc5896982131c3857f0fdfde0d7879d42b54ca5a71', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa2e1244ca33d0464ce40ef7987d4f2c61666147fcf6f4f547ad4bd5f2cbf8b38a5cf840791fa7e5b6e4c4541a755ed2c', 16),
+                    gmp_init('0xe69cd88723eece77b35a172f90e07df36d9843b8e63fb590f93a8938c82b96bf5086381d59a066d1e635ca723addd723', 16),
+                    gmp_init('0xa98917240ae18b1a93671caa8527270052e52de3eb4171059d961c7e37d51cd89e789e41f1fba58032c2507c6f83f572', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcf7249128c6be24f58bd46a2641e8e9b0da324150cdbc38c55961975e6548b1041ed0a5c26272dcdaa128d3332e60d57', 16),
+                    gmp_init('0x3f577a0b94722e4a81f9bbee26b4ee6911cfd799fcf6f27a14bf596b623606e245cb41bc2616283d5035514b9139ff33', 16),
+                    gmp_init('0xb1abf3d4b9567ad5ba383b0677085bca6b22914b70851f12f600cc7447a8fa2bfad9eea87d961f606b5673313ab5957d', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xfc7aaade7e659d718a28dbcb858c336aaa537ff4bf70335ef73cc9cdaecad1985d7cc9d7fd144c8a66114f03d3f867a4', 16),
+                    gmp_init('0x152b8d3bea7e9969b18f364200fef4536231fb036b9ae7c1ceec80d604ca174e88054c289424e8d78355282090dbb8dc', 16),
+                    gmp_init('0xb9556b472e1af0dfddf22fd4e60b3d0e9020dcf417719fa619bf6356b0cdbac59d3791ad812052ba2f8b0e7575a5cd5e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x73b40cb6a0913ab9bfc0713dd531c7f493d9be5d4dc149391a81e87ba4ce049c77cdf467a322482906ff1a634bdfc31c', 16),
+                    gmp_init('0x399bad3dc89d859f9ec41f4ae69640f12f0b506eee39583d69ece05031e7a852e9a8eeb474f179d15d83529ed81c0b48', 16),
+                    gmp_init('0x9729c2972743b602850365752d4b76cc953bb662c7ecfb4ec18bd4cbb55fe7dd496273657f16bddf6e0d85856c0c4ebd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9a4aa553ae1a38ef3ca65f1ed47fcc2f907ab26f020b8293a664a11313d24a26f5ea26678d2cd26ff35f97ad826b6846', 16),
+                    gmp_init('0x149045df0f5dfdf110a84c1ba2878dd79cf4fdea2ebb5aca20539dae48660940692372c28b7d959162f11a24ca10f32a', 16),
+                    gmp_init('0xb860021e87657c8086e4478cb9b8a3eeadbc00f4fc5af07ce535cf876dc08dba8b8d5d78de9c7362cfc8970ab81f1dc7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeef974b7cb5a9788972b1bcba10fad30dd280faa16b4eef4613c5af61eb115df5feddd586df4d04fdc73147b17f0f3ab', 16),
+                    gmp_init('0x3da3da00f637c464a2ab3cddabc1eccde18e34ec94b86058840f6f03252873deeebc0fb40ee8b24ce7f4a3f74c1795d4', 16),
+                    gmp_init('0xf600c7e6b7da9b93a12900ccbe7f15d62a687d71b2d784d33b5003127e7cbd38e6e7d3eb0c1257d06a5d2eb7b2f73471', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x23e5e012996ad0efb84c1066a400e7c55c8075241bbbfe8e52319415f6d138ff1bc9da2cd6faedbf961e89ed1d7f0d30', 16),
+                    gmp_init('0x161c2e1bbf4e02a8f0ef05c2dd51ecff386a4e3bbe536dabfa5baa23da98efe34dd164096ffa70eca3e9133f4b74ad8c', 16),
+                    gmp_init('0xcb3cb6cdbc372bbde392f6995b83249f6b927b86ed227769dcfd34f503c3d9cc69cf8b128052295772b926d15aeba606', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdefc0e600d283eedc0c582603bbecdc497cd2cbdc78a93491e59e910eead9c93b0b27fe7b8c4aea36d4c9ec28f4f4a2c', 16),
+                    gmp_init('0xb6a678d5702c9b83e0ca8331312896247b056dcaf6ae908b87e519321bd6f2f258d32ba8297d8fbed1963c47d77c7696', 16),
+                    gmp_init('0x1fea5b840be2685e5b29c9bf5fbf737187c50bc896545a57c48c9a19333d51394543743943c191aa44b97f2e62eef9dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x997f1b266f81a7464253d249e527436f65a1355295ede9ece9f6db2b8de3ef112dfacffe799aeabb177dad2449b549f4', 16),
+                    gmp_init('0xa39a10a1383d138c90aa4a29333def7d4652b5a2b7144ce76e487b0e670e7689d784455c0b010a8be8202d7683a92427', 16),
+                    gmp_init('0x3b0f54c14190079a078cca78431b20cad7cbe3e827ecbb6250fb520636db409cc5749edc8dc32190d14e09afc202fe49', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5ca9470a71160cfb6f13fc39b44361c4ee05c7825859e75def317f2f2596624dce4ae0a7bca297870d1cfccd579ee096', 16),
+                    gmp_init('0xbd8a81eb6b3bb6fe4a1045c8367e9e6b7a3e7cc685f413a5ba05220710fd0506c6290bde17e41bb267ff507aecdf567f', 16),
+                    gmp_init('0xdc61945225f958a04c52642d2596dad3f89dbd780d75e50dd1614f609105ae0c4ab66ee494bc7a3ee6080bb783fc3c0f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa3c8a79e793c4457702d66e5256cda17197046b90f01bc5ef95f3b531047915dbd2f844ec65d7e2ffbd67659306111fc', 16),
+                    gmp_init('0xba0ce677dbee679011c8f454f86a2a7b619e922f220c0d61473692a4fa6f645275800627037b657c76dfb076674302dd', 16),
+                    gmp_init('0xc473565ed864379b80656a0812c1b6e9c481193155b1a06fe9631559496c80f8aaa18139c9775b39484181afe384a0ff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce1a701b94adca7c6b9b2c6e616bf30928d813dd677ed36b372f9f6573ff13688d133ba5745304040570fb1269a1209a', 16),
+                    gmp_init('0xa999d6c7323a41c58b161f6bf53436d24624f187ed40cb843748449e0fc3b52205ad09b792daf45c5a1f74682a3f3bc8', 16),
+                    gmp_init('0x45b8692125e6560cf974175c3e974854434a2f4f80693fd1e15201ba6d18dfb479fa0988a09efccd766e0a8dc1b5864f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x52e563f5d6c02ed61b921f2d909a81eb344b4574db21261ad8a9029a48a0e2062a021a8a5363b5e75fedc5c9c5c57be4', 16),
+                    gmp_init('0x9fd343148a4639eade156ddae6c401667fb725f7b8eda7d8afcdf900beb0e37f1e54b5fc840a9eefac3063028c06c18b', 16),
+                    gmp_init('0xb1842554587a32590af915fc2460f9d8620e7be9b758237a14061bbb549ba599e06ad7a495e9e7ef037b657e240c5039', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb2f8e2a790fb42a6fa5f56433370db49edf409cf4180f6d71e388aa2100507789242992f94fbaf1b92c383fbad47582c', 16),
+                    gmp_init('0x1f9626cba73fd369788a4af180708b4cb7af0ff884c78114e18f46ff63a373cbbe2c45ba63b78c25662e4fea0ba38816', 16),
+                    gmp_init('0xbcba53b7daf202ef5bfe14bf854a05992818f00d51ee56f4e4d357477a512ec73e2f37bbc9b7fa7f4f5470caba88b47e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x496e4ad0a4455e8a0897d19b11cb3f6d83b97d0f4a5647d961b16246e6ca6eb93c624aaf0564016133b6f3b2af2dbcb1', 16),
+                    gmp_init('0x21704c19c578147dd03423c1512f165716195ad83e090c188cebfda2d56f9080d31ca4000d6da27de569d290b4dc701f', 16),
+                    gmp_init('0xd55915b9551e31320fe880ad7bccd2d47c2e3243cca8f5583e28b0de110dee1384fb56cad88b579c5f1f7d36b62d396d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce93f4438f539e3611b2690d2d83fd5752e19dad055fcb7a132684fa273815b04ede6f5095a37154e322c282a8f9748b', 16),
+                    gmp_init('0xfc2f0549969c46189f45fb88ad37592b6db80f9ba42f681fb63f983c0a737915cbf04314039b21e8f2ba554ce03bfb00', 16),
+                    gmp_init('0x9d567587ca272f3e15550f3700ac46ac9f2585e06fa0961256a53d9fbe482dac737effcb4bd0dcbb84e6505b34579b4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf67864105faac9efdbbf08897291f86a1733aa5d0fc07ca4fa9f063297ae98dcbf8a85fb85c8cda898484ccafc6902fa', 16),
+                    gmp_init('0x562da9b2c7a833fc176059db705a00488d606f4ad087e7bc2095c56c81ff1ddfbc85e384b74033f1866c675f373efdbe', 16),
+                    gmp_init('0xb2d829310f4b7f58d0843b68075488795b88a07efa699dba6199a586e4387ead80aea84b1922d0348d4938a7462276fc', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x602b568d305e5545ed5493c5de06f93c76ec8bb952333702e63d7db7baad8fa9c4e9790e2b04a80a7c4564ff46c86b14', 16),
+                    gmp_init('0xc58c2f48aafe3c6d4bc0a2752896fc553fb73efa316e757486b1eff09d1e74c7ade9ff72e99f3e6c9c29318b40e1eb8e', 16),
+                    gmp_init('0x648e8af7242ee3915c084dcc02a2614c24744b8643e4ff3217f4dbd16e57aa7a7ffbdf6f630eb2e278237750e9311a21', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4a0f8680d14b1be736c55c544ad7a49c073f845df6736dd5ec85c40805913b6075c61ef221d405d37dcb4f23aca38c9d', 16),
+                    gmp_init('0x9d392fadef8ac4c71261b4d372e6d0fd07e7792e19c800bd9cff6efc4670f00d1d6aad80ae3d69f1e07f3b3691d1276c', 16),
+                    gmp_init('0x7d4337205a9e73cb92c0c6452bea6c6d782f25b55fd46cc614c68723c3d08cdadd71d96535b116c09d843318636f3df4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4dfdf19b97277246c8c49de16ad1a6831db2cc572e3c2776dd88b190103076fdf785b0546ef40c0a73104cb0e90a0ca3', 16),
+                    gmp_init('0xf6bf77a8a02da7efd35b26763e012f95901392d00f7c3abf662940da6750450c1fe4e9c27259dcac049027b13f7dea48', 16),
+                    gmp_init('0x8d6ca49d7051dd2c58bc221872ce7c87e03310ff499bb4bd0871e9fbedd55aba79cf4ff858a296ebc738f4c099ed2bed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x43f505cc9f9efd9d4949584afaa576bce98098549a96249594b87f5377459b8f31436fa640793518f7afbf11830c0948', 16),
+                    gmp_init('0x4d8ed26c4b0aca8963854e6474dcf52025395c5e540f4e23b975570cf531633f8f49fbcdb15c8f2058bbd02392d9a6', 16),
+                    gmp_init('0xd1c7798b2bb0c2137e4342212379edf1ce95168d5f5b786abcc3990ae9990bcb9db6c4fadf9d1b4226617e4813321398', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb0669f3bccb59e92b3ea713ad79d8235e4cf5fa1dc0e4872ccc340244dfd64c808fb08b4fec27df1fc93eef552b7e538', 16),
+                    gmp_init('0xa719114ddb9259234e517cc3e68db79f1373894bdefc603590e87b60e47ad59c23fcdba8e90e068fed1a453e48c63da6', 16),
+                    gmp_init('0xc9f3ece74471b03b6478655ba4f0501434bea47425e85bfeb0d552cc92bd871c1741e82a2f52171f6e6e4c154294f53e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27a0ed3e8372b0d02ca5fc6c668fd8677bca7e4c44ea4711370098008c5ae0045370ee7439260055480b8d0f7594cca8', 16),
+                    gmp_init('0x33e15711040982e27bfd9e3b5f22116212068ea224470e65e88578b775fd799713fd7d19c454b371c03a9f43fd356b6f', 16),
+                    gmp_init('0x391c356f2073c9b290bcba44791ecb0a0fb969acd445c4590a5710012ddf64c74843a32581b2b78c3e55557fe7a4b078', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb5cfa7fde4d4d846a2d8f43c6cda8d019e3cd4f1eccbfad0a6f501edabf322351d099a1f933b4857aba30c998f829aff', 16),
+                    gmp_init('0x2fef1ef7e55e649342dbd0bd597faf7dff148119aedbc9bec46775d67e4112ce98d754a44d1ff899a9c45be2023a04c9', 16),
+                    gmp_init('0x22fb7489253af005f4f067ee81cb20a5d4b238dec80b2cd6bd51360b0653ab3abf55c92a7080f5699d19db4085b050b9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d3c8701ba50c29c0f1491e7cdc35699f86d3b04ff5b8c7434173d79a5a5c954c4f1c8afea0b2dbf0dee0f6e9c16884b', 16),
+                    gmp_init('0xab514eed658c04f7d384793132d8a30881df1a6e51dee50d5fb4ed22edaa8954088bef3a91b5c2aacec9f56e358e06cf', 16),
+                    gmp_init('0xb9385b41584c69849c95d40649f67a4b4d2e7b36b522df3a852a7227b6a182b23c0e5ab6aba0bef9233ef6169afb639f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb78d00f399118747436fecc00c32c5acf663875da8cf221508d91205f66a854327a3bfa7a114fe89e72a5d3f924d2b5a', 16),
+                    gmp_init('0xd0fc431d5b3923b4b0a56bda6b15cde6b6e8160252dc7abaff09ede0706e153b993da8bcab9569033c041e097c078cb2', 16),
+                    gmp_init('0x7a82f6fd3eff99daf068d4e9f8f9ec62cb8aa120c689bec8d8341359d98cdb4927e4d66b3718812dea09c902e9c6a2ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5764d927ef8ee2cf8dc5c83d041a13672a66bf58e904e387230b7b78dea674c14e98eb541aef00ed9b1b12d34ed9732e', 16),
+                    gmp_init('0xf501c8048241adcba5af4d6f0568a83c1bf9916cf337d8aae6045e52ee3430de559e34f582f42cfdfdaa49529306c0d4', 16),
+                    gmp_init('0xa2f87a44b0d2d6ad1951ba294be72f9cca7bd8b4cbae58a6b7d755979966cb02a876a3ee87b1cdcd63cdbcac6f12bffd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6a194597fe1498fec10345bcbd86e001b5c2d49ddf20e4591a39682721fe4ea604f17d054f327bc5cd26c8df261226e2', 16),
+                    gmp_init('0x9cb5cc3dc235337b4aeb004bb242e9544f039dfc778fc0fcee4fb10f4fff052d6c4c7ae5f248d4d39300f793c47ee272', 16),
+                    gmp_init('0x305425352b783980820025c21534dca71e4ae5192463a9937019f464b4636a20760d1cbe9bc45ac6beb1bf7976a5094a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfd8ddaca9ebef424eab6a319c4e69c0650274066b366a36f2f668738bde27efc0d20555c1918002ac36a4961fdf84195', 16),
+                    gmp_init('0x7d2ffc94c67311a0bdc1c4b7c9933de5c869ce11cefc89eccf56dc602b64da08690c1b18e8c8b208b4907c793f8dba75', 16),
+                    gmp_init('0x581fe4c345346873ab01a76ecc5b9c2fb9c9a68595605649753168645c4a6bf3b2f2f78eb5ce5f82e84bbf079cf16a9e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x75555aefb19f00ff176c590177305fc5cd28b842ed76c1570f273764574045f1b0655713198b78fb62d05350ba6b68be', 16),
+                    gmp_init('0xcb0f63b6beefbfd0141fb7ba28ede4d8e8bf1d4c0026659c708078954a097fd372f722b8fef3e9e4aa39c164e2db9b22', 16),
+                    gmp_init('0xc053a2e356e6ca8e70a4bbd10588d59eed334a1a26b229355a5fe5527d04bfc23d34da14ad47e770628ca53468fc0c03', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x30dd56675c3b3d725ae7bf1ace894f7e446e041a0096f656a45c6e21c906781c5c7241f9b9f97da6d3d0d56734c41484', 16),
+                    gmp_init('0xa243ca2ccd72aef55b172ae82cfc451080e77d20b6165a8b0c6904b91ebb8c07555f835657d72d3e33cb265ba0835408', 16),
+                    gmp_init('0x6caa5cceba2026f6c81760103a37ae7cdfe3e8ab63bbe5aa9fcc84ca8a2b4a8f16df1124731cc23f665cad0ac62d4251', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d11371ff276aa01f29fe54b6c25deda7642bb66a015f6c267bc60abf0fb3dfd19980c3b815578ad4c2300d56f54bd1d', 16),
+                    gmp_init('0xf092806770629b943949b1079da057ce83dda39fdeb99e5873a2f4b819d2981a048ee2d8e4b390b7a139f1555f582da5', 16),
+                    gmp_init('0x9b9f37daab6f6dc12f8e75d44430dc7a85af84c30c789a3808bdf45dcd9a140e951bf4da4a0c8eb84bc2ab487fdf3d98', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x610aa70de906f185d4c7f9f04240932383046c59f0262d3ab5fe51be4106fc9c30a3dd8446e6a799a4c3a9f63bd106e6', 16),
+                    gmp_init('0x48bde240735e94abe33327f7fa05b90419c96cd626e213d29b996d6605f1178ff534006970b9fcc7750ceef2348c4d5b', 16),
+                    gmp_init('0x4ab35505fcbe1573576590abbdde861af8e970765f3402db19b752e2c31a60b405bfa24936df3d62723670d310ef0613', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd5b106c1192761488d33621bb3ee112931a5f03e5b4a3503a48d090a9cf6f843114e3b270ca84bdffe2c42252abe967f', 16),
+                    gmp_init('0x7f44197c86052a86dfa293aedce0a7a406af357b30b27f207cce2b0d410dabc6a1faa3a58487fe744b65a3512ba55631', 16),
+                    gmp_init('0x7d4cd86ef64a4bfbf7317b53cd6c73a45d6432f08c5a39ddbdfdb7c1e8efe3699284cd13c50443b8758c2ae58e81d446', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4b0cf506e85dc1a9942e221b0f7214d090b0cd269400fe10b3eca08fa5ecd3ad4e4c0ee640c68d8cd10680d22f618a86', 16),
+                    gmp_init('0x241fa8e3319d9788174cd1190e241234b940b2e1168226acd29cd208764d66466f00a3fa8cfb5d20907426abb0a061a5', 16),
+                    gmp_init('0xa61eab961883a5977c36fa39c56a80f097b8c2ef8b44967f4bd43732ad2a8b8a7b4d62460d5b4d94d5af0e1b57867d79', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xba76ed84a62d9e689f47fb53fa63beb3a4a8f6fa208ef6b9ed31831a2ff985e245b1ab0f7bcca2dd451a0ffd8a3e1355', 16),
+                    gmp_init('0x299f93badced7c32652777bc3225476b95d845d9bfda2926a2004df77514d8dcacd35f87d7babd45e3028846f81dc83f', 16),
+                    gmp_init('0x15255538ddc8a5b863ac25dd39e586df3a329312c355fef6138784039a20402ef16a4b8b9ecf813f6fbd554734c82f56', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb94f83991323a0a0c596916c9b884c8dba1e58b9c4315e77ad044c72c16945e7ba0eb9c4c4e039f0bfca0b06daaf54d4', 16),
+                    gmp_init('0x61ac08c5a9c304ac2f85b19f209e7f833ee99c83f8a7c1089b9878cae8f114d3b39144f2b90a731f8021501c07b68afb', 16),
+                    gmp_init('0x3028466e9cc323938261e70f6dc7ed56e3e1c3f562bfe2086ffeb896d35cd903ec860210a2d2f27e67bbae5462e62c5d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa5863593850bbac105dfe4ada420d11de5f14128b916fd5aa092838297bb2787c12613a15b81f044d3a3a4f90c6f67bd', 16),
+                    gmp_init('0x2a1582dfcb4178523de67efe5e0fe37efd55c6460b35fd4da0d3209713576f1a3bf46948792307ecc7ae6a397535312f', 16),
+                    gmp_init('0x70a8634e9788f4e8bc45d55b1baa86de0834bd977f8b84d54833bcd21a0a526deca115de42f02c2fc3a5e3b0baa375e2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf5fff6a21b669ecd1d0f5294870eaee1cbdf89f4bda18e5f23116bb482f90857c6893213a12939a632d6352b858378c9', 16),
+                    gmp_init('0x9ee0f8f30f5677dcdcd6d6f7dbc612bbbc49dec425fbd1b1ec5bec92cf9e1ca02d9630f8266fa992f96a321955783f8', 16),
+                    gmp_init('0x37e6ef8fdecfcc85559e9e768e742297ba8de956521021401d038aed70769a3c36bb2b4f45dd60ca6db7613da68e1d01', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x778d90ab156280cbb81b96b4f19edb160a87912fb995e59a986ff7f56e131d2111302f96321b62b3d67b6ccbaa1a3667', 16),
+                    gmp_init('0xdbbaec6eed52b116fde360b89758153f41fc5070c5935171cf73b15d0043dde86bf9ea83a3bbc27afdbfe36d48af395e', 16),
+                    gmp_init('0xd1b17e6291c906a59031feaef6292111840e532b53bd5dd47ecd8fdb4ab8c6e6ee2c9cf6a7837e91b1a6a3e191f3077f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1cad9dc7ea53832fc68488d97ef59dbac8e97fb318a53f18d40581c02ffa864d7b156df660aea54f221bf5f6ab631ba0', 16),
+                    gmp_init('0x6264e5e0915d86594ef9cae81e48c958a89e85c87f00aa2b742b69f99db43fce861ccb7b20dd702d07b9e86927d93d45', 16),
+                    gmp_init('0x4558a820b9572812256a1958c513b3272a7e589bb5d0a30ea0d93e2b764007e3a4827a311a7494ae4473f08bc14a2594', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb33d06c4022832310b78a21165c5263d83e13626f0c79f30427d8a0f27739b60a53c7503ebb7c750e2e3ff43ca273056', 16),
+                    gmp_init('0xe09535da8aca0ac9f8f74eb65f3ea68b9a4d1c610b03da3b0f59ef17f6d697cfe7df42b828bdfbe6bb04872fca50794d', 16),
+                    gmp_init('0xd4f2fa9f9ff9557a3519b86df9a31c0ecf1426d96f90e3206694b3c545863e93e0a85774cda363876682cfba97c820c4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2184cda7c8817e67dd157e7c6e7f3021ed6d8df849ba655be52c6baf750ec1d81d104f64ad5775c74e13cb6ea5a617f2', 16),
+                    gmp_init('0xe0d9e377f097476a4391f717be308fab1ff3b2b6a3ffe7c0802734f61c0f3ceb24f1667df4737736f59df4a116625185', 16),
+                    gmp_init('0x6d037bf5224b911b1eb860ea52df72bdba4797e9137d2dc1c3274b7f86747dd934e8dca8876578427d8a92f50ac88fba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb8385b98af0e0add6c6b7587bd41a381fe75e2bae421631c81dcb7ba7c6f621123f7ecd929721e86b18e6c88c1cb662e', 16),
+                    gmp_init('0xf9387896a4d2fd38aa943476e2474ef4aadc633db0d6d06f75e4f38790a5191fc7e0614d6fef24aa6261fe8c8f874a9a', 16),
+                    gmp_init('0x622a541cd342f48847257737533d33f7eb35fcad172d126294df70efae7f80595aa5625bc4efde462e829d87f0448051', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce0d82ca896f05c122055def56b36b12770706d4e6f4a335ae2926d68e1d08c73d09853cc0fc60dbcb2639aa67c54e02', 16),
+                    gmp_init('0x1d41bccdc6b214666037e9da1afa6ec5c245e37e17dfc6bd9ec5e31760e710cd2d4d5f4ff65a853506b7d8a073d445ca', 16),
+                    gmp_init('0x7ad6755a14bb1f63a25bc58fa059a7abb1a6d6a89bc35e97b3e337dc29e0e051a76ddfe9750a0aa079e34b1bda24980c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa7d4378155aef9017170a259430ce34d295204de63cbd7bae4f05eca363f60d2e0b56de9af2a715681ce7f711c34c9a8', 16),
+                    gmp_init('0x3c536a62cdd758684f3e54c54be7bc3588921776257821b4ab0dba20d43cf830f91d8446d1a6b9f9ba1e8058d12b1275', 16),
+                    gmp_init('0xb1bd76d51f6262c05a92d685f8082ab22ec1dc87f1f661a2e73088cca42d0f2f58b8c99d6b4956f8a8bc9e4c0ddebb01', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe800d14fd07b918a8299b405cd0795414019fbf8fef312f4f3db54b7221e19f1d89848d8ff19b3d53ee474d331e94e2f', 16),
+                    gmp_init('0xdc22e9eecbe71904508027ef21295145684f987c92c2187d1be30ab7645ce6392aeb2da95cce6ede3c8361b95f4b3d77', 16),
+                    gmp_init('0x8c37ef5ddfc5f6b1639e2c6cae8a479207ba0287fff37bef7501d7d5b8bd8894b55afddb5b33572531b1a9b946f134f6', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xdd789777ce4b99d53c9350a409f52c6eb83ea912a91815c693ae29e5275e5564a398b6ad78cb9b143f9b24193bba8175', 16),
+                    gmp_init('0x318ad7a9bb6a63ea11a261e83705979b094465d00465f78142af0c5b0d011ba49d076a3ebbb6f0e8aeacc702658ff32d', 16),
+                    gmp_init('0xaae041bed3b0bac5183a80cb0b686f190db13c38705568a87127e3a6f6a95f8408b90065398251b873de1e8c5db18d26', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb7f3c453bff1bb638499e2fed3709edc471afc4da09591f856791ea6fbe03cfc4cb8dca6b1e8271ad1346c1a2949ad48', 16),
+                    gmp_init('0x581d28c1c331d9a7b53cf1f05d16d724b350779d83894f632c251515be16cd7359dde4985a7e7de7edbbfaebccd913d4', 16),
+                    gmp_init('0x756af6e7226ccf903e6f5c821954d4d7a1fdc8626d9240e5c5a37485484be5a49942302a252ec1c69572097b485378bc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc2ec9cb1993b7c8dfdb7d57c115c073569a8d544ac3d20cde92ac86b83270e32fddb4b1136ab77f622bcc3164b5d4626', 16),
+                    gmp_init('0xbb65e867fe77e9a5094f5b9c20e5be54e297807941449ea147701c216684cf164a2442358b26592ad3af4320df9990af', 16),
+                    gmp_init('0xec45568a175a33b1c1e3b1722e9223f3a20af97fcde4acdd2ac3ffc6b72535b7f40227d43cb411b1bd6ef6217baf75f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa0d4453bfe4fda6a493fec301840b7c9d7d6f131e52faedcdcf3e50cd03d813478007008863f25fe927d80f1b5b45f06', 16),
+                    gmp_init('0x1f32bb0333b7d7c101be9f98ee899da3b539d8d3e0dfb43b8937f5ed66d1211b411bf243b8862ced33d155b436140260', 16),
+                    gmp_init('0x2e50a75d52cdce5464eb5cc4a547e4c0e7fab56d9897b3769e5f7b73090664a602d2e2df73915eaadcc8640fc72c842a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9a5de6bfbd3ca729c177b3dbdb1a5d224118eb1c20a70bcb7eaea111a727496d3fc18e2a3ed951d22ebc13c1ae2aaa25', 16),
+                    gmp_init('0x77ac5108e956f3eb147089926048e8fe3acf4e7689c3300e1258c3abda2127b517fd78462aaf8875c01ef533200cfe90', 16),
+                    gmp_init('0x733b268ca81bd3580f56b11ca8dbaac365ed3e36949a6a78d0ca4cc2dca823845775ed1d0ec700c09d1719940c27f82', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc006c743fa865d089ab8dafff76b8e12af1778016200a0643727ad434b9c027983115ee79aedec367767959d82d5e79b', 16),
+                    gmp_init('0xc5d449a671cd0fb2e58eb3e0abfdd6086c81c4454b2d272b63482e1b14f53d96248b42cf1dcdf9fbadf082b8ba744477', 16),
+                    gmp_init('0x3e4f1bad80e3c5069253aa26e2ceb895f4c2eae1c9769a9658ea0740314df61108c2f0c9d5a0b4ded6927b82efec22a8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x41f304f1685b4b58c980d82773c15fe9320063fbea448e22733ed8dfbd34c24206aeb1993aae67b880bf9e4070fb0992', 16),
+                    gmp_init('0x46989af73abc303502fa66dc237ad19f1900a356601532b3aec0ecabe86628dcf894a1cf4b29255de895c4b53f8f23e', 16),
+                    gmp_init('0x5d93c5118f485faf9a15d624e96f3030c912cd63b898d3011b5c774c253f7198b2e1b8789d3846d7dcb65c5011eee5c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf3008dc3ee91752e71d1d5e4584ea08166d5117d8df77d7da35e23755d89cf94373c3ebf75f3e7bce09f38c19976671', 16),
+                    gmp_init('0xcf9c0bbc79fe73f8a4dcc7a2dde815c49bb79c81937cfd7ee951e05ac4723ed0f18745ceb537b7bbdfa79b606e5f50da', 16),
+                    gmp_init('0x3a1599ffa07f61141b7a9dc8de3b70b96f15a564691e8c438b580f6469af2f2f129a7cba25242aa9ef38837863cfaeeb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x337d5b7568e6b86faa3748119173102b1f06c12b30526b3b35c13ebe6ad19f8dd17364986ea99f30f5692c7b4ee69e17', 16),
+                    gmp_init('0x68bb87af033d3bda641c52d62e7e552ef2f24a7f0ac2e968e15f7b6832c33c4ac59d40842f1f4c8b5d17ab6c17496d5b', 16),
+                    gmp_init('0x131fa0c8a79db986a9051e5299e35d86e56afeeebfca447fb7648589f51760ba225dd9ec9c0aab3f783e16c81616aaf2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3992bfab975cec396fc8c59965128ee5d32f81e7d608b1921acf9aa4803aa3bb15f52be819ef1f0731eeaadc61933832', 16),
+                    gmp_init('0xcf8e270fdc0dedadd2705bb38a87bb637a08bfb203edb1af535f6025b09ffa5e16f285716aea7253e57588b09bef4dad', 16),
+                    gmp_init('0x2a865c956c7bba61144e07925f012427603c3f68289b5b81350d3fc9bbd22a6bfb64cf92040b288e0975623bd958bce6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x70c36c9aebd601c1ea0d2b23050d6b3a71f1a55d3f5cc69838e840fbdd592bf17cea18e6fbcff1139da58032a4d97cd1', 16),
+                    gmp_init('0x323a02d19f61382d0ec6b248947f66ac30c6a68bc6c9d6698db48576b1068f1644fc788d5e4c70519078934ab5e782ed', 16),
+                    gmp_init('0xae41cb6ec0f6c65e8aa16d7a17afe257dd6e428f50415c98a36e5a79bb5bb4c1ff88f1b945db54b3e86c54b12223939b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d560e702efb5f504f0f533a4381c8de2d19f1e15a2e55e8cd592e7e1f5843f6b42239adc3bdd7e8966a7c4aa619d58d', 16),
+                    gmp_init('0xbbd94795990dda8de066cc82a41cf16cc802f30440834eae4861021f6a0297c6052b0d7306acafaed622a72174e595d5', 16),
+                    gmp_init('0x1c1827e54cae970ea3cb0caca763b4ae722ca8a32bf2b16e60d428c9e7923e6507f91bd4b29899f3a7fd663af87bebcb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x12da48f57f09e14291a87d1bcb1ac939b86a11854cebb78ae237126ae0da7042cc0ff90e056329677ab1e74c428bd2ce', 16),
+                    gmp_init('0x359e19eb937eacfa500382e6e92962cfb28e94a407b42f05726d77b264d206bbb0144010821888ac22be9225a55a547a', 16),
+                    gmp_init('0x3f00aceed0c064dce870d94d3a2fe767a6eff1db09a2d4530f220a36f40c91a05844e9be0e3e3693e5a613568c0c4d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3b2033d3dffe99e23a7a30a693da5061e5eea49a601943c3b863c98a7427cc5dd0e70b39a2746e13123b8b9f4fb3adb3', 16),
+                    gmp_init('0x94011d930b08cd4447d1a791c0238822282255817383b1e4600b9afce4d88f3865b1d741ebc5c388eb8303c52ee49631', 16),
+                    gmp_init('0x47f6b7b21eed7b680bf5999e2264c189e700e356edbed020bec051312b0e44020ed76fe017c7235ff85a571bc4bbcf76', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfad305a22e993bb65cafab2716c127ec1f5e629059e56fa8f49510fcf480cb7740b9343f562ad079e6e095fbdce66668', 16),
+                    gmp_init('0x9eede7821ee00c16ff79da8e59f45deb79a3b432824ef60258b775c6907df1da5ad94523aa294ce116253e563d5a46d', 16),
+                    gmp_init('0x6a1667c9bdf52000b259ba6e14c5085dec9a36f75287a7549624a10dceb965a33300e3cc45cdafab31eb3025ccb80f9b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x855330d68571664bb4227df6d40cfb8d088cb3ac8dea6503870c5dc5a42d7f0919213be9df5429049a23c7c1179297c2', 16),
+                    gmp_init('0xe74380ada279750ceb0e79401633a12c283ee9f5a09903a74d39bae1cb241deca2c75a85fabe9cd27a208a133eec2caf', 16),
+                    gmp_init('0x672133d5f1904f2ce87d7e5bd74c7127a8a186421f9609bdabbc04ffe125c665fbf120e4b59a7df634d451c7b4483920', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6c100937c9ee20d80de1ef1496fde4534697e92d3a4f9544c63a7b6a35e62fa45a51d2dc2a88fda79fecbdb62b005ada', 16),
+                    gmp_init('0xa64d2733cab2f72094981c34da77803d8ef761cf1939352ee8b37942bb27e78b12ba55ce885c5de5714eefedafae49c1', 16),
+                    gmp_init('0xd322f8321db9db5fd0476c763358e1ac62735b6e6b1419828a057fbbfd9fd874438adffdfe87902707a7097004003222', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27fa7652eaa04dce1ffe63211dcac33d41b0aaaa5961f145f1d7799dd5d0cffae0d918a9ab4fff50c0ee8df3288e0d9', 16),
+                    gmp_init('0x9f2826b544393b20365e783bf30e36ae2bf3521ed7a25c2406109b575f4896244161cd58e806a97b19cfb5b3485f8d5e', 16),
+                    gmp_init('0x123e291e1319f4a64a354261be2748ba9420e026fce1e3041cf13fb0c8fc7628bc8f33296394a561aca36174c94ab389', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa9195af0825337df9a4a182a3d6d791a7cb05a83fb275d781d616172ae83e889a7e45accf54d0ce3e3fda9ed2f4f272', 16),
+                    gmp_init('0xe6214d6dfeacf448b3d234ae4413d7ec71a0c81ddcca3d67a190375a5fb530cec2b705e8637500c43dff8017626f521f', 16),
+                    gmp_init('0x259a236241e546dc87d1ed1ed74b409750fa7bc022b034788c2df06f6876ee4fc77493a30760b56770e039a77a7f0fbe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xed57798ee457db6685307cde63c53a992f687eb99ca50a894d6d8de825c6e96d915ba11b62015298bb9fc68a2b34c2f3', 16),
+                    gmp_init('0xd522ca08b13f7b6461be1e44b41ab2ac8c747a9f0d2d99b471ebefb65ef87c8e8f9ea70a5451898fa17bd7889660a9b5', 16),
+                    gmp_init('0x18e4904acea6de4504e2195263ca9ebe70d063827abd71a1d72bd482180f8db2115edc19d989671ac7242a83606c659b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x18012819c1f78c8f0e19283129836a25b751dfc37d54e0465f72cab8f052b0be1121fec34cfe83c2413036e5c257550a', 16),
+                    gmp_init('0xe08a616ffe94cee6ad24cb6a3732910b9404dc0742b7e8b1e9dfadf6627218cc30d48de9cc32b4c372f08c6baa880626', 16),
+                    gmp_init('0x79e12266ccd7927587a553d06e8d08df784b51e4b57b9dea7a414611afac1742cf773a29621acfae31b0b3e37cd758fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x158187833631aa00a80d63fffbb8f3204271c1e76a47f6d341cb6c646625b9bf4bba1856125ff97de34cf2e8eba6be2f', 16),
+                    gmp_init('0xc73ee40728c62350ae1187a58fbd694b752ac817d8185ba51e644d3100ecee7f2d004ad1b4748b4ae2f2de943025bfe3', 16),
+                    gmp_init('0xbe4ae4472e189b721fa8e97e27e4f876fa3c364fe1065ab8609c4a0f22cdaa078dc0989f12eda36bb62def04860cfd7d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x64cdf60f95626a221a492995994340f301f9a962c69b9f7ad650c3183331972608a646e652289c661e19524a2c6e1b9b', 16),
+                    gmp_init('0x8b7a1d9e8b0c307fecc6ba013018e3df17ee2871f21e57375b475a20fb47be1191177e97d1da969a5493a34238ab83bd', 16),
+                    gmp_init('0xbb545ac307c1d81c5a4b48fe703221b6b31e69ceb31ab7a0c5daedb305b863d9ba98c2eff56ef27dc5c6418969b6d475', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa7e48793966497df7d18ffb64b0d6627d620cdccd32e36f927780631640eba489fff0795ab396ac368fe66d09f74d23b', 16),
+                    gmp_init('0x534c332b3152797c0fb019bb545cfd2f54ecbf63e0fe360ff4159821f58b6e44bf8349e78980097d38b879ce42f3c459', 16),
+                    gmp_init('0xb09168f082e3981f3524215e79e33c65e932c6971c5ea2a28ddb1aeae351393df0c7bc51636ff12a4e7a6126b16e0fbd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd93bbc8a15d0d9fe23c81754e861ac255ddf38c57821f2756ce56d941991da7ee47204aa94b0e8d568e164b78d77a0bb', 16),
+                    gmp_init('0x29601e625d8e2e372c5fa1f745e48e2ba65132ed7704d826eaff20cf0b03d80be087dc2bdf1d7d4ecb021e90902f2432', 16),
+                    gmp_init('0xbdcf49c22ddf9f8093808df93661a538d0c62a95ed29d3f5539503b73f7adc7440e9797c9ff9c850bd1b088f27696c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x24c8091b3935f6abbe5218eddec3501d3857ef21322125ac01c4ce917499c129d4e02bddbfab4eeecc9f71f69f89fcf', 16),
+                    gmp_init('0x2779ef1458779413282756b932846c5ed0a5f8dec888260e25838a4dc8502137cc6defa0842b6551fc7d2c3f3fdc6242', 16),
+                    gmp_init('0xb8569674910c8c57d63fe491309e35fac43c4e4c815388ad728a8ba93ce871d66b06d2a1853de9a4b456674b6b204d5e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x685899458291607510c81a9eff3e03633be1d67409b4660db906bf00ae1aa53df798e8d18f47fce6c40212197bbd0812', 16),
+                    gmp_init('0xd434b890d267f91c2da88bb51607a4275f0348f8986417b15299e5284fd6f61fe131994b93baed4dba46ca293355ac15', 16),
+                    gmp_init('0x61d3bacbf5dce10ce46654df48b4ac69c074275a30285e0610d02f838a241c0ba487406996bd40e942e89e82b98503ea', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4deba605d63f7f47131774d80e870e2d4526e292b56991caa4d31d0118591e8df8fef3f33214fe75d5c2c0272697fd2a', 16),
+                    gmp_init('0xf5135e746921ab21db010204522b02ed3a820906e5d8cf6fc331059d0c6218ecc8fc1159c309b981e98e7167d76ff05d', 16),
+                    gmp_init('0x347c406e80979e2a5ab6ce91f21e474d39fd77bc89f907f1ddf0bcfb5695a9ba6952ea0ced64b4bad5d7f4d80ad59d6b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xebd70ed3027dbfb8a54bb5bcf5d275e1baf92609217ef87eea8164a89defe23e73fb14c8bac47007cda5f21ba8525888', 16),
+                    gmp_init('0xa87aac75e67c8b2ca157451d6ce8c672bf2f6e93161135d04d7691bf53cf7cad3cbac03fd5c818aea0f4568dd5340970', 16),
+                    gmp_init('0x6dd86e827aef53a6845a4005fde55ae4fabc4750a51dd7484baa79c6f9f1420c06ef0f38951566f2b48531ecd17a09ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6735481a464c8ecd369c7fcf13f6db129aae8fbcb0071fb31b9596b3173baec3d70d566e3ee1242d702c0d41cc7ec1d8', 16),
+                    gmp_init('0xaa0dfee39a99f8892e9e69cceca460f7f114d5a975f064b53f99883f924054605382c26339098941ecdbedfe6a37350c', 16),
+                    gmp_init('0xbcf1006a7b29ad8443f1b9741c6a6feab19b0def445833cd1f52caa472335b54723f6f7604dc0ed556fd81aba361280b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x2cfe41a697aaf4c97f51f712e9cb78616930c11eff89e3686f993d57c649c4998f6fbf94cee6fe807b03b3826a2217d3', 16),
+                    gmp_init('0xf420a88fa8b82f545b3d4aff62a36a848075ee1fbc39a411408bb050b28074f67a9da4e8187eb0261c99b1cdda4c3b6c', 16),
+                    gmp_init('0x8e108836db8c3b698f0fd042257ac6c5db4a4564a0205dd823412111ba400f11debd3ee47631d63b7a89900f8421e9e1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd4a793394a45114459a73aee7544a32d1c65a66f20065261b91175d230b6629dde1f0eb3fed015929d78a73a3721500c', 16),
+                    gmp_init('0xe1d46bc458f438e241edffdac49e15536c4dc80b879852f316b5280971e0c615c5357773ef415511c1262f2b0fb1a77f', 16),
+                    gmp_init('0x84e9d227b5492a5332f3479c6a15850b7fa594b45cd1c7c7a52c972b20ddee8b7293de2c05a30b8feea00a93adaed672', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf453eddb12467143690c802e617fcdf865bb94d7481672f74a51627a56fce27356ad78a693330a1295fd9f0184b89e31', 16),
+                    gmp_init('0x9c1e494f440b1191084ff175799cf8c7520dde420b4d59cb8fc798613270b9a1fadcf5a4788481cd1e4516c08c44028d', 16),
+                    gmp_init('0x3bf931d85834eebec01f6a9af77e3a2051d9e5a581260eedd77822b0c5b823d9f0df82e4c59363bb263a87055b681cd0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1f98e93d41359d1db4a839967f0e8b1daf7642c9be4e4eac617923bcd6324cde0fae32ae302ade8de0af58f4c75d83e6', 16),
+                    gmp_init('0xfb274b5934fe687ec7ab504040bdbacb02d8d4002140fc7ae9271df14a16f07f44a3666046eb55848ec04789a8f08e7d', 16),
+                    gmp_init('0xa08b8f38bf62396ce120136c5183aa0733dcbe63986bb04913d74e91176ae7693a2d34ff017515a799302a7b0560d8eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x743219cb377ccaba1edfd56db10310feef60e288fd48aed2e0c6d3751c9d5b840e3e0132ccff3804c9921951e4c93f3c', 16),
+                    gmp_init('0xa93e2d643300f8f1196b740c0df163e9f0e075a8a01176565beda83ef4f27c32809a41094f8d194b4ec53b23c86fc89e', 16),
+                    gmp_init('0x77cedf6a18c14a3812c6ccaab314f54cf55d17c82d9f4ee48d6ace040717adfa99605e635680ada54bc2cf24fb99a4d5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcd0439ca3187fd021638bca395a248e33bef7b39c21977a23faf1f22f8e246f19df8d8a4812d831f5e9bb3622c0e1ca2', 16),
+                    gmp_init('0x4914b61f06b98cf49415691d3ae8259e790722a0106ca7f3c06029eab23c6da47cb28df1fdf9d3384e0449bee2ccf44a', 16),
+                    gmp_init('0xa08ca4772d70af36ef2134ab56664dbd6228e166657c799af53d35b94bda78e4f88b220a5afe9f6046c837141a6b5bd8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb55d91cda9fd73ad99cf27488a74662b0d21ecd45634afd22580fe1205e0ff3305fbf3abf247ea73da4763b63ab6a7d5', 16),
+                    gmp_init('0x9069057d48caf0c1bcd92d02d5ddf5cfa807710f0c243aecc9e74f513a95ae8c45a22dcccb1d758be38c25cb69e582c1', 16),
+                    gmp_init('0x7998a843c7c9943188df41327fb3a3a040addae994a555fbbc7dd65979a67affe2a454d667ff74f7ff991c10fafc246a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3ae1fbff5b848ce19358680ef1f2f3027444433c5178ac61bc08abe35202acd49c3ef69b99d42c44b99be04f9d691a57', 16),
+                    gmp_init('0x9ce1a12370db5e6297d34b3b2f9ebf3435ff2f56b3d1cb8bc8a2c270518bfea1e9426e701b9136bee243b1bde4a8cd', 16),
+                    gmp_init('0x11b10d0cdd9d1caabd0d6ea70ebd135b4b969a4438f9b6418cafef16c18615c55348590bc4fc6aa3bac6175a5c3c4f6c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7e8a0392f5c80ef6a03930aa6118bd562a7d314e2b535c0c9ab142c7b5484048b924473a4410a6c0ad5b3d826bb48fd', 16),
+                    gmp_init('0x3c41cce13d2878ef0e4d92a2fd1980a22a6197d47ab381ce9d8fd4cdc417e74bf87ce8b3ad377cea38060acc13bc0df5', 16),
+                    gmp_init('0x7544555f470ca6ac591d72aa6d07cdd98a2bf03754d660e16019c8938e433c241a5028435e3be804e90c40c010d33ff7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6b0f1b55b9826944d4ca64e4c7560244bfac7bf5743f357c137cb4d6a850e044805ba6ee3f68c4d9fd950dcdf5e3bcd', 16),
+                    gmp_init('0xe1f44075b3de8f08a125ef4645eb407fcf2758066272469cfb4f1b56a5f7bae67eaa2acb1aff38bc957225c0121d63a2', 16),
+                    gmp_init('0x6f44931a8f4645b2f927b9971542480e07119bbf4700669f7bc04b93053c0c9263022c749749ae39f64ddcae6fa658a4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3d0af516e19bed1a2b6ebf69df9808c872fcee683bc3660979486c4425e18852a9434d5e546f3704a4c6e62d1099e15e', 16),
+                    gmp_init('0xfb4d651cef3510ea5271c22a6f027ed2b6f67f6bd740239433574ce364d0f7dd677a4b708c1a5855bcf29c092dbc0776', 16),
+                    gmp_init('0x42b00e3026aa044fa15714b74aa6d0b7fe7b84d13457b432adacc797bd0d85eb00626a92058ca281597dbe623ce05f54', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x474639b024883e1c4d6fbe6950cd5da0580eaa123eafca9b31aa2d00b708b1dfc7d724d0d59e6aed6dccf464745cf69', 16),
+                    gmp_init('0x3526b725fb791c28a322dc218a4ef14fe6979eae10cc29561246ac1fd988a20198c71e4132fb031bfac83a679e9d8733', 16),
+                    gmp_init('0xfe2bad5ec5b0e2b2ecda98e7dfd0506190fabd5e2e3f8f6c8b173513407324a064d816cc6f2efdced28eb18e44cc01d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf9e8d08240cb4a8f68c1ff163ac403b19f56ce8e4616bc858471a1299ae451b71056d828a77bc84e2659140230536eed', 16),
+                    gmp_init('0x13b5f8621bf343b083084e71a0c142c38414f9593f2fa595d71e6e4e4558dd0662375f99b0373785d836631347165ec9', 16),
+                    gmp_init('0x54cbcf00f03e01cef2684d24adae8d4158a911a90bb45920d386b9ed529fb31c202e7876fca3995e701efbd3cfbd3226', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce73b86359bfc87d95ae0cd3f54a54c417f81e547a9c15221b1fdf01d783e7074743553e1e4b4371b7b0d9d18307fb94', 16),
+                    gmp_init('0x46e4b5ab321173e17bed434953ccf343e22ef23b558f206cceb4f1c4c8ec4cc1eea7432f83f08487a8eebc77fac55e98', 16),
+                    gmp_init('0x9654146cb5a082c21a9ba34bf3e3cb0d702ebc4477b6e0a6bce4452c74534d9d6af97db4f4af64cd8db04217534c7cd7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe089c2d37d9f53237f8ad8ed8af40a86f3e6b754507e72f08c3b909a25b2304f5c6c65db3b5a64d8424433e0fadc7369', 16),
+                    gmp_init('0x914000c4f9888b736543e8c755f0e58673fa7aa7c23f3e5b714f485a5fc1c87d2f228cd8d879f24d440c349a5ca30ad3', 16),
+                    gmp_init('0x1a54eafe21ac6a4093213b76dbf0d58d3d2ee5d31274b851ca8a5fe23ca3dd19d592b41f5fc41d4dd721d54c939092f', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x5b9903469df6d60439d44ce47c7701b9e5f370798fa32d07e07632dbcfa9bef1cfcab8cb1cc4a6f035542c8ae62a4080', 16),
+                    gmp_init('0x1de67916c2c9a7371ce8e45f853d35421467b448bbf00bc1dfa0ad43d282d57836e4a398f88171ce27e680eef8a38c91', 16),
+                    gmp_init('0x758e62b5ae24e67befa6aecf947564b4dd96402fd4f4298d1529b2f99353fae9a1bc75ba5b75101b7741fbb3c5bdf646', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4cf51d50b0ee51442117b05a51bddd02fcfc451e8ec8ab2d1b5522925a434ee8cf5259dbdf43cfadaef098622543b9cc', 16),
+                    gmp_init('0xe22efce261615f1c7db1e7d6410a66ef2c095587ad40c42da20cb5ebab298d139c2b6658d8b84eda2933cf4715b270d5', 16),
+                    gmp_init('0x4c108a0c8cbdc03c9c9ca4a41a972be3571739c1b5f1379d335e2e3f18f19b567a93469048e3cad2fdacf0b55fc5db07', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x641cf9a37ae562322d47b69361092822a89e27b83554f58dbd723c28fef21fc1e5d08e66660fbceff0162ec3325b34b4', 16),
+                    gmp_init('0xcf29eac0133abad17cad6c22b6f270f85ed4205a97217cde7cdf74b3e98a9cbce751f1c8a4dfaf1df6deca06104e28e0', 16),
+                    gmp_init('0xfe68421777b722479def21257751960e9ac186950961ad23d697f138ae18337d60e51c9c4a5e4c19ba88cd724851e8b5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb21ed73152552ac7c28d53417c3e0e1066c121d7b58e5a0b563d54bb5c65b899df64c7d369053eddb968c6107491ab34', 16),
+                    gmp_init('0xb85b0042c37b86fc4115c38e46d2a699a1072cf5f1dbf099e1fdc0772af2d0fab283e9ad9d16b570fcf2f251f0554825', 16),
+                    gmp_init('0xaa1fe292233ecb2e12fc31266e7f55f1de8f6783a155ca176adb3c1d4198c29546030566c46dd98824c17daf593c3231', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x40fd49e1498a855477d27bd12186e7a019e985512880f1c6b6c2839e78d87e8ae25a98c2f779c9eb3557cf238be5f051', 16),
+                    gmp_init('0x899d8ce3137e82ae14216022b58c0d31032686c87c04d52bfcf729ce4387709207af8dc74c10dd92e8df86e8f810210c', 16),
+                    gmp_init('0xbc7e7c71feab63891977d7df3f2ee5538fa4b24b919c85675f89fcb9e1126d5d884b241e12d85e26932f7dbbbc5bea58', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b1c7528c198bd1e04d55c373d0881766667807c6e0ddc2b4975969320eac3170127347d3f1fb4b28eba33fa2851e270', 16),
+                    gmp_init('0xeac1243f64b1fc09dd698f3983a2763fcc53d0b42809c4ebad97177b548dca8c82439597a91727c8933ec6adfec2f065', 16),
+                    gmp_init('0x993f39a18beecd886bef62f4e319f31a3c791d21acf64bc6a0bf8168d0460d17de3f1fd763d6f81709579f480e1c5de4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe3c539bbe9db639a4146c08ec92e91ac8e1a72300fd08d653b127b821ef3c3312f29cb5e9f749b7d20f00a25a5c7d945', 16),
+                    gmp_init('0xbf4194b4fb47917d2ab0944591a6743e7245d885b568724177c48929e7e0c1709974186fd2311ba9779261c707214f78', 16),
+                    gmp_init('0x7339387a650de4b2b921881e672b01476113f7971ff80acf5941b2a5a8c8a41c6b3d6f3729e12bc5f7b00262ce4fb6d9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x90da86ff030a819fed8d8c5a84fbe60454b78507f815e53885e733cc2368bab8a9068e6d822d861786cf40ac8b80f9c4', 16),
+                    gmp_init('0xbb0f1e75f01e5bb77a4d5a4ce64301cf44188a5ec4580fc04f371a970ec59e18ae4f6e90a9b49281a777c41b3c76f74a', 16),
+                    gmp_init('0x38f667b217d49edc911fc20eb14164551378fc71b44f5fbb53f5e59367435d4f23e892da3ff004d59bec5a7df2bd8a6c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1460628b774a98cfc1357afa1128c3ba602d80689045d54ef1da8705ccc743375b9a9bde5fb4015e09c0efe4d2ef1c05', 16),
+                    gmp_init('0x86dcf574e5cd3205fd86c08262b4129fa5af9547866f4402a765de8acfa4dd432da43b370d20ac04d71fea5a9df42895', 16),
+                    gmp_init('0x4e00be06d24f6794ab2b58ec2bd8f14cc545fe22928797b98ffc47143819f177d368e892e9657e8dcd002e626cf49bb9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xee5165f552c3483d989c7a26e092aec45e9b14c1cd01bb5d796abd80dd99dc78e6c17d234e83844d8b5a15a02f993f91', 16),
+                    gmp_init('0x6280ab3ea59a82a20786ca8bb5d7ed8df9796e802b1ae61e27422107de2ddd4feb06cd2d908d06582f26297459e73ce1', 16),
+                    gmp_init('0x343552636bc3f3c8840515170a689bebb6d63c46efbff6071b43e44a67137c3fb59f86f4835066feb783a15976104b5b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7d36c3412a52e5fe8277dfe50e4ac03b55225c0438f82ffa76ce482b0fc0ce16c85a27b467a52f7b792e7cb2a0cccde', 16),
+                    gmp_init('0x5429476ca59c24d1b9764d67df984687ea1868fa997dbffa198b827f35119565a66b65f04a294053433af5f0cfd596a3', 16),
+                    gmp_init('0xa0f15216701fb8079f94dc9c753b95afe76e07cbf1adf79800b1c6ae08ff75ca08918350c12cbb810674d41595cfc74e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb3eaee235ec7cae652d9d9954c7f4104340de595aae66324cdd774700744d3a94baa09729e025030b6088a8d259af1f0', 16),
+                    gmp_init('0x97b05046f10610c52b6a8b887e3eb46f380fd19036a82384e35945b180e1feef3b5b3a84acc0ac5be892953cd6b61f8a', 16),
+                    gmp_init('0xa0b3606c53fe5d9086f186a87682d5910c7ee8cf5ab63aa88e0a7baa6d298a4960566cb9cb09d43d3ad8b5c7014c5897', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xff7c652427376b13df8913734f3dd961c5e72fd773e4341fbc49014d119df2208eec794f0fe5b4c988cd86cfde713c80', 16),
+                    gmp_init('0xe25b223cf5dc58e8a9ef48d4a7a41c60ed99dc9a8c75d1bd17fcabc7e3c1e5029f01a6702ccfc21d138cbb3ff7e7df92', 16),
+                    gmp_init('0xd1a6db2bc275f26016c0e7744e83f707ce9fef1b14f8076dbf446b0fd1d9c9ba460696185f16be5df0dae4de4da9f172', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x44bae206518910b4f633a7d35eba608846ce7860724adc5bf4d9a9eb54bb051b0ae2274ef8a7a85340d634fa82444d7e', 16),
+                    gmp_init('0xcfa87b637f8fc4dcf4956ce606dcace5adca98a845b7fee16d3bb5a99a90fb2cad98182460d3a81c439af8785130c208', 16),
+                    gmp_init('0xf5ffd1534a3295b038d505089fb4ed82808548fa10816291c03ed82788bffb6f908a8d881231206e20b382a601b44078', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa63c16cffeb23a6f01dc3d993fb56aa14cf572146b580d1410df36dbe43d23c668065c9aca956f29cb87f8a64877df34', 16),
+                    gmp_init('0x1fe9145055643ff6409184b311e18167fd57eb06d7499d634b8df026b23c5f5bee6c3baf9051b13f2e71aa220202ce57', 16),
+                    gmp_init('0xb6dbda0b26a1e8358e3d2b4df12c6f7e276707af5b125ef66eb05cb0df88b028de95d041b530abbf599a787ba999e7fb', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x235f54fa2ced03a68a9282c07273a54b13efff256df2d79809fc76e7511b1654684d3014f0c0ed3fbb04500e91e3d55f', 16),
+                    gmp_init('0x2ec686c2d31095af1e7afc110e166c867abeabfe86f454fdf8a162802e32253450743abb6466862bc033024806e07d3e', 16),
+                    gmp_init('0x9a5b7339bcb641eab16c49db66ef046385cc3d05f9102b92befe2f086e10135f8488559b667eebc305428b2dade36e72', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4b062c925307eb6adcfd770c97560b11043857e7b65c1607839e242eb5d12cf563300b6fd91814a142cff005937af53c', 16),
+                    gmp_init('0xa386f985bf4c43741c530c919bbf47f145cae9aefc7cbc8ef53d6c0f2e5e16bd1cfa86dfaad5c461b2a521eeea48019d', 16),
+                    gmp_init('0xd053f455f431d061e20cedcc36cd35af554c403135dd4a016a8ec6842023f81a12503fc869dad006150560b254b030c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x59d3b5b076cfff16c738c92e22564fc398f5f2653b62d2d4f36b13bdc4fccd7a819129c413e4cf3a678adc88722d006f', 16),
+                    gmp_init('0x64ec80aa09f6b1f0858d19f3276004b432581f7efee75883edd51001ed5208fc2c97798429118489916cc003f5e2ee64', 16),
+                    gmp_init('0x98a88b8a3c9aeac42d7dbda61bc66f1300a054d3f38a4f78448672f45019d72de68b55bf5e6b130826d5e05f923f642', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x24ff4ab9ab901994d15e12c771d94b05b07c5e6a63ec1ddf9e1f813cd89ff9c9aa00137517d032f49ab5bddc8352434b', 16),
+                    gmp_init('0x7e9a698227f8bab485ef0c18290cf14add59caa0a755d11524095befc2ce637a8b58e191b33087bd6625fc068f3080c4', 16),
+                    gmp_init('0xa71873ee3ebf5c32745f61cfc15bfd2d11bf742170cada669d270169127b444488ce54badefd1397db3b072b1a7ed011', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e07521d3fa7ce0c2758b907b5726967768e42de8ccae2aae37771deb2648102b4cfd0ba8348dfcedb9c631b8e15a5e2', 16),
+                    gmp_init('0x71bb49b6f5fd0fa2fa4db720c0f5e70970ecb644d12489fc7008bbacdbce296d53a29f11a7eff9c6220070262cf6b81a', 16),
+                    gmp_init('0x4327c41fedb428c77d9bfe4fbad4c00db5269a80eb398daca2df8912e53abd1f1befa3cf1458963606b2eeaf72aaa8cc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfe988a7bc2ff7310e3da76d10b005e156f080c5276512dd6be643da6eb67b9cf916c71301594d8ee5a1ef43f2dceafde', 16),
+                    gmp_init('0x8831612ae6fb9daa4e75fb15624b2e4bcc251a7933208d1b2d5fcdbaab11c36995c1f83acda1ac2f948836caa4b28a15', 16),
+                    gmp_init('0xdf01bcdc978f739833154a03b8bbe95b361f42d10023dc99dad4bdf3a95398c70e4e42faf71a565ee4a2fe3fae433dd0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xace5869a4c7663d729cf9de8cb9a8d9a687606b55290fead80e40df194fb1b509e1481476482744dededae362da12bfd', 16),
+                    gmp_init('0xfa175193da5458d24d17333e3feabbab62abdc98fe67c63f1b180d0d93d684eb7c9cb40b6c559acf7a70bc2b38c23aa2', 16),
+                    gmp_init('0x46bd59afa34ae63389ee44f9d6559cec4f532cba2d08c18399e47fd0dd102ee8bd84d3de25c4d4d90a94e69434d8b00a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7065ec89dae69cc797d0b8cc0b89c45eb4d55573bf168a44bcc64883204bcdfb6d41d6d2906155e30aa36261efafcdf9', 16),
+                    gmp_init('0x263733907ba56109ef33341bad455b553c0b0621283672158d184a62a0c4b833ec41290e242b765f54e03b347ad3f2c3', 16),
+                    gmp_init('0xd4620526811601b3df2233873a88249f28fc9e1b70a03190be2bab05a355913330e64d8618bb2f7e40d46e4e15c9affe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x43bb2693e3b47f17dbc4fb378e26eabcb2d40c617f28018c20d40dc4ab08a72d9b2e5b0b6818c8ad04499a126ab64d0f', 16),
+                    gmp_init('0x394a11e5ce858f827085955a028ba8e63344ed48c5b3347ac1a03fb954afbb59042112252b60394826d27fd839db1436', 16),
+                    gmp_init('0x1f0eb57f94eff33546dce5023da2a2863fbab69226bdf2f70997a9e980ac4b0ed124f03a45e18f79080bc57ee5ab7d74', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9163f1a852302a6102c8789e63968a70f9e4ce887e32d6c39aa77e73e1038eba402b0e81c1c90552d2a8c4566c1bb33f', 16),
+                    gmp_init('0x8e5f987da11418e35e3e8a9f3a2c8ddd502fa75b1e7ab35aa34875577a299a87870e080fb25bea3ce75a206eed59b16c', 16),
+                    gmp_init('0x36025ce585e9837471e42238d402203dc032cfd8a3602d2df445f9e05789cfc58b18b833a0f5ee646ee45d359e63c5e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x16695c4512f473d3bdc824d9a788fe79b4fd1517281b10b3f61e0b2a8012da85c2f7be1f5c117ef2c19bf28f8e9868ff', 16),
+                    gmp_init('0x42bf9d43f53cc51046399c6346960eafe882e263119e02b23fe8cae05fe33e6adabb21c866481e96850a03a69cf0b889', 16),
+                    gmp_init('0x3d30f9247e5c6897093e7ef6dcfa3d78be5657351b893b0be77a1f977d4355dd1d55e8d6cc7ec1de582c6b8d6502618b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf2dfc7207ce90ef02ee80c06cb1d420cfc17e525ec71a5897f9c68a822ef34bc717fbb94e809321eaaebdfc8ffee5e6f', 16),
+                    gmp_init('0x67bb5923c645171fe601f5aafc44e34c59f84a42cbe32f17867e7fbd42f3bf1939e83d1b7da4ef686c365066c2098e45', 16),
+                    gmp_init('0xbcea1cdb5b4577401f5a262131cbea2a2e5af8b256059631d26ce3dfd4b6b7f6cda1ebc270ed8254a734f396758a7186', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x58675df9c4131e460c2c14d4c0086c1afeb45da9327b7a671993f7d2833259a1be433a2a5cce384500bd7cd71f94e949', 16),
+                    gmp_init('0x1ad9fee6403dece815fb907e9e637624ad1ecb15984457ae6bad8b6207b289e8badb871e479f7f020e8cc828b853d059', 16),
+                    gmp_init('0xf3b18ffb9a4fc735a65e34be9d6f77717e6005a52e49ded82eba75ab502221a428cb893127a0b2791135cdb22016a135', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1651b81e1cfc77e022746d15baa8cdbfdde3b967b6685329ef4695b49b637423da09aab5e8e11ac34cd4cbe34dc6fb31', 16),
+                    gmp_init('0xcce1818667b2d3f04463838f8d574a9070cc698b62580e283d5ad87f6af590a25b3593caa7d0d7eb6d8ad02dbe032dd9', 16),
+                    gmp_init('0x5953fbbcecf63fdc60717fc5fb5411d1f78b0d45c4677416be6fa1bbfde16668d8e514b10ef0a646d767910175942840', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x95bd960e4d7ebb0cd8db72d22116e0bdc18e89515a62a5c81d6a13bf523c5ba0168e4c3c53d20de6db4e2aefcf20637e', 16),
+                    gmp_init('0xa2d7e8e4a9f7f458113e8c81ca43ff23e150ba591ca8f6e166fc5fe924ea30e2b98cd2bf0f4a5028045a03a18ca4000f', 16),
+                    gmp_init('0x23f6557c70d1ab39614f293fbf8a78c87cafcf1d366dd7f9c3efe7982a756a60653dfad1e5c528b115b38db0e59a4334', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa69609f765155581016798236b84a8c1211ec550911f06ccb8fac5e7439531d179bd15bb13d8075599dbedcb5f4534cf', 16),
+                    gmp_init('0x74a9136865498e8fbca2fb3e089fce26405333296a35310cdc631f15f8a5d8ec4612d47d9e6ff124f67602f03f55e1c9', 16),
+                    gmp_init('0x628ed9e3522affe03d96379a68441c5e587faa895802ee8c0dc33f7c40c264b1abfb44122891ea5e032bc8c38b438899', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x922e002a397ba091d11cf925cba50547968cfffb6bf0f501318608b7911501dda06787847439dc88d7d2d23f48f25ee6', 16),
+                    gmp_init('0xc8779815f5144355c2029f621b3e8ee11b1dfbf694869fb517925b21270bfc94d2af5db9becde0ff346c4eea7b858eab', 16),
+                    gmp_init('0xba1298ebffb4b7ef7e3b032c77c5dcb2e6fb5ef40e4cfc82427604ec14a255d937e34ce47c1f720de23028cdeea98f79', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x34115ab65f10637aed3bcdfcf34579dcaa23a2c41d01a1b72e3ddcb0201e0db64f73e8eea9c536c1b315e2ed8bc7e32d', 16),
+                    gmp_init('0x56d088234b7aded0f068b4563b9ec4adc287027a114e27090308163eddef9a90000cb2857b37afb26791384a43e2cb2e', 16),
+                    gmp_init('0xecdb557a166f6a1f01f4e550c40e0f11f37971722ba7329b6f08d1eff0122ff6baa889bf383eeae9466cb43e49a924c7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfccbc98fd480dfa6e9936057c2fae0b07a2051ff47bea1a7017095e60134ba0880b0503a459ec9625e5f77bf9a34c959', 16),
+                    gmp_init('0x2af86939db72102286b994e912b0e7b32a164537482481e946682c2ba495df0b585826c71136fb6728828b1cff1b40d5', 16),
+                    gmp_init('0x2a607d36044779a1ec4a116880765d9d7ccf24f55c8ab638ce1bcdb316220f689bc2a93fcea76c4684f6304fc3de5c62', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x22b7d6ddd04a716a75923d5103172d4e6a24134dd5a64c5c6fb7e35ed5066b3702d62577901f5cfeff42c035419a76ba', 16),
+                    gmp_init('0xde002e43d8067d435af4fbb596be2e576cbaa490cd25dbc217f6e2660dfabe62c76ed659ddd1dd426d6e3a9460bb2088', 16),
+                    gmp_init('0xd4cea7068823be830d70c035b490bc6073c9f0af8eacab052b447f2afcdf0f9da19d40846193bdcf0d8164b7ce4f8ccd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfd04f60fe9666f3587faff5fe9e9c98491b11a97f2a0547f899758f230bf4245b3a897b12fbfe075bc761bd695351940', 16),
+                    gmp_init('0x926a54f7855da0e9df0c6eb439304ca9cdd7e3850367c57cb8eb15b7331d46fd45572217311aa2232ab6b7f4a12f08c4', 16),
+                    gmp_init('0x87aababcc14e9a23ae884b31ec35ad4fd2fa8b7d2f6125e7a9aff865e46d437bce1b5dcdb80a2f1ac2d7ca5038848070', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae6695800486d6f643cefdbc146ca9d3424e8d12bd7506ae2f2480910b466ec66f7bcbb541107175406494f9d9c3f11c', 16),
+                    gmp_init('0xc28fa9993f30cdb88ea7922df355ec0521f19768eb53337060beae10030dea3a9c7bc9304e9931baf932c1bafe3d3ab9', 16),
+                    gmp_init('0xc88d260486e5df779483b8d4ec5f5e8e4d378577f6d355de2b7c552d7279f7ee4cfde46c8e3a5814cac954ab0ad4570e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6235052813b5b0901b10212a771dce123ce3f183fc730216d4737a4521888380f6f47277b43749b6b93a12d25ed528c', 16),
+                    gmp_init('0xbc7315848b6505e7ad5c5d4b2d3e9be715672b9e84266df56a729a7544c5e621a55baaafea861cce23f6f7618e4d47d6', 16),
+                    gmp_init('0x267dc2036fbbbd1d8f0f93531c594270e1a9fd56d5b85fa9aff3dd3e149a34a3da48d846ef8387eb553ec0d73de3c22d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x834cf47b8d6965a9c2c5f1c2243feb497fc5efccbad0aa9c57c138c944ac20db169207ade5ab65e4728ad24a28d3a731', 16),
+                    gmp_init('0xc50fae169d9e1b4659becf6b7ba5fcc2706037023f6aec548edb8463e64f32cec87bfbce860a5d6faee229a370dec9a2', 16),
+                    gmp_init('0x48c823ab85c5db0730c3a7aee46c9d89fe3bd2e2a346f5b245dce83ad69563de4d0d23d8b644cd7e115e7e0ed3f5c452', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x53a5265d19b0a2c87f77f04b2138c7d1be9255e83396c1f62344c94d533d28207cd1691c71e11ac9eaa79f3cb32f95b3', 16),
+                    gmp_init('0xd9fa9a5687460886a62e3b738b1f0ee8fe0a4ee42ac601f9c58e84ba0f5148ccac6db907fc6a247c45b7cff02874a092', 16),
+                    gmp_init('0x27f87074058fe26a29d6aa9f5ddb711ef822dfd43b25bc62db21128075c824d7a19bbfba2061929ef3b3a365e7742903', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x931fe7ba4c0598e44f142503eeee8ae289ac3ad4ecf45fa772354c9c6db6620d818accb5341be9c3c3ba64cd1603f3ff', 16),
+                    gmp_init('0x77c2afaf4fc6a0574972ff5981d325945aace697ace897f07ad5a603b50cd33f61bbe1a822e80056054f9cb03425e70', 16),
+                    gmp_init('0x5fd4c3a3aa42811279baeaaa4e7655023875d3119fedcc8b386c67d195464c91d347762dc6efbd0eaa89273038471135', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd9213608fce57047b83376fbafab8986485bcc3a74589b3f5099ddfc3518815fbc3def118e9111b154841b5b890c44a2', 16),
+                    gmp_init('0xa86ebc3991528637cb2b8244df16f52fcf8d97c2e865d37f15dfe05fef7bd562a83face93f8c040a3d080f18fcf19348', 16),
+                    gmp_init('0x37098a026d4c30d90f93f3d4b4ca75ef368210c2590ed5cb1d486513db211aedd1b448c3f8f1bce3d7a5675a285814b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x85df0ac4ad9740b2de175c51fa17b3ad18529705dafd499c33321b24b15a649db58f6915d81e38e6116dcc21a52dad30', 16),
+                    gmp_init('0x3d39aad3f50981d15eed9c76827972ed6334f2e0ab07d5525ad4c7fd636e5bfd15b9541dbf184a66a8e8e8948d061b2b', 16),
+                    gmp_init('0x345bd704326b2a87440c54f1a10eb67fa2ccd4324b4d8a740c4712253181ff03f4edb8524de4913c69b2df7057061880', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x31bf674e4ac1f57bedd7bead50318e78357b480dc91b9b86aa716e1699145627e565676f0bf333ff6636fac03d74f2a2', 16),
+                    gmp_init('0xdb269bc0fabfe03dc3b87f433330a0f4f0544e33695632d4b3d3f338412f3f2abb1614f67bed249eb2d3c46180d4e181', 16),
+                    gmp_init('0x580c11214c2b5a5cca966c31c4e3e759ba69bc000681d426f4a6baa67035862c35da5661ca940662b4067545bebc9adc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe522e42bec9a994d3edd858e6344e7e6496ecabfa9ab9801166f691fac8780ea2d7dd86a2b460c52b36e0001be3a70af', 16),
+                    gmp_init('0x2884a3afc651886387ed5c8df43adc5b2996685ed511f41470a6a254ffc163b279c02a8dbd1eab12493f9d2fbb35e2e1', 16),
+                    gmp_init('0xfe11b17cb0c96ebcd174fffb0848a3e27ae48d73c8907ff06ec3fef4604a0c635aaa7e9f17bb7981f1d238155d1c65cd', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8b73d03e55f6879e1bb243e150d41c99564a7a1a71a37cb35d589145a4613b3df51be374f2d4fa9a950cf3c3f54fef34', 16),
+                    gmp_init('0x4ea10288fb5b1961f02589b1742a380923622bec2457ddb5b9223b071abdce4bbc07888065671cefe7ce278c1cf63b30', 16),
+                    gmp_init('0x62359ce2b0b102b55d67b87664bd2b54f9d0924bc46e75f35e85aa45207813b0490e2a0dba035b7f3861b09486f18a3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x89227545b1e665f5c2e87637d37837815331caa4cf4a337e38882d7b9188031f540e3a4bfa7d8432d63dc56a4c7a9a86', 16),
+                    gmp_init('0xd748e88ab35f20cd250fc446ed617b0876b1c545f3f9a4e744e16621e4ea6d301bc2c132d0154dd5bf6d3dfc9a2f1fb3', 16),
+                    gmp_init('0xd0c828d5d40b384e2f6ebe70893c05eb85e4fbc63d7d53f1d623e8e01b57d20cd69e946ab43ed1eb6a896d2078798e7d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc7459cb989aaf3a0dabc8e7332c25a9bb37c4d38ddc9b2518196fa772cf15a9f7e6c7b0229072267d200d14210098f99', 16),
+                    gmp_init('0x78262fc8096450a3ae78d22ad479bd3c2b584a65ae91fdd1bdfe6a43b614c69e00204190fb7e81ef9424b5c1defaafb2', 16),
+                    gmp_init('0xd706b7c261c917d542244686343e3fd1e3201caad644794d184fa28d1afb79dda235922bcf7e46daf4ac912ceba12ff3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa3186a7dae26e7ff788279ac79a7af266fb09edc3f4f4e5ee6ffa8c1899b862d802c401a8e687676813e0c67c1725f29', 16),
+                    gmp_init('0xb9f9fad53611e4486eff6a3c84565c92c8e1fdc9ae0d17e975bfd985ae538397f73d8147afde327f67dffae2fb67aa', 16),
+                    gmp_init('0xc9bb3d0e71e4db4dc084c33c1d721d6011a1d35895eaeb66b6972c0a45382f0c6e2df0ac05db432ab42f1dc0089dee7e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x74608b5effd119fc969efffa60c89ad9010d8d8a42053ec2c93cb18b82b0f36d27170631d2b3171eb12eea807ffaa2c0', 16),
+                    gmp_init('0xa52e83dc5fe182c17eb6bc85f006f10e606403f1ac7faea1153ed82c28f6d0590f31dfbe0ffa897e8abf3f9fc9c5e4b0', 16),
+                    gmp_init('0xd2465abbc16faf83bba08f502f8ecaf11838a92fbe9c476743066bcd2fb00edfd147b32db8726d5000ee404d195236aa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xac24e0ee48843b845996fbf3879c5a963d942174f2b7d1fa0fe38fc01a1df1a7eea8ccb966bd569b830fbcb2da2487ab', 16),
+                    gmp_init('0x8010c2d9be892f7bf2dc0d2db324ce1932a1442057f8ac7226d5704116525a82b8705e5427028100bfdda2bf063b0b21', 16),
+                    gmp_init('0xcfaad78cbac47642a3dee827208f3e28446f476d1a7e07d46f610e3fe64c5f4e05a0b56ebcbddd0c552f86b4fcfad9ac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5a012332c6a7c6ef58d1d38335607bf4fdd5c0740e9e1d1dc649df4f15e2a0a57beceb3ba6680c0748bc86c5367f3ef2', 16),
+                    gmp_init('0xeb77bd61d4f1fe0e621e4f8d6e81239e5694f7d15f9f0aaaaf5550ac009f998b91f8aa189a6a4af372c6ea885b40ec46', 16),
+                    gmp_init('0x72435e45b1f367d965ccc8983ae34bb69be000daac22d0064430d3ae1da7f01ebaa2767eadfcfb9e0a1d8bdd01b68eed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec7291ae12dbb37ef5969298bae169101a992306f326bc678801220da97b12964835eb2e7c45c28146f0a17b4c52ab80', 16),
+                    gmp_init('0xa0576f350eb2524dd23acb8a8ffd8b9ced95aadf7ca1681300d857568bfef535a6efb669138b6facd8f719686c643b4', 16),
+                    gmp_init('0xaddd65c639621d8247e9870bc9ecc5d5826c290699513a88a95583addc1e7dbaa052672402b838369c1f3f3017577aa2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x88cad664fe73cdfef1fc54bb5e3f9a472005701d867fe4a05a29fe34e2afd6099aa7c84e063edecb55a1bfa290748ff6', 16),
+                    gmp_init('0x59a045642f817009d7681505aa60e5790654b0c5f53fc18d1999e156708aa285d3fdfc612d944659ea27f0e54c59fcb', 16),
+                    gmp_init('0xf4fe35bfb0d38354b8d752999aaf7611d46276d91199bec13364a02eae9960d94302701b3b6aa58993989b301996137d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9a28332859f1353c791b3521faade2b7dc32f759e10d3ff682878138277e69da26070f11e7abbff27a6f0b8670e573be', 16),
+                    gmp_init('0xaffc0ea8af63a09e49147dbf7a89e533909a1a8df4669d9fb59994fbb2eeaad732502a927e199320f5511ff3b9eea393', 16),
+                    gmp_init('0xe0097ab35d0e56a1f88e39bc343564d0e769643068038fb7a567eed6f6807c9c1efb558924ed8575d544e76456982a19', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7fcce4d14683a81a72a4d35bc059a21548e2d3b845168b6f38c1e3e23935227bd2721cc78ee3946e979169cf0a9911d5', 16),
+                    gmp_init('0x4f91a284da7ddcf46163e526b21c77da9771a995e938a9eb933316e7d0ef58579b0004635489766bf0a5f624c9c6a144', 16),
+                    gmp_init('0xd98219b7286d9bcd210f71d0094b9b8e4e6074747aa58810b3be3c6446b39b4e1a7750ff4b1be6792cb196ba69d833c1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4f3b138ac71b5532f9a04fc081c31d8161aa655be30ee1e7703810e3f27ae5d386b636b3719f9c796986f86d2f645352', 16),
+                    gmp_init('0xdda69170d8de36d9db5874653d014f48b5fbc9cb93f97058131b3a7eca6934370fd0a46c62843f0e61e4fa12f6dae494', 16),
+                    gmp_init('0x592e3d80f2c7e41ec38fbd0dbca675e0f6b7c07378d4fff664dcbaad43f5a2fb0d684d3377bfefdff9bc5da10efacc35', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5e64bb401a035d3c6791fa41efb64a92af3c4daf850585f9fa9fcfb1ba18541ba06848a3c438533c9e68f1e11a1c2f83', 16),
+                    gmp_init('0x3e49578d46451f939050bbc0b256ad2a2f131bf7b8cae97a184e8392f5141f0206a0f06f66d7d37b2cc1019c8b0471e', 16),
+                    gmp_init('0xe28cedc41ae7d96d4e06ab98f097846d5cb242e27ba1122802e0f047b6cf8526920792c70de1288fa145f03cd51115b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d8406074af5676a5ac4174fa14de1f6ce05107ab803bd2577b083d444e36df6f30034dc1b3c0a1dfbb7b5b90b369d4', 16),
+                    gmp_init('0x348d2c2a658faf91c95c5f46b478d37e1cb4dde8299f8a07d0fcd3bdeb34c230e2a99198c38c338e7a944d0b8f60ace2', 16),
+                    gmp_init('0xfc183467f268227264a1e6bc91e6922c0659aa5fa525b6f4b1d4a47b4d7b066a34f03f1d546184f3d2585c005774d12a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb3ad04f6580957ebd34a838a3a876d361f51a006996a418c05d07707faa740f1ae433425364c6bd4812824172a4bb85e', 16),
+                    gmp_init('0x94cf3855bd2d7b6eb47069ca6666adcc7965f3ed231eabb1d2b22e70ed61fce683d71df78732b0a0a84c51b1c58045b8', 16),
+                    gmp_init('0x2eba5a66b154e8dd5cb5c7050e568d27929fee882fe54e6e56cbc34ff8bf42d8ea89ec6c91e33956d0e83736ac46728c', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc5f6c66917afc3b9131acd52004967ad1beb5802ffedb7740593d3893ec91dc43e4c68548b3dea07b23c0d00412d049f', 16),
+                    gmp_init('0x9558196c65affbe07373aabb53e1a9d0a0c8ee3a227e29c20e18b71d1b94802bd5e795ab62308eb3b90e54de3bef389d', 16),
+                    gmp_init('0x2cc08ece631d58367b718efde2b25523db655ab2d18b5352c3a2434b03a53b08074183424235f88aa6f55a896acba976', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x17d466b2a1ed0a5d55c52ec47682f6e5f3dffe11d3926bc7515d348b9dd9db6b184b32ee438f98b9d5308648c020a4a6', 16),
+                    gmp_init('0x85837c9828618c32bc085132a50f1cb76e25cbe2b41e13602e547cc694f7c111a5ea69a7c995367f83f4193ba029146c', 16),
+                    gmp_init('0xff971ea67ff5a69d6d237157d07633e1df2044fb0240ba735dec28a1ddd7ea386a4747e862176cb46142ecff2f8eecc7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x85f62e270222086c4d95319ce451979d82846de4cfe150caf3e4bcd5f6544dd1a58528b45f8d8fb0e87edb1e01352a13', 16),
+                    gmp_init('0x4800d57463d691dac4ca10355283dec4428c6e99602581ecfd0e899dd32a56b0101a9b668fbdaba1186d72bcaaf5ee12', 16),
+                    gmp_init('0xc300db78f5f233129a959bc186897156770bb86f450b6cc7a3f6b920208a12e3edee09a4b736d9ee0caf1facbcf61ea8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa7f0a94b35849afa644ffc36cfa57abfdc5c04ba8727205ce7411db12101c6e7d3cf7f47b6d2e3e9c0e8f2769baa598a', 16),
+                    gmp_init('0x385b504154e4a8e984ae7a4be86392973bb144a16ccd589fc4f97134b3dc5f9ee7f5a25ea9fec1f197880f3e2e38cd03', 16),
+                    gmp_init('0x2fd41b252c8319b2d83a8290fb6160f544b08e4db9f6ab0a4a1b6b4a92b24a4ab9eb8ea348d7fed82619be4874628b5b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55b9b47b3db6329311db2ccd5141e8681dcdb45019ac76ca28e1c4a7096266f9a17178c5ceffbd3054841f8b6e051383', 16),
+                    gmp_init('0xff674c707f2ca378224beca13feefe1e93d004409617af7c55666cbaa959b63ac46be56d4e0fb8dee71780c7ba624c2a', 16),
+                    gmp_init('0x14e178d898a92761d711e2ba3d1de21e78bcdc03f0d9c7157a297446607176bbbb9921639f122391bfa201d64f3a8c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8e8d129bac63ea1b6f5405a281bd626c37b8e8d44f7158338b55791274ac94240fb386d6cb28867d9c2cb7f1e4385e0f', 16),
+                    gmp_init('0x807bb0f8266d8b29ae8fdb6b112ac7b18129d34c35e8ebd6821cdf95a46c34d31217617918581ba18fa24f3886c842be', 16),
+                    gmp_init('0xffa4cdfe76c1fc667f2600e7b15f94884af1cae7fb7c8538bede7afffc131119cf32003e026a15218dc1466f79396cc3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x84959bf3af7baba778f38b4956d73bd951c52ada8a0ddaa4a05ac5a3a9895a9c1752d0c5a58df80def3723d2c5fce70', 16),
+                    gmp_init('0xe2358e37e0e17ff2787fdf1f4bd7ac2cccb742168b688bf69bc865949238cad471a7459fec061a7fa2aacf604fb248a0', 16),
+                    gmp_init('0x652e38bb99e6009cad419a5fda48161a1a0d4ef1d3dccf9b9c645e32cde3bf5224cb7573d5486308772b715126a4683', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf337783a9fe04bc546836b99ee2d449754de9d4fd6e5e2ecfa4dd9ae6686b2c3d557a1393f25267d9e2540f4c6402484', 16),
+                    gmp_init('0x1a44a0e7883e94f47db85dff857fd088d49af968fd207ab493cdf594cb79dab27164744e30f7c10e6c9c0f9621b48045', 16),
+                    gmp_init('0x7094fb4dcd289fb97e2bb6bf9711665ee70498cbf7eee308dc21b0fd41a0075cefef0e548d6dd41ed5a87374923d6711', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe1e3fcc32d124ea34d19b9cd04569a7aa2e859059623b77e8524d4eeb1815d2302f060e93d7e7e87e41f9abae81116fe', 16),
+                    gmp_init('0x438e1a393727386089cd977cd1bec0edd95754355a67026175b572e58fd0bfe2616a3cb18b6db86026f1c1614bac8e9f', 16),
+                    gmp_init('0xacb25961ced592ffb19dce1016c7deabb24918c69cc2ca5eab474280da6181839222dbf6efef918f5685002e40a44f57', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc163b2cac6de2c1e280dcbe0807f8187719e76e6ee0d50b11e4390220b0dc5dcb13f1d50e50bb35996813411ebbaeea9', 16),
+                    gmp_init('0xdaaf15f19de97fa4b8e4932d93b9d38c35d6880f92c6ec00a52930b003634b88564f20141b1ef2aeefca9442d6449253', 16),
+                    gmp_init('0x119443d2459d0025017b638a7299fd0bc780dae3c5cf3ab42bb3270c58239aeaec1973d8d4f0245d134604a071dbbcc9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6dddddcbd479c303199c10c4e4563c61c5b08252c04027c57c440cccdeb18f8060010ab3460657be92f6d0f954c98a1', 16),
+                    gmp_init('0xf27d5bc9d69633951a949a460058f72527ab2d348172e15881ac44fb4a5ef7de8387acab8fe52e7a214a2f54da896516', 16),
+                    gmp_init('0xb563f8e9bc6c0b1c6557db7cdb191b5d84039a581598b7ef6eb85f5b41371802b1a5890d67c4677804880e482a53ee3d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x44d68763f3030377558b015f9e4380930bcc9602833de0ddf45e6141cbf035da215aeef2ad9f3ef7e5118693249e0356', 16),
+                    gmp_init('0x954296c784085eeff60d20fc80332f025902754d438a6b068fd84ef6eeff994120178e0a060101e1e5bf9525bd31f6b1', 16),
+                    gmp_init('0x9078e9b1a96033ff4b67bc75c769a803b1358fdaba1e491c95c4ad3639c5edbf38f134ca81193be34f7f7ceace7102d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa165bd7d98db12195f89310d5b42ea3786bf733f7c892c9322f19910a02f6648f8129551ce4e8ad4dd85b074ec35bd3', 16),
+                    gmp_init('0x4e4edd75b0eaa4e03eeebeff3e6cd248f7abd1a732cadfd5add32d88d8f0655380061f6a8a155c2429d6222ededc4ad', 16),
+                    gmp_init('0xff3e2d0c5a4cbbf4cf14099c9112f38a7d15918f45d2184996772a70a110697f1a8858db3262245c8f9b78755f55ae82', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x637c020a049f14687a906bea202a28de44d2169a11aee4df6be30130f039db72053602d3e1d9f8a870faf4816c6463ac', 16),
+                    gmp_init('0x5f83065e5ce45d81cdbb0d86657de1d0f81f1d71c8eaf0ed084d17459a1567dfe38a0160db49e1f62363b7daa6b4411a', 16),
+                    gmp_init('0x1a0210e25cad2d6de64052a415febdb82edc25d56131890ae171c8a28f863f2bcee58603bebe928bc31f651872a2cb53', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7085b12722faf549a76f019825c947e57916f7094e2c7f4cb3ab9b46ee7d0123368b4b78777f55a83a0fe65b9deeb23d', 16),
+                    gmp_init('0xc074b037646aa5c9990c2b613fb01c0561cfed16e3f0b9df51286cd7570dc6dff66a6d44b9b6ce6e0e9f17417fb120af', 16),
+                    gmp_init('0x8cb66e5b3cb6638cbe3ae438cdc2a813b17cfe22b64f83b742969bdfc926f4365444f4b53f6839a3b67243ed8174fe16', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x76eb6f54358364eb3f8b0459da51ea40eb16ffd2f048be5991f4e61ef926337129ca85ccb58b66472fea47e9b7ccc9f8', 16),
+                    gmp_init('0x2b8e9e67b5c8236a82a228a76a35aa4bcb36c72c93d9a2e473a00fbe4b2dbd4dafa119e8b6528166c1628be8ff9c2410', 16),
+                    gmp_init('0xaac995cab7a61e87c320a7c423d566b9d7c94a9148bd2aa21009e3ce6f5e19de2dad78f00c383af503266cd444f482a3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe638e0118592656a1181b0301af7379d460cfb0c18da9db05344c5b2071937d9c604b4d73a775d82ccb5319c09ef2853', 16),
+                    gmp_init('0xf96bf601bda12b08f9549878124e37ba4e9d89ca1e1c1d47de043fd85cb12edc8998b763cd42f47f349405cec17665d1', 16),
+                    gmp_init('0xd53772c7fbd0ea06728aabea3f573bd65399b85b070c2cc492eabb12ac1a0e40ad8080f72f6bbdfef1dc90ad61435f74', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x692ab4e4c023df31f00e6908fe617efeeaa17c12fa44d01a3b16db24d6da606eba5af7d4b92f090afeb1edc10d18e484', 16),
+                    gmp_init('0x4890b1939928b98c4922d2121a3740b0b8f2d045326dc5a117aefc28cf05f3b1dc734a1f838ee0c1edbcff8c7d73af2a', 16),
+                    gmp_init('0x19faf28da30fb75b8b25472bda11e5c80d10370df30c780d3a3050260f19047d08d259cdf1b21504b2eb27dc8fa583fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x20a2a0abae43b9572713d12e4f6e1618cdac37af0f5cd4f9d05fbb08532024d24e4aacdc0cbc9784fcb734686a79889b', 16),
+                    gmp_init('0x9e6786b71d8b9638b7abc1746267ff748c20191578509c2e3d57799d3a8a33aa1ae4b8cc043f256d9e3d70f803d6f983', 16),
+                    gmp_init('0x659b7b03181b4ea10a85d051e1f4918e4b91996bc1eaa0cb86d48cfcf3424380d443df4fc7f6c69141e1d5de111c5adc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x29c3955d9c74e990f741fed9673a1dcc425dc573595d58e997cbe4c197e038bcff6eda3ca6a07c1933ac67529cc3ac36', 16),
+                    gmp_init('0x3d4782155e809d21f6143a58930af4793ac8aeadc2a1232723979f42301b2b6475ee0f4161a2fc0527e8dd3ab7affe29', 16),
+                    gmp_init('0x43919db0aa30a7db46b6c06904bf15cb758160c7b539f4bd8752e99fb233d41760be5953cbde6d4168fbbd86e3c4a2da', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb998843a366f883b3a8459a00145a2ca0fca1bd08a63f6f5a30b000b27175d36ccf7e8c0ac8d7133f0f311c84916a4d8', 16),
+                    gmp_init('0xd80b7b7385763625a61e104b3648d04fd7e8c6b422f6acb1230c4885725230b3752d8179cc7680ce87051948936a2274', 16),
+                    gmp_init('0x2b2d642ce068c919b711d413ca0504541469fef92e258209b3545e50024966cea3cd23448ed09819ae29491d38269650', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9a1f479161267ca9131e1213e5257ab4b41ba253ff287f07f1e9dfa154d0126890d148fd78f0746490fa55f3c633dd81', 16),
+                    gmp_init('0xc0595c9c57699e2bb6b76dcfd8040e6c3d04afe14ff3a9efb9b3c7394ec5bb4ea58ecad975d8e6f9f4b019b59a305150', 16),
+                    gmp_init('0x5b1ce9f4e7135f4a803134f1abc58a6f42ac9d01698ac2a1e128607a8180bb3ca3f722e2f5fb3cdd41dd90cfcd5c514a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeb6da7bac35d79a9f5b2643bf281199ce0888a135def79b52bc17a3b442ebdd843a65518bc9ccee771ded5fd6df052d7', 16),
+                    gmp_init('0x72ec351a70d1ad2e01b0db6aa13ad0dc3ac6b5afffbf6cac74918aea9f967c51f2031c99cc514498a9916c7b587f707a', 16),
+                    gmp_init('0x8a1e77276bb6778655549ccce53c28d938b81474443b1084eb26d39f7b2e29a67a6d42f2a3c2a6efe49de22e67ea4e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x87a0960facce3330e3306670fd8c3831a9c2b0ac53e31ef130514932780a9af5329562888dade86ae8b8183ef2149372', 16),
+                    gmp_init('0x55f21b7eec694556fe6b00fd8667de3762c94d120d147978ed1183a0352daceae8be74ef1a31e4934d07c89fc3781c', 16),
+                    gmp_init('0x9c4362734b4675bd10e44520fc6699c7dbc9a37a32e6abbb082c828b4b418171be99b435427fe49d52608ef67303c1f9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf32650e2230608a4461461ef5a97d3baeaadfa2b168243c52c8c607802980bd0f2f43bd11ca0200ffc53a6f6bfe3ca53', 16),
+                    gmp_init('0x7d54e8cc98b54726d9a8cc2546730cbb7009e9d12006df2e5afd424a84e523b49bed384fcf85a47d42f48e2eedb2dd47', 16),
+                    gmp_init('0xcd9b0dbd796f18bd976b3e433394eead953d00088dff9c10799954f10cb57e4c62227f0c9a7f87844c4fb171a2b5315d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc830cb95a69a3f5cf37ea163bf5be40dcfb53c11443f31af60de7d429d8fe9ee1fc768cdfe2fa60e4520215b9d7f2365', 16),
+                    gmp_init('0xad5319cb425cc84552c510224404a1a54b7277f98c67a826f87b6181f284c35fa4de98799d56cf715df8e69c2e11cfe5', 16),
+                    gmp_init('0x1fe03a6c214559b75539916b9b31098db27ff7428d02fdfd27403bc5107fdb9f2a7bbb700a8e68b441a9dda0df84171b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1d358020289e59fc3c168ee37986ad010a26d2ab9a48d3a96d339df76e98fcf60ab848083f9b0dac78064826c8611eb9', 16),
+                    gmp_init('0xecc34d51e148f3fbd6ed882724deba21e11166db3f965b7df4271f55989ca79a59698fe260ac0b478740c7741e8237f4', 16),
+                    gmp_init('0xb0e957abe4cba12538c96b87f08b1bc6cebaa567c3e86cf8e015d20bb55df63b1223b4865033fcf9afd19a730d3dbd57', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x894becb25c7dbdbae1b611139b4d9f66c94fb722677847cad8619146d8d377e6380d2735a27d083139c459f1ddc99f8f', 16),
+                    gmp_init('0x263398f7f3692ad0bce28cbfaf22f02ccf51da9dbcc0d93bde04e8b627fc60e7fdc0057666ee8e0faaa90aa604531971', 16),
+                    gmp_init('0x90d844f88b29dd35d68cfc8a95604d972a8693c1b34d94b392cdce5ae97c4301669ba282de752347981c0418b2dcd243', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6af11de37b427292f97cf7e42522f30e511054291aa1556c5ee7f61ea2afd86412327de5d1deb7cf404dc069a616e8a', 16),
+                    gmp_init('0x292841e4da10809f38202bdbfdd29c90e6dc76d0540a9a1215633b63e7540754637eefd32841e4f7fac8fa2636db51c8', 16),
+                    gmp_init('0xb38c4c5b5aa2ef720dcc5c0af57932a5fb5e5cbc97fc16c265e895df46f032ba4c5bf5fec181167fa5e9978c01f847fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x68793b83b4737c4c1083d1d21d5e9790e2b7dca126cf6f77357f20d7a7e67ab116307d11c838842851ee98233ed8a073', 16),
+                    gmp_init('0x246bdbf595140d7b3e048e19e0009b0c79b8143d79e149370a621b3ea92d8e07505fb1e26324ec41fa207c201323eda', 16),
+                    gmp_init('0x1f4b9f9f832f0c61129f1280297a105258e45bc7f12170502f7e6dc6041271ab592ea976658f69fed57f99c9da3e9cad', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x833aed7a18566a4588194f5b9dba383c4dde781a127b8abddc6ab17caa0392331d6732c2b85eecafbb9db1a866f2a1de', 16),
+                    gmp_init('0xda592d8ba0c7e99d192989502bc10960886c4460a728ffbe3df9167e65aaf57c75932a76fd641fa7b47650794cc90ec5', 16),
+                    gmp_init('0xfc4a02c36020273f642fa41aac80892d4342d679af095efba1c2ebeab7a24cf4a3dbe552333daebb8b30f34054f84242', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1db22ef84ded339237178a8199500cbfcbcaf85deed09f461b99598a51208a148b7ed460251facfa1c7b5ef031e003ca', 16),
+                    gmp_init('0xef20d35be2bd2699cd3325de04bf5a62e151388a65d9405907f5ad98b9e21604ae24dca6fa52aa7ff9e4b7fb930ed0a1', 16),
+                    gmp_init('0x3a90ae63ac79432624faf6a048daa7ae1093c0261214c7fad1af3023fce173fa71b4bad1b61b7a9e7463ccba6464771e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc6b719346bfe6066da827ba45e2688bb2f020c78bc5621000226e2c50e167706d60dfe7640306d16d8563b5ffe4e0fcf', 16),
+                    gmp_init('0x886bfc391b80bb0a42c26fdee319cbcbd72527ee23f0c8b2bdfd0f5befb355c9545d111a9cb42dfe2c19ca5984aa9690', 16),
+                    gmp_init('0x4158a476e513692dee53b11fe429b6954f0d220eb4a04c298fb689348edbd4c5fc7ffbc36fa0a66ad4441d6e3a51ec5b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x507eb77ddd7384adbe80123c177c8ee49e5759a8f00ff5e9bd61e6048871eae070d42afe49837494ed16f67a2a0521ff', 16),
+                    gmp_init('0xaf69337608d3d62df53c8f1330e9112afd89142c86cec16a103f77d609edf622305e71f80d8ee308624142a411777116', 16),
+                    gmp_init('0xae7c755bbeb77cb866ad2a6da3b1745349f3684b98bb9d860ef7d617991c170dd021256197e5a47e71ee9a50f8b9232f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e470b49b3f4987771890e922032c7f8cfa111812ab20276e262d8fb96fb3194455b44cb08091899104a7920ea2089a2', 16),
+                    gmp_init('0xf506eb58f2ccd69cab419fb6274d1098acac28441d7aaa6395057a001fedd5382c2070014a13db13d73882bb2c554d38', 16),
+                    gmp_init('0x4734d7e82ff0135a885cdc64450e837170010c30a1280f4ffde8e2cf3028435cd953df7e0abb602e816a7965f5f42c95', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3be190b15e94e2cbac5f9948647cd5827481bfcb3215018020af2d83f806e372ddcc8765bf7d06371645ace2208a7836', 16),
+                    gmp_init('0xb89ec9785a275d6c4393dffb5624c98706c2528cd490963a36537195e970a01240aea106830effd7d8e2434157b967a9', 16),
+                    gmp_init('0xdbbf420399eade638ef9dddfe0edb4dc64f4639996468b926694f813e8bfeb806d57e8ceb57aabb19fe3b8ab494b0b53', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbed4176ecc6c9fd8b3898c25fc6a5c3b3d70aa467bf1cb4ee56c6513a566dcd0a9c7e24a6a93960c1428e0d13bb7fefc', 16),
+                    gmp_init('0xaa901a7799b0e1cf0745baec21ac91daee1783edd0725ba774dc4f20a0299b0cd7bf146a2e75b5c732dd9da40230a7dd', 16),
+                    gmp_init('0x7fbb59ddfa10aaa0ed4f618dafb10f08d75b23091fee24b6bc9c80ac1e136a3f435afdd85c6108024037c6a6ac3b1cca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7313e62b779498155762e6197a41a7329ce8e5f725bdfaaf49986beb9d44556c073bdd9132809822e6712ccd78185ed2', 16),
+                    gmp_init('0x3f740e1d89b347cc7138893c3addff6efa915238989bee45b1deae47b35c3045d53736ad3ec261fd47296f5547eb32ee', 16),
+                    gmp_init('0x2e60147dc338ef018b0d8cd12bf5a2bf43d4168db96c6b42d3cd2d267f5b1119d802ab1fbe02a729a6d376574819bf4d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x64b06f67b0081a374d097a2e88bc897c359a065192459ad51438c8b4d0fbfe9c80d48aa0f8ecc7dddb730ef09f99f2cc', 16),
+                    gmp_init('0x67ef9b4208bc8ff1ad25998098559ff11e229a37d416f9154a9d2cc1b5d2d1f73a1f4ae7e035f98f126858cb03ef5f6d', 16),
+                    gmp_init('0xaf12b53eb4572f416e256c10daf80a61ae5893a1cde8533890acab5f16e7ae68756617b321ea7f8cfa912cf612462cfa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf6865461d1f61c66b0a661a2cf39eb510a195759f50b17a98c86495325049d9ea2919bde0149cb521390b96c2652a5c5', 16),
+                    gmp_init('0xa2ed2808880b31d9f3e677554aab01303c1513671154238452bdba832e8e57bf8823ef04c054c39d83f5d9c23ff7c894', 16),
+                    gmp_init('0x3cffe3239bb5b64f110875b75ad011f6ce0be998335d1149cb70494810e10956657d6fa75dad272be11a1cbfe3069dfc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8cb72f8a265f277db43fbb777eed551f4b5fe964ba2ef4bd07f4e40269641824fff5ff2d6e4f61e316d91972a3c4ef11', 16),
+                    gmp_init('0x35c2deaa2245f2cbd6ae782809ad1d4355575658947dd9fd10e6fd2acc6dc98ebbe6d990c881724a64695430e002becc', 16),
+                    gmp_init('0x39c34abcf313bd361b34fd79e7a8c1ccc25aaeb9f8a981c9ccf24337c586a997529f61d1e8bd7ad2a9f38b668306974a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3ae48c5efc54b19bf9181d085b0c697bae4fa9787f6032eb4b3abc9dfa2a47ede5f169b147210f4332335f0954bd8b2', 16),
+                    gmp_init('0x90254c720281e8e72e368ca3ac365e3b5f473a6fb1f6f399c43036de3327a4ae2fd20c022dc030168c041bf0f4084210', 16),
+                    gmp_init('0x9e40b585420528afc1520c4fc9ac328c564e7f7523b33151c14492d4c4e9e79d4d15b6d1e19ee8734885e827755ca5fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x95fb7a40b21e768eb254ad8a1d96e402b790d0bf3a82df6422f7402c4da4f9ea6ac3115756404c993080b03b63b3c0e2', 16),
+                    gmp_init('0x72102b36ec43bfbb2eeb1bf0095d08929dc54396fc6d974076a8daf96ad48868031afc71488b2ba1b4581e6281a6cd3e', 16),
+                    gmp_init('0xc947059d06f20443dcfecaa95f120fb553ff4df686aa18323aaa39e0b994a105a94233c95084d1dece1ebc632bd81243', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x30809f92612ef9c38c66841375c34194372344d0020e2611679c25c1d7f0f7d84514438b0e24bb45553e9799187b62f3', 16),
+                    gmp_init('0x46441fdffbc6d4a99e00c32868cda2004cedadcc08d47c83633265909f619d92e1596fc26bfef3c13313f8f26f3bdb5f', 16),
+                    gmp_init('0x38740829bbe30eedc41d17fb89559aa3812fd18a8ebc1c9c35e2911c5b1aa9e644260d2d12350377d252a9f4657b0f07', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e47cf3e046dea46362a4b0b9958f15d9f8d6f049d3e60d4388183628d1be02732bc765cac2e8fcdf82467855cfcb2ca', 16),
+                    gmp_init('0x5873ccae10d4f6ab8e169ebcd89da3346ca0c65928136dd8371ada16d2ea309c7387ac0d24608d9f9e7053dc0fed9b34', 16),
+                    gmp_init('0xdd90c8b5776732b1f82d51ec2fffe90ff74cdef330a460d35e3176aef3016a31853dd15919913798b5be7a1b2b98bf01', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x33bc89f3a32e991290e30f0c1b949a9dfe9b1eeb7214a59b75b23575b8c3f8dc862553667789e33196fc529a8399beee', 16),
+                    gmp_init('0x2171c23a1421f7af87a85b1f1a17f0a941bddbafc3fc9190388ec6a28933de2ff64ba511db0e389056f5b21549be7096', 16),
+                    gmp_init('0xbdfb9c6d3a49ce46849a2c827a954d0375c5bde4cad6a31d1dd7fd83d1ddb7855da78ed05b61dcb09891e5c1b5149444', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c2f8ab929902870a206d23cb033ea6110d701ab2667a1fff844ea8e32836cf1cf82ecdc3acf1e93104511ff5dda2750', 16),
+                    gmp_init('0x59de2049394f13af1d43b417c314cb2c0b5b7f7818073c2adbbd7e9e9147dfc7e64356533b75d12322da496fd225b07a', 16),
+                    gmp_init('0x42247a9b4fbbb3880cc2be5bf3f24f058f7631255fe733315c1e1253af4981cc5bd87bf9bc8952e96d89d28e5b779cc4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7069f825d6bbe1843c4807b1b4f7aa3e842ca9cb1b7d3b5a498084d79d4d5c1fa9ddceed855bec1ebf340be88fdefde3', 16),
+                    gmp_init('0xadc938626c3635ea5e38cec26922ea16929a78821e733b7931921564d67af50b0a7bb8595f0bd5cc01e348e3e7d925a5', 16),
+                    gmp_init('0x195f47d45c28a0f977a2ef90983b93d3c6d3937912e9b176f2e736707df84e573c7d24bdfe43091f6e73bc77a277509c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1338a5eb40e15b1a909cedf17bbab250f06f59fb1d528d4d5ae48330f1e07d8861086294059b8bb604a49b765296ce09', 16),
+                    gmp_init('0xfa0a185e54d561782dcf23057ecb5e1dd54bfe239bd30ab84b21961df1df69f668724e741be9befd1f6629a98501ae12', 16),
+                    gmp_init('0x593022a7bd85c58275df42faf3061f2513d2078c93d7dfc16e56086789f046c76626191843ae4cc195e7cd717635703', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9073ae8a6b17b4792fb45224b43f2b8863d811cd1973b53986b5e051f06f155010c6c9259cfcb4f31eb5d4c232027129', 16),
+                    gmp_init('0xefb76e228a913543d3889128240283248aafaa3debcce021535f5d54a1b097d1e3c5ad318be428896bce86f71486f135', 16),
+                    gmp_init('0x7b0244b9624a6bea2a57dae2ff83f555b50a6f189011d9a017bb9002891084fb6335fe55977b246104d2b2092fbb77d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x51065b7c0195248d9183e53b8d751dae1b7740d874dfc211323cc193abc10edf33bb4a80b996b8a290280a54b1ba7c44', 16),
+                    gmp_init('0x979d0f05c6fe2da111335cb3b555f2f316a69687b7ebc549767b18c80e51dfc8dc5ed5402aab003ed82c989a055ead96', 16),
+                    gmp_init('0x3f0c1b26f1ef09e8136f4dd636023e9a64f2455c79bc68ad42a701a86a203326ae3bb288d173f9dc8afb357efeb169fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6387bf63e0c7ed73b5f53ef46b6d25335008b0df78c019a08976e8093578c5dcef53212e02090b1a4a0a33f8178a5588', 16),
+                    gmp_init('0xa809f40315cb09ac53931237d61eb98a6fb755e2879567f58f71b5645d58732dd20dd88a558dd7de3c4101ae3cde64dc', 16),
+                    gmp_init('0xfb0198f4129c8416f3ecf9c0775eeeaa72861aa5ef19d2eab1759e91a2bd16229f7c2ee451dd71a3e0f31b25a286c7d7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5dfc623ce8facd8f5f764e042d3115c70b26bb75591940be16a772e3aa6b4e4600167b18cf84c65e7bbb8d133b18b77', 16),
+                    gmp_init('0xfdbad689287a848f66f4157f1a6e20d525dc1b52da4d82a5e06152fa3fbeec70e303af31ce5e6944d679fe46e78c495', 16),
+                    gmp_init('0x2a5e0226a238f4b40e58aad348f764efd4e06cee6ca4a16be75cb98f410d7f703444f54358da6b2ea3b86b48468c7031', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x600759de6e9b18bd0c1c44e78244038a8daf392faaee72d02cf51361240c8e32bf388990a43c06fb21d25d182487d0e5', 16),
+                    gmp_init('0xb428be31e3792596737b7c94aecfc5a4fe751ebeae324d1ca3a00bd380f30eba65b3922ddece6ec5cc2ab0a79b731e26', 16),
+                    gmp_init('0xafa2a0f541c290b98bda4397809e05bc7b447a9f25814ed50fbec7d241bcc8a8710167f54206e9240536ed421dfd6088', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc609c33de580617042892891f8b88c905b4c0a101101dc3f8ac30afcafef20e3c2aaf6bd60ccdfd3bc0523c2b6783124', 16),
+                    gmp_init('0x4778174a96ad98009da9f25c453a5b64051f20084c9724b627af1103af422faaf4b802dd60781a6e1854b64158bc4f6f', 16),
+                    gmp_init('0x3329a96793bcd8dbf7fe526e9054ce1b43a39476c8d8b9f51222efd6b5fa5ee25ac3b17d7aa0aeb3d83477201a17a94f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa85011250f4ba0e0bb2bfc885e37b0bcd272bab31ba873b7c58059c680342d03868ba1571c18a87e3656d4c7cecbac74', 16),
+                    gmp_init('0xf37fee2c57a62e398de42e7f1680bfcfd852ec0d32615f9db2afbb15614447019e1bea0816333124af579e049737a844', 16),
+                    gmp_init('0xb9354b96ae9888f118f7d8704272586745600baddb1a36522117293199c6ebd4ebda323ec4ced55f6080c17c843f3844', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x53c4c5b64acddbb2611f91dc5fc3ded80ed0a54820ec4a5137a4aeaa5979d807d3b5968f789bfe9c60715afdd3dd5e0b', 16),
+                    gmp_init('0x546b0ff61e5709e726e1beb0e03d20143c1348f214f3d6718a6d46eadd1ea6fe471d8a94594c2543362c7122e57546ea', 16),
+                    gmp_init('0x79c8c3f5c9a0a745b7dac887d4009098f0c4f38e620399acc28916e644911eaf94b4ee4d90e9b9bbb31f91611ee98aa4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27c5a6a768aa554c55b03effefb0c99462f45c17aa51f9a58b11c20918cc6a2f274a6ef7a1792193108316cf2dc31033', 16),
+                    gmp_init('0x51ac5b64b6db19f76582885bae81af842dd63837016d6e52f9981b19577afa07325818924ebc7220facd45c00c8ae9b0', 16),
+                    gmp_init('0x26222e9641206b2b853b869bd06155b3ed4d2654aa0c6955e87133e5ae1718bc7939bf29de0e42b691f03fbd4e7d908e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b3e9249dbc148e227c3d84167b1c16b003c3c8ae0c99829a02cfbe44005f7c4358cf990ef36bbd2f882b2bcdb2b2837', 16),
+                    gmp_init('0xff87eb4cb651834b263a5cc1ee21f7cd016f53cfca39479f407279575ff8ee10e3bfac5e96835a20df5dc600d59f84f9', 16),
+                    gmp_init('0x3f62682bbffe6645e05ae920d5a1e7266c9794f08b54d2b5e75f7c074eec67c5ed06c2313c896d0df9fc2424e8c6b497', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf55823c4c936d727f6a8bbc219ccb097e4192f7f6e01a6d917600be9dc97587ff4b0b12f0c625d1aed8a09d0eecbdbc', 16),
+                    gmp_init('0x4fd3121c5379b151c8728241ed37bc39e4f840d44ef97b318ef67ebe5366ca617812ec453b7de113a76812de68671749', 16),
+                    gmp_init('0x22a505b3b67ee623c0a5baf2ccaf14d992e1b53bcc85eb61270e1f9a53ecc6fde8d0c9c4c63009c2ecbd2ab6bf15cb7d', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x830d6df29352a722b3b7d681064db3b068443ffa8cac8a71bdac7dd11049d89336bb45ac0f904b58ca087882dcbae928', 16),
+                    gmp_init('0x4dc4643f8d3f49e4c5db890bd492f501688423e50a2df99267f286beafac888b77f5b88ceba71ebc13a45b01062eea5b', 16),
+                    gmp_init('0x9ce051d14a9666fb015815c04c7441dd21ec1b962b2022aaebff0eb92d9773994b14311ceebabe48b6428d640859e54e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf9ce3d3febf60e94984ed42c67ed88e6295b9856c5aac2b85a37c2ebc740f42b2807084d65a8ff36f7c3c8d78e2c5531', 16),
+                    gmp_init('0x49511db43d7c706f5af65160e897cb7248dd557599c0b5abae542363163c0c5ee08505a7fc5931e08b277b4bc2b5e39b', 16),
+                    gmp_init('0x7dd7c18e7c66520a41987ef1a685e0ceb9c0c9c937ea0e5ce8c52195cf63e4f68af086318e9ad7034f2fb7ecb33b1562', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4ead6203f59040b48b0a8b0fa1a8f32ddf5f0634c2010e337e521e725a80ef7d65ff5dd7e65b40219edc718348a8d9ee', 16),
+                    gmp_init('0xf3a3e361559d5945bc079145dae86d46ac09a60e470a9ca820c3e13be0e8578b55f1645cca52a1a2c86ac7b6f7a8df46', 16),
+                    gmp_init('0x7715e77f2bf6f79bb5223d390b016604d1ce20f9af5ea35899be53117dedfb2631f3810aaf64bfa7ed6e05010b5b32c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9d6706f1f999c9de76e61734f429318b0ac9471486653e03f60c68a4c6a65f83c6e56cdb3d1c956e6cfc642e9a5a8333', 16),
+                    gmp_init('0x556901dbbc094a6b51a6399a3afcf8df6d3017d21c9a3b2fdb37017b60396df2ee2a8798d70df945bf771776fbb3da2c', 16),
+                    gmp_init('0x2c97b6dbaebcb3ad46943b4b664a677a1b1b7eccfc191a82334e40271b1c890a6d1c2a8eab1783bf924b66a1c28d151b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8eb063d19561c79f900af47a0553b4ddcb50454e7ea03c44133ea29dbcb349076fd7177b4a57653e88632ebb56f4eba2', 16),
+                    gmp_init('0x655bc52baf7bfa21228f76bb543e186d1f6026a85ad1ca055682fd9cb908037e9b4547bfa6763de980b0044ec212d39a', 16),
+                    gmp_init('0x8cea1f4a7b6710e0c5cbd964befd2bcbfb22bc9adb894d3b74b316eaa42e9673340573430fc2244bdc06788ace1b112e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae6667edc2f0c3a9ebf76fd88c3926f33e1593b543e08ddb2a728e5e71de1ca0eaa04860f76b9e851d7b494cdadb888c', 16),
+                    gmp_init('0x5b0c55e08720298da03046120f7b1c4d85cfd755861a5383778992d4911f52fa57683475644084437321638018d7879', 16),
+                    gmp_init('0xc0bad65d8fca59feddb7d800162f3637b8e075f3e946dfe6902abf700839784aa283c09dad2a0baff3861bccd5a34b7e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x46c3841e3c520330a1a2c7ad28238c6ca56e35f30f055c3fbd7ff277ca5e357e121f6c198639782faeeb5871a7c5c2a4', 16),
+                    gmp_init('0x4bacc72385c7cbc90ac9862488bcd2b2735be5382565e7184119de3864e852e92ba60532e128e11edbb25de172629400', 16),
+                    gmp_init('0xa8cb3cecd401feb2681febb5dc5a9db864a3c4687b12a83ae66def10b6e68d23ae7ef5f6b8c51bc5702c1d8f51ecc918', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd74be0b4722c8d70f9c9d970c00027eb39695491739ea0b415df7ded7da181701111dc18c53bea33d37eef2f8ddb72d8', 16),
+                    gmp_init('0x25aa986cffb5c520e5e6bd58d56ba109fdcf1e8d4468686d6ce0d702b5fb05ac10d8904940f5782b22aba0aa25df5ca3', 16),
+                    gmp_init('0xb9aae9d62eeec1fa8343ea8f9f09369f404b04e49845d6494adabc5a8fc7ecce385f151f06cd43788f9f778f51c8b978', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x70d1afadd11be26a82df9a44a642a1a21bc6c569047e88c054e37acc137173c07c9f53379964b19db0e6c08caf9b22a3', 16),
+                    gmp_init('0xcae9de6c1756cd47d0b2bee49717acb0c27fdd113d4a8f5d47802ebe1ac96236c275f5d6536167bfa773d25a08d7f859', 16),
+                    gmp_init('0x176af7c3384454767728b1f72a19568062c7414bdda3a7f64be5801e65e9c70dc4ab62f874f6c7e52f4dcda7cb87285d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe9cc92be322e005be06ecad6e57b12e3b1b2e4c7a0337f426ef22e950f6896e01ad99536ec130a5cf2ff16ea863d2c33', 16),
+                    gmp_init('0x7bbd96b19e54a7bfdb00e86288a9bc7a897e8f3892e9dde398055e81611245a9c57d22b379ef0a3dd078f28e65ed714e', 16),
+                    gmp_init('0xc293b8454f3ab89ca1d7fb168b1079542daf054595e13e1a05b10ad3952e9784b92781ab817a466e1427b8563bcfbce2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa07c6a869defd01c489d5454fadc78fabb1165bb52a46584e5dc56deb67a0d059a847bd1ca6d2a5d9328e1bd5b3445d9', 16),
+                    gmp_init('0x300799296ace654073f933bb08563b30bf3e021d507d3a22683f46c9f1a0321cc12a150ce64770fa661988c14cfb0434', 16),
+                    gmp_init('0xbfabcfc8f0aded2cf002405dd088ae48cb8746917b5a41f59b6c2c2c5e09f4c31a19d566889aa43886332ff1ce8a0638', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xef983866094f461d095f3ef735e2559fb5849971708061c6c975500ed4b8adf9c942a9298901fe2cd851f81d21ac6b', 16),
+                    gmp_init('0xb923c7010e18a18abf588711bc46ad67bbc41abe1a962c4acaae916f39f3482c283ba193636fefe4f026c2c188b48fe4', 16),
+                    gmp_init('0x367055713292660870c3ce44c354d1f0b30125c5765312a4f070df300428fed25061b933c50979aeae2948c4aad7c04c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb414d97afc8d46a7ad29853769b9a013377a4c4a6b070a71d59d6d505d3dffb0cecf79eacda85e7a1fc4f4c631b9bd0f', 16),
+                    gmp_init('0xd9017ff7b8ab8bfbd1fcaec621e14d3c5013b0305e01a1f5f900ba78975a61e16b00dcfcee8f675ca8d5c4b33b653977', 16),
+                    gmp_init('0xea9c7ee577944cf44f273cd9c4c76ec307a77ac257e4a9ee83647c45623a0a1e771261b6ff28ca443c4e6df511845ac8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x806473be30f6762a6560bc51e43dc4519cc615d166e72aff5289b917ba1be71ffb1ef525df4032a0c711240ba4f190d7', 16),
+                    gmp_init('0x253a661c0c486845c63216c6c350b112284f7d15d12268bd61ab4fc9d49534a180c6e3befbf036a3bdbf0726c080f81d', 16),
+                    gmp_init('0xf0942491d97c74da47f04942d32f74997023b31b349ebba72a57fcbe427086fb603e90632375f877857029239b4d66fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb02d1a77fb6887e9822a5899c466d2f733706f2633cf40627609e1ab2e9a18327ab86ab3d15963623f27de165dcc3777', 16),
+                    gmp_init('0x5f90aeeb0b91bcc7429550910411cfce6af15dec6419870e1bbbcb4fbe71fbc23c6dd4cab33025ca86eda5a140b7352d', 16),
+                    gmp_init('0xbf8956f3b31f374d63bcd7be0abdd12f5e78f7748460fd2c13e897989d21cbcbdc3a4136812cbecad825f329666bb271', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xf2d8cc208c66e6782e862c18158b4db49f7be12e2b3d19c67fb48ce5e37b566e4ff3a6f389c62e613fb32d413e1d326d', 16),
+                    gmp_init('0x60422c80a494fd56b43166375f29123c5d4c18c84a06559e06a56173ec72b13fcceccdc3843bd2b54dd89888ba41f4d0', 16),
+                    gmp_init('0xafdf113956421112907fc9eab6c75c9e3ffd2eae1fc554d44645aa20e2c2dbc204269773f8c5647d7000bb39f07e2be6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x66362ee6bfa37199fdb31aef75a416046530ac605fc45600b20ce4729b895dd3765442e60a728cbfd794f9940c0d7329', 16),
+                    gmp_init('0xc3099ba4b17ecc8023c7ce11e6d4e1ff2dbaf78ec8135081c90f10eedd5aec2af938bd1975eebb198e3c594befc58dee', 16),
+                    gmp_init('0xb9be8ccd1e039bc368aebbed988252a14e8cc7ff4f06462a5066ce604ba1ee1f6785e4fb68c1a45731795188529adce7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7bc63d133c394c8fe2248f9b50b7bd1189d0a47a48cca70bfefc5eff86060688d7bf92debe271dd809ac9e6ca20d2af5', 16),
+                    gmp_init('0x6d2508bf0ba1e9040de0bcf119fbcf098243f746bc71b867c61b831f42e938d8bffc65b5d1c457a25b000dbfaef86ac0', 16),
+                    gmp_init('0xeb852a22b20ab76a4b825fc24baeab6aa5e17d63fb019c09a10c28815817123dbfe81756fb9162ac71460e9cbaea9073', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x898a9d31ce7367d6b311e1432a53cae98c28538f1c0346e5184e27c329910135032a10615bf6e833b32bb23dcdc5110b', 16),
+                    gmp_init('0xfbd23f7917d0f0373cc2ab670e96535aeb930c75b5eb573a3162de70e66da7da07d918be90e433afe073a6049b09a2fc', 16),
+                    gmp_init('0x42e5be5c2d950379145c0abdd7fa58a36e26fca5d3d218d45a3c4ab5e42a601662f22ac3e0337aee1123367485a99f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x853e2e5d441694d697aecdd08f997591e9d6e2764bc2c5f9c900094fb40d13038949a5e4dc26008987aca6a0479d7a78', 16),
+                    gmp_init('0x5fc7e827875c1acf1ad6bd60935fc7b092e3eab3b86a5e134c275dec7412ac4e6421b6ddc8ec1831aa8f106b642ccac1', 16),
+                    gmp_init('0x33d029ba4ed010af71d81cb19591616ccef8e2719804fbc5ac5b26a3546299ff37b65ac3f1578287a39eaa04e06fa68f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc28fe8383ae644f2cc54079bb9b20f51df30efe94169a5a998a11a686386ce3adb6c96b3e9f8e0eb80dc24d334da32', 16),
+                    gmp_init('0xb98e2f49200f48bc9387c55ea651a157e448747f656d0d9c635bb3cdca4c63ce0fb049f629906c608d923a5cb8acf68c', 16),
+                    gmp_init('0x847bad704908576dc354190885a8ea782a3deabaf8ba257b468eeffc569258e13335e237dcddc0773abd199ae702ef3b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x604a7dd1e834359c20ad37674bbb7d18b4fcde86c3d5e8255293ad85d692935ce371c6c625b7ae51a3deb43e814f197a', 16),
+                    gmp_init('0xa88ac0b82bc742b8cb39b3f4aea3dbd16e01a2c6a42d949a60be25b6493405c6c1e53d8cb84d439d61c8d61e2b908841', 16),
+                    gmp_init('0xb015aed12ff3ad8060b70045913383f56a0d4e576820a45d7587525835f1400b6cec8c31e63b5c85d0ff9ccec50f556d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa67570ce9a0fee3c0f612d074dc7f3967e157edb8c62bd9f984313263259666ecf7479950f94a425feb1a17c584fbd19', 16),
+                    gmp_init('0x57e425c1ba88e7e277aecc2117755e346777647409906eb919e9cb0bb1530fe8f67c43e3ddf90230473f0fd5121653f3', 16),
+                    gmp_init('0x9e73bdc457000d1bd553f47c2f9f76592ede4937d53ad3373df1f657a14ea719979e9fe094193681f9bb6e256f275025', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x36c36cfb3f1677ba36a52989932d14735bdfbf17df85bae0aa88ee17d2e1a7a11f4b1de1ca2a537db8af234d345671b4', 16),
+                    gmp_init('0x25a453af0affa0baa60d9fe6876360dc740e970cd3a94a96c337fc51a151adfd858b4ef059249318dd194dff2f4fa053', 16),
+                    gmp_init('0xc5d828fde5dc5f992bc984aa672b873577427ce640ce895a0a688992fe92313162ef8e32dfbcf3df5d7abc2f1d64f649', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa1da7bb80eefc27d0c87669a30603caa7c22b3a0761e13dcac7a8327644476c5b25985369fe98faf6a5ed45a7ee946b6', 16),
+                    gmp_init('0x10b673cbcad007e182ddde12f98f54a079e6f2edb6f068e4c53be82e92d729dcd480b3cdda2a4d153594d5a01fca1f93', 16),
+                    gmp_init('0x1e1d0c3adfd7c900858a21d7ea191c0ddede01d3bdadab9977c751e253bd783c7768f8fc409ba180d51de114d7e8a7a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x377f93a63d312d82e3956b10f7a47d03c1143657d9514a16b54c5c5691e42f769227a0df3d829920c19b96c7af92abdc', 16),
+                    gmp_init('0xe0dee81cfe03ce202972288d4c643e5f469e2eae6cf88bbc169b35420e24f2dbad47688db13819a8c5731ec7cb3b684b', 16),
+                    gmp_init('0xb2390cf0a0151106c5697f8e2908d8fa154a7c90ea1623c5821d90fb96d85e22c55838ce52fc97ce56ee5c9d6a2ae5e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6374958640fb7568da4cb9a91e9d7a7290fb676a248cc42c19e8e24be3500f872bf5ab83ea851cadd835041cc802ac67', 16),
+                    gmp_init('0x6c8af211a9e93fc9d2372567ab9af48311ff31e5aa2a58b7fc5d97a39f8496e0016dbeb5ecc7e31785eb657b315292c', 16),
+                    gmp_init('0x61f4af3b21708e7b6463b9e4130524faead91fd7996ef2881b1fe319191502832945d060341232e3257ce049c87cc2cf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4d172939259fb9093cd63b166662bfd97d6949225367eb9e08469bd272679d902ce0e81808945ed34b2fd55096fbb69d', 16),
+                    gmp_init('0x7a51dd52ede204741f28b558c23e06e6455212bcfd3ac494dbe2c8d4eccd13f9b3f88e59dd7440a847d52880bca94e1b', 16),
+                    gmp_init('0xf656d627282e5468be1fa9c237aefd984af8b0446bc15453c12beb1112b3208970710b2d03554bd38a8198f6f353c0f9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5ce10f57dfe7fe201466781aeedd41fd53485739721e39c510b88e2373d09deaa37d90c99ee2b226cc27c37cc8a50c92', 16),
+                    gmp_init('0x4a714bba8dcaf383f3a86b14e9f15bdf4e802d8cfafae269f3f65203c165efc214a428f66059efa81892495c61071c8e', 16),
+                    gmp_init('0x9283212253ec33c368aba66ec9a203a74e2703e5069d72e8332c91228ec0d58ced11e188a185bc6b932c11d297a5c37b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2f0b5007bed2442b5e1181acfe2df7192058e7e2bd710e6bafc9a820c00416def62bc8b6ed07963a8cb0374567effff5', 16),
+                    gmp_init('0xe483e76c6e269e4258a94fcc937ccf394b4b852e2f632e37b05f4d8e6bc7ad6233935721296697e97d4dc8f7b905e99d', 16),
+                    gmp_init('0x77b6f20148247812e37374553efe7461e94a229a62f817d121b4740cc3828ca6229aa9f4794cabefa088a1a4560d3e73', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x6f00db10de1b626430cceb17e1354cbadbcdc2dd3ffc0b8dd0f8a41a41e34835d27c03b123defef17912d8236a6c88e9', 16),
+                    gmp_init('0x35a2db4920fef777f477e211212b67cbfa2dd125ef0e6aab9749a1ef5d918205491449affcbd1e0b4e37af513f4b23d', 16),
+                    gmp_init('0xdf39578146d1cb4fe35c3e52bc8b680bc116bf293478b2bab71c1b32b6f36ecbc24192ddaf671d7500a856720f4d4943', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x487883e3fc0e6f4fa42912898fa33d2e140840291e1bd58599756c79ce895ce8b376b46577eff1e6012c38e139f56c6c', 16),
+                    gmp_init('0x85e9de1ae184f02782b48b8062fce1c6c00366dfa82dd6d917df0fcdb10933323603f35c53b515b9c6ef0171d0d5c2e8', 16),
+                    gmp_init('0x324e5b621dba128a7b6c2a6ba549a4bb5b19d2cdad39e3562521b686ccbffd894029f0f66431437f24e037c38b7742a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x400c300304b355ab23b98dc43ea3abca43fa58e624f5f65928b02a0602e4d185847ceefbf1cd551f129801cefb458594', 16),
+                    gmp_init('0x7e109466a3c41f435b325dff50fd690cec2267582a1bd24fcb5eb2b065966809e9ca5ec2ff7024e45bff0b9e5a56d4e4', 16),
+                    gmp_init('0x7b005aa551c1e5c6c036df8c9a45e27b56fd8dcb0943343524b28f39f4edccbd70d7d43a1d2fa52fe66c059577bd7dbb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d163f5162a6e4be0150a19c633ab7835cfa63b6c9cf4641ab982548e06db64c079f3f35254381212065b5d1f6cb2397', 16),
+                    gmp_init('0xe63841d00b972895f202191dc82ccdb91511ff1370ecfb7df9b54e1de9921591f12d805a51920ae1b443e6cc93802c43', 16),
+                    gmp_init('0x52ef7b89b459e9461d7c133571963345a86bcf0abe99a66c3cf5e8ceb4275a564db9c0249c5d1ade5ece5258c1463652', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaf7a6fef5cec1806be7e7c896a7d8381394f6128156c2143c2fa70a5d84b5a17a13c77161aefab00cb5b1eabe0ec567b', 16),
+                    gmp_init('0xe9b8ee53aed8b9249e18cdb79cfb8f9fbcaee66717ca71348039ecf69c9a03828d3f305de2c69589ea0d5ad9c5ce34b3', 16),
+                    gmp_init('0x3232478a4c9620165fb5dc9abd7db4b5047b79965bd7e10785a5a82412e23b0412d3da0020c8a2af9ce1966c34abf3e0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3fe6897c7bc1bb60802fd89348c1b0df97e410088d1060552bec102d17eeab7547939133b74e0bf4ae6099c351dad2b2', 16),
+                    gmp_init('0x8aa5d0891df43a892d2be02adc2943aa6df9c72ebc0dd41297c632494d1dbef09f8ec8dbd068685d6f7607b2b3868668', 16),
+                    gmp_init('0x91df296325569fc8e003bda0e2f2a9a5f69495172127b458335fabee0145a5a436a7bf06b0da08091e5560c2e5cab098', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc62f5e43466bed009ecce6259d103f8573d2beb4adcf35a173f0ffc98c6cb2325a59529bf6fd5bf9f40953940a11b57e', 16),
+                    gmp_init('0x5d4cf69248a1a900ecc63b4c18c9c5dd366915c4fa0802621bb84935cd3458873fad35ae30d94d9020500b2c475e464e', 16),
+                    gmp_init('0xb8350bf5a0cfc4c24848f06d8713711860a6e556a3741e9ffb84f0d1d4718ef65d19a60f933ba013d355594cdaacb98a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf2a1325c7010242d0970557ae13bf97b661c056a66fd08e196daf547fa5484af1dbe7fe67f99ba1f27581fe306f9e776', 16),
+                    gmp_init('0xaa76dab04d05930da0403930d5794cd410efc0334796cc7f179b82973338f29a171eabee3b8783d782a6e59b6535731c', 16),
+                    gmp_init('0x9a25f4fb704153dc6e2e135b776d709a97921ed8fed44d616113f19553d3f3272842c528c0765b51b7d81a6f158cd3f6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc762f3b4084b31ea43206c921c0359a4b1c8b1ad8dcf73ecff6843a8e73aea30c03f3a6a8fd78c1924d74f0e22e6e88', 16),
+                    gmp_init('0x407a0711fc6f1c55402f035f3e978357fc77f0d75b380fc1adad9340b071bc69000d7e9dc3cb8014c32817260a7512b7', 16),
+                    gmp_init('0xec1670478121cdc6febe44e60304b450c25f97f632cb82c1bee3a2737da10dae67faaa687590b7c9496dd02397c46c77', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xee2a38b33d022dc6fda210eccfd5d494a38a1fde50b41ccc9415cd0f21919265a34fdbbcf5089dfdbbcbd26d5c5ef5bc', 16),
+                    gmp_init('0xf2b6b9d5b335d137012a46e5bb3925daa3460bda65401e03fc5b0541056e53820b21028bdbc129629ac16365c7e3bfd', 16),
+                    gmp_init('0xd4294a33aaf56ab6e21feb056687c12a776d61f46e0a96e9a7b80e01e3ccd952277994ae93f4755d6e93aee52ab9437a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x75e24618855b60440206ad6c96b62e6a8cbcd1c169cc4b9956a663443832b5696cde741e6e2af77d50a19621b6a57aca', 16),
+                    gmp_init('0xacbb1b280f4e4aaa09bce7ba4068bc8880b774224ffe2037075d899bf015c32b43751595252245805c43228c4e5f135d', 16),
+                    gmp_init('0x663643dc37b4f0eca665c2855c96d4ae0061c015f976c7e91b933ec1a2b0eebed8d6c4f61d0280514504372abee0790d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x45af2b1818f11432c95bb43c065e474b60f76a4c9894d7fbfe8bc107436bf3c31133230fdc59b808c8440d5537a438d8', 16),
+                    gmp_init('0xa06e18740f5da247ff2df6a0640102ae825cea7459c0ac2bae128ac429d90e69121603ea704a0f834f16446d70af4ec', 16),
+                    gmp_init('0x11fcd16c4c4977b0a0426f8044979d56e2557aea5327618a35ce73944bcb4783291ddb19a92dad0abcebc70dd04fa966', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8b904eee1292366eda95047b1bfb0f7805f6cbf92fdc7e4e0bce1cad813ff16bb54a14c45ea6f477781f8ed268448ef9', 16),
+                    gmp_init('0x9c1c69fbf6911f4fa7d43dd3320e7fa3da393d34acd09153d640d8e9f8ddb1e9f3cf93e3ea89ec1752d13ab30fda1f0d', 16),
+                    gmp_init('0x974ce84eabf006f147a87f6a987382cddd5f63d431360ca3d96ccab5897f2a6815b4066b53c77f14cf77be5da0bdf14f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf7d59e73d07d07bbbc707824b808bef10af270a36fca65fd6b78978fe4dbea72778c85802230ac37cb22e83a5c3b250e', 16),
+                    gmp_init('0xf1e2e46bab5b56830908476c0607701d22fd40d6b1321a3955ec4cb2bcf2477eea83540d8739dd787f203731efa9d459', 16),
+                    gmp_init('0xf74a6447dfd7f2683b3962f9fbbd74de0eb5024537da17a125f6908dd08e95a5752d7def5ba6dc3c3e2a3954faedf79e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x996dc9f86ac8199a1d30e3839c771457a663b3ee09fa31c569cbb5f72b29e555f24d8489288a7b0ff9fc5b466be71157', 16),
+                    gmp_init('0xe6e704710139def5f91b9640f611d943fc4479cfaf28effebeb1f8b68f468f32070e1b815091c7648ca977801ee846d7', 16),
+                    gmp_init('0xb744df96cdeca13aab929264981c9b5e2a848241078434659c5e69bcbb701358b8ba0f66e3b6320e74feb955e6a3897b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x711793dbf7bbd5a84539bef0c45600e4bd33bf32fe1840972b2df5a4a2078ff6d3f5a10c70b06b988ae4cd9feb1e8498', 16),
+                    gmp_init('0x9be3d22a8f0955b9588fe7eae0517718dec53691aec2e3d01c677e7ab36d35547b2f5ed509a4e9e493b722ba4c0e0d35', 16),
+                    gmp_init('0x7d91bafa93385f29b3458784cfdd4d18967c635a9e3785f3065f4e928f4e3f4865d5f8aaefa0570f0d08d5f63a731023', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9851f403062781b9b3cdce8b817bf4f51ea1650a8cda11ad340310545a66248bcc24903098e119bcaffd22a6e7391738', 16),
+                    gmp_init('0x340217d0a9b885f384f9ee9bfa280561ea5583ab6bed541f196c24a8fc71afccc78911a596930184542207629a5b4e7', 16),
+                    gmp_init('0x928f35b9d9c8dc213b41516b71356c9e35d89b498c03485290e95f62b7564f08222246bcd8e693f761fbf13328bc83c5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcf07cfefb106aa86e54b9a01403f64eea9cd41fbd16fadd50004a3fdeba215cf2b177cf560c1cfb6a2a61a2b74eebde', 16),
+                    gmp_init('0x7b0b38c518bb9d3ac786b0b90e7ada453012e67513abe93b85713886d64b77cb8591a0216d53149ba90da146d13d4544', 16),
+                    gmp_init('0x90018d1896eaa97807efbfdab592de03e1122f81e8e3553f955f123b2a9d925bef22991e395bce04b552dc17b442b984', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf5236dff8755061a667f5a21351631092e195f96396edb9f774912077b83398e52e1d06149e2b4c46f980ec8cd86c9b', 16),
+                    gmp_init('0xe269cab0af7ea85dad0c3709d1030bb7d6e35071eeb4c14b9af0bf150c5b7d539fa23790ba00ecd49a00e5d86d24a0fb', 16),
+                    gmp_init('0xb8c650bd8719e79ad8624e9afe5cc611f1fcae5faf8b136f44f6ee2ca13bb1ea494ee98cad2672b35d0fe2f398380a8e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf297c62671a296203cebf49ee42ad69ca08449bd6b1316fff37f48b1e46566fb70f07ea61048389d36931924a96b700d', 16),
+                    gmp_init('0xf48d3968385f962b130a2ecd5fbd674b0287b2c42f8999c6233398882284f55d1a99a7d2612bc6426a799b965e52b18f', 16),
+                    gmp_init('0x96236217fa7988428bee5dfe966f837cf885210a14d3002453150e83f8d1f8578415809d6d553c312f79e045dbc4f55', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6a8c08f1a1ad8db270540171ac620a42ee60e01ab52b8487a1cc1d0de12b48aa70f6f1495cc7c880343a2fac523d53d7', 16),
+                    gmp_init('0x77c4e15fab6c38a2fb9d591a55569ff35154095b207ed219bd9bfc8d812aeff77e7dbb538a0d52da456d67512893a7e6', 16),
+                    gmp_init('0xd143e2efedfc2e36759d7a6bef50f2dd83d271c8b44077bacbfa93c2d93e02978a89080a5d536652eb93eb4f115c3e86', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9cba73f1d2e90a00785b624827d471c610195987af8cbbec1f1b1ee5631a7080dfbaf923e19072d1b4f559629b87ee87', 16),
+                    gmp_init('0xfef43c946fed5a50f06dbee290110b8e0ca09c37cf5d630999c92f0d837270b5bcff1b53f3b2a027b67e20b2ee91fe57', 16),
+                    gmp_init('0xa49deb315a98dd61b9a38e6729954be53073d5993125cec399f18dbaeba4d601e2c5afe91ab498dfa90709417dacf004', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb360d8ed6118010060b740390b0436342d7121401fa4764f32e04936d574c3bdf9bf77e9ce52376d4697a08aa2fbeebe', 16),
+                    gmp_init('0x36895b3513d489ef3205b6d8592755e21f3c086215acdccddfd9dd01f1036e06740edcbb0bb31067d5cf7480425f5b19', 16),
+                    gmp_init('0x2877a6a10e74fef4030bbecd55f56d6795bd0d0dab5289b8efba96e64ca549f179ef4958c5bfd8ca9f524339a920dfb6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3a5e8a0c4ee24ab9750c05621e290c42d2c24128ad7d6ca97d0f1f67efab8c339de78e20175406936cfc6cbd55a2a35', 16),
+                    gmp_init('0x6ff1925a10f498a895e3de6a56f80c88d77435fb424b679724be943a2354a1836cf387f34d9e9f196d981ff468933578', 16),
+                    gmp_init('0x66c754b1a45053aef7d4a7d86c1ff7d9d90d775fed301ea413b46f748f0d93f31d73f98bb2c9b72dba18adf19f8c0dff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb9a71c8232d5a763514d6f463f553d5434a93a17c002f5bc232fe56b5ced6071c5361c885f5983617f999d8c41c120b1', 16),
+                    gmp_init('0x17d032daab9868fbeea469d977df37c99beafe0b7102df9da02054161e631e27a52c4a6d3e1084ec72929c195ad6f3d2', 16),
+                    gmp_init('0xfe24098e774859ab3f698a3e222f2fc75728457fad24ede51869b4a8ecc5563bd8236daa15eb9bde06d70075b324e7b0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf7ff5c146d8e43526fc53214613e4661e0ede64c37b1770d1b6d14ced323c73cb840f51b032d21deb5e579fd4dbb3b21', 16),
+                    gmp_init('0x97a00c996024c1b78e96d3ae043b90d46252d38ef25291de8c5c8f7ce333836c2c09c139b346d6f2a2f432a66112d904', 16),
+                    gmp_init('0xaea30601c0b3cf22b56eb26ff9f832608db73d26b15b9c5b1849bde6ec73d1cd213c824302bb9523cffad2006fe9db61', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xad39d09640a42a02b14c6277e23a1cacb1771a6dcb086baa0fb37a155454878531395f69357da519e9f450b5cd48018', 16),
+                    gmp_init('0xb2a305e5a898b2ebfcc8978cdc435e1420ec5816db6ed8bb521f5bf7467c19323d0db6822f243a153b7acd7b4b61527a', 16),
+                    gmp_init('0x9e2fdd57d34f3fad86939e766111fbc346247213800f0c019572eb6a760f76ed20b4a387642bc8f29b93f1d8ac64850a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7471d58d0a9caabba6eeb362cdcfbc26c58fccc33966166f442e616d039c3f08d332e8800e4a5a23eda0c9c6efef1b21', 16),
+                    gmp_init('0x6e8573ff59afe755bbef1183103a58fd718be70cc476979c9adb8e29c967c59a30cc6bde74d1c55be4cacde1a6208e8d', 16),
+                    gmp_init('0xb1b6624af5ae2b3fdf08450072480d803d8126ea6b75ed5292f8ca22f8b8aaefb087d9f57d0315d107bbc5e3eade16ce', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe340f6772c21964b4a42af5cb31cdc56d0c5e7640e9ab3e299e9144413f011f4aeac418cf9ab528ec4052d21faeffabe', 16),
+                    gmp_init('0x6ca76e4ce81ad60fb11b0b6d2beb0e68538ecfff6ee399becdd975600c6c8a496ff06c2f61b3fb710546a7dfd293cd51', 16),
+                    gmp_init('0x277d0f4b686665bc344bac4640e25470dbdebb5ed8c505ab6cd4935a5724ba4f95c17bd75479ebaf2a0256164ae9df52', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2a3712acfcbbcbb4ad2fe20eebe90e8489235efdc3fe1aa42992789bfebaa56a9a7d523aa36b740e34093a4d3c5eb2c3', 16),
+                    gmp_init('0xc4c35e613c9083f77bcae125d9459218f9dcdca328ea180e0f592f56258874874a9187ae607cd821e31823a7583ea91a', 16),
+                    gmp_init('0xc091d78823b1043a5790746f73be38198befa4f888c467c238d14ad8c3954bb1667f6eef0ac24ac842c2bd8f25b41232', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x4ea28cecbd012c0f78581d86f15c7142f02942af6f8bdda35c1e03b0c5f2809518761a69dec06eb9c0ad98e142be3177', 16),
+                    gmp_init('0x945576131d964d758de4f74ba28a0f8a6e26a35e328c6d846ebb1006e11fb5a892c0b6e449c6c8ad4fa21c684a50c8e5', 16),
+                    gmp_init('0x328f73c2d9c80a4f4d899f028891f63c9d76350d7222bc1008453b08ddded417dc841d2149dddffb2c5f9d7d1f44121', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48d35e24c27d90c86e3d697f4c71736ba3d402b3b8786bee0136660a79f63c0f1ab8fdd180ab65ce867ac5fbe8ff0361', 16),
+                    gmp_init('0xc219a1c64c796b316e27da4d35c9ffc54d385a294504f8c426110807417778a8037ef06d1e9fc4b70ab4980145cb81d3', 16),
+                    gmp_init('0x801768c9fe248f27262f622d8bead7cf2310641bbd69d850a1f819ba2de6492dc3b90f64700d82de046a53a94d2d8937', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x40e6f87504bf02c642d11053317b5920d517128d8a26bc98f8b0b1be2d7379caa9b5042a793f7d72a727aa107945c0e3', 16),
+                    gmp_init('0xa7bfc20df2b5deed5541df9a6905632ac13c2fc6fdfae540ab7058ca6bc59dbee784f1305732f706e04ce9a2978df317', 16),
+                    gmp_init('0x9c0b622aaac26e6f81a8a50060e22d1b28f5b27dcf7868968d60917343172cfe4083836b482766ce9832bac31eda87af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x407a58265ed63f1e6baa2053ce91b26598e036c9528d02128c52e18f554012e7b10057dfb688430261380083f3994d30', 16),
+                    gmp_init('0xf356411df6d492c69f6523417d32350321161e8e1aaa74dd4612778cef8285f6968e1dd54c75f3615d04f7f90693df7a', 16),
+                    gmp_init('0xc8593af3775bd561e69ef3d9066d7f560fd5403d04ea26bb7ccceabac67c7f11d690341012defadbe5b1062ac4256f77', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91f41523cc94a29ec320acd24d2776dc998df439235380e87e22e8ed1c6147e98d2d232a9adf2faa62fc8d0253d11268', 16),
+                    gmp_init('0xd5c48aa314911444def4fe29400054ec39b27a71392111dae5807eca2a21472deeb157b59a5515ef7bc75b28fe54e41f', 16),
+                    gmp_init('0x54200782f33655140c36d3389149e5aa52bb31552e03ef5ce88b32ccfce5433af0bb08d90eb0a38f85705253007a4c44', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x547c9b51f5cfe57a30d702f5b4c256b1092de413fed8549cb4d24b16f96defff12861cae489520a4408cf14ae3c9783', 16),
+                    gmp_init('0x2fed4741a46f901ac70b8f0cafbc5af38108868b57f201e1c1fe1b784d1f0771159c191d966101e8a08debb62935fa30', 16),
+                    gmp_init('0x7e189405d4e485dd2c301d385f36aca607edb41d6f3aea0bcc60a16e4b407d531613bb1c18b582b7c3f138d65264773', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9041f6ff00499b7197dabc21c77c5c7b58be3cc72c3a45f4f74cb4ee2df72bfabf61779aa3a72869319d9b852d2a8579', 16),
+                    gmp_init('0x3dd5919f9aeff94979c4e88f73136dcfd9e6abb5af05a6663cfb5b9c438a505fc93c25ea49480a0b6ec19ff45879f650', 16),
+                    gmp_init('0xd74bb752cfb18412beec3adfe5ac40b62e3ac2fa7e8f6ad32ae50ea629025862a1764aec15fcf2f73ac2ca91bedc99d8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c21eb209925e68f2b9fa79c5d1d2ce4e9264e1ce8a18706cf074509f25855a5cfe9ecf3c3ccc1a86d5a621d9dda9108', 16),
+                    gmp_init('0xf414533cd3090ca45fa5000899c03cab1b44e7c15ab508f176b19d7a71d3a161d8d094d612d6d6ae3bd0b5ae3f7e75e6', 16),
+                    gmp_init('0xb28acdc247c22b55c84d54d1afe7c8b2486361908db720ee1ebe3369a1535e5ca4a282780cfad87ff9f804fc82ce063e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3f03e8ad7d8bf8b3108c57732b2e972d3c967c1c3f8f82764ef18521b8ea0945459c950b9586930f45296d3b54be5c6', 16),
+                    gmp_init('0x8ee9522ccc3a04c35bb2de8c7f80fd20d72a3095ab4fa91eb8308c52441f4962b94e59bf1ee42095d91953bbc40fa97d', 16),
+                    gmp_init('0xef8feee558aaf2349a3db73f6b48e6fa91097a945bef3d424bfa74da9fa8c5b955d60081884f290abf0e162de410988f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf924bdf457364158e422277a41f9b9323d4ceb0e77db8468c98577f658d74140875b3be9d998c7978c0a50d3777025e3', 16),
+                    gmp_init('0x71aa646b3f1236e9042a6bae3f3ffaab1636946d4c9d2df81ef0cc803159c8b3b15820094464b7b358dd1298cc52464b', 16),
+                    gmp_init('0xe05032b60db1a5f9ba78a3d68ef2ee47d82cdd7d69deaeac27290a9f370817b2dfcf5ba60e18d0fda6df7bfd7b272529', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c3310bd4087055dc0263470eb28d33d978be55a4229779f16a3750f3534fb77c66b1f8c29c36f5879ded3aded39e941', 16),
+                    gmp_init('0x64a471277e16017ac08c7f004cebd5091c2176aa33d3c5988ea4d90a25e156ee75aa5c3fb571c491bfa4e28513d872c2', 16),
+                    gmp_init('0xd88f3838e565db7cc7b1a958fbe903d5bf1a18d9fb85c3779ab244e925109a72332ae93b0b8c671483ed66ce00217cba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xde0edabc9147f3f55790d2ff358881b01568408b3cc0e934b0fc2a9ad5cff097b7c985424c5062c6eec3da8e0c649919', 16),
+                    gmp_init('0x60ef7e707f9113d9299ecd52a06cded53f5fe214644a9568c2a9d47a06fcc45b876c0ef563e3b9e6b8908220e84ea398', 16),
+                    gmp_init('0x5e05dfe5ad7ec61cc6cd354d6a4dd5b2deeb4d2d4e9f2c4c1f4a5c0f19868014da6ff4177ab2cf34cd7a259757e4b275', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8531c8c946353127443b8d4015b1a0b06418aa82a5257c99276b8196e65278e696d0f99655d55a83ada89a14e5fe6651', 16),
+                    gmp_init('0xa3cef5b3260e7e28562864c1ad272a0e4b5a91841a2bad57ffdbb84a48d6405b218c45a70d67ed6cf51a7a8dc02f16d', 16),
+                    gmp_init('0x480afaea2918fdd09ed24139fe61c3c70103a625552eb728ebf24c10b5e15ae887f4eab98fc676087f35252b98e0284a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbc1ee642c383adeaee46da7131e2ffc63c064e491fe7bf1749ead6e026b20ce491a6c4c462fff4ea22cdd486766a6b99', 16),
+                    gmp_init('0xcc58f3d88b8172dccfa9a9ba28cbdbf2c20801ffb06e4dbce3dc09798bdb3b03eef6ef91f673d8338fbbc2202f8090f6', 16),
+                    gmp_init('0x60719d7ff34c8319d5e14e04f0c9afd0dcffb392f0b32639ef58b4b979d7e890b473f8b67b17e49c4479d7d1c005890f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2781b3b0b1a47eb90ecf023ace30efce4263016e95ac53ae239dfc91def4bbe8394afcfa070d7ee5c30777a06587471', 16),
+                    gmp_init('0x92f5136e9a368a68c5ccf41ad7d7f459b76db3880b83f1c51c3e52203778fa4b95d8b6cb7e9a87564940cf30792db61', 16),
+                    gmp_init('0xa7c3ce8cd42b9a7a2093e5e74f9bb1fe7728ed8cf157565c05ccf3c6e71089f9f7de03a37dfc642b4385fed9c8d0da8a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x29fae8cc5ded9c5f701adba72f0c27d5489785676ca3c27a65b68389b70cb7223685f6aadb22d4684e9685f41b13b447', 16),
+                    gmp_init('0xaa39b043c960c2f7645a05c552c55398bd8497d19d2b4319dc5e2c0a299853038a6cdc63618096d894467eb35b80ed14', 16),
+                    gmp_init('0x12d413f80915aefbc8b05833a2fadda4ea9f6eb184596e80926e8b66d50b05b509b9d790732f708c5835a9e22d99a710', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6ad7a6f5f16288ffc39f1383786fc67730193f43f1da5ce99284fd41b9db45e39a511dcdcd695c5a71351c122815e2a6', 16),
+                    gmp_init('0x79ec7943a68287aa303b12b6a360d93f9f354a64f07e9e1a53b48386731677cf1f4612ef9ae50b0a25b3481304738bec', 16),
+                    gmp_init('0x5741e02a03c9c77bbee4e41bab951f06b3d4c7dd5f291435cb047b138e3705cb0f09a48ca7cb4df53a02c6eb9348b9a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca40f1694bba39bb408178fcbd813c391db008980872a3618532d6a97b6ea832a8230c59f62605233ab514caca060825', 16),
+                    gmp_init('0x3f46c663c72f6eaba41a7ad35cd78fde89426615f9f34beecf89f621f9aae12bec29ed6e7422498f54777247d338d3bb', 16),
+                    gmp_init('0x4ffc7577cc58d8a7dcb836e19b07018025234df9dad1f36425421731c32f355c44c138acf50fcbc9d7d014c17950f2c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2469e1e74fb0f0a711c2ff453eb8e1067b7747f6b6db312b90f241666b6ff0a5430fee6787b5ee5c980de7b85731e83e', 16),
+                    gmp_init('0x4c6ea616aea7a614af67446326868d1c4e6a2dfb17bf9aa9ade583a5489b1398a014565957afd3593e6c51b32e4f1c3b', 16),
+                    gmp_init('0x2ee535c19db0b57119ba5093dacbb77b1cfd4da51b1b5b2fbc0bb131809133dffc5441c8d3f7731a30c518a10835445a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf92985f6c4f9e842cc0e20b8ccc5eec677c3aaef82e207f775b8f8e770375f247f5cae9923a3265616e88fe9faab9005', 16),
+                    gmp_init('0xa83d51ebef842ea4e1a0a8901b6644947022413bb120b6b5c4a97eb6c8f5159e6b2a32c29972c035af0a3d4f4c2231e7', 16),
+                    gmp_init('0xf4fdb7872a745036edb8362c5a32141c507859160b46d8caa3369dce6a4802b392ce6d4fd5895196db3f953b6269a6fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc19f13191ba0f00de9f783540dd470f37c5eed2c4236dacb8a7b480e036e99e308b0437465faa54fdaeb1cbb81095e12', 16),
+                    gmp_init('0x153482efc6d1c14b2b608adf8dbd51ec9f7049644c507ff7c37742ad74015badce9b5ed749dba021dae00030f4123128', 16),
+                    gmp_init('0x8647347487ef8859d6a34202d878fa1a01f54bd1524f77605139eff71f47299cc94474708a981fdbe7cfed24b12afd0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x77db9780cf7f39e6250e9491f66406bb7d5ebc1175c5a0a17c2d5076f744d99c89c5c3da247e2dedd7fd25d495154eaf', 16),
+                    gmp_init('0xcd085c8935115531187845809220fe735eaea4a81d12b2888af1efc76e9d4bc581523a72ee1be14cfccf32a50e30ca74', 16),
+                    gmp_init('0x3999ee759f5c2021ebafa3fe67896b79f1a09eb6bf1699c624b73a39816142acbf00f33063eb0a1b7f02ac940b6ccdbf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5c76c4d8fa51a851b57853f4fe8541063e2bb1e02f1fcf9837a664997e3d92a42bed8594d395259ed68ca518f1946f05', 16),
+                    gmp_init('0x70e6fc04cdd7cbd0180de95e8f540799e1dc551cbb21802e9b67ae87093fc900490c465e99041b427cb3e833ea6546bd', 16),
+                    gmp_init('0x3cbae351881a2e31d68b4ecef682501ea5134ae35e043ffdea66a9d5452cf50d3b7f2c1d019f6e7013a5a862b47b0af6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9f9a000b55d04496a0819b11b151564068e633fbff296868eca24c2a35535d96c80e25ecf66bb6ed534b6a3d7f18a5a5', 16),
+                    gmp_init('0x5e51431aa89a20bf993819c63ca127eb9d9d4bb0469157d3c0d73455cb493a6dc544cd1c276c5bfffa9b9a3cd557c10', 16),
+                    gmp_init('0x8e1661e4ec08ef7d1dccce2f22e1e54c30d7a66ab834fdd7d8810f4c042116283b09ae92554d3a3d1b8a9b38277c04d7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x112f1d00217f4e83c1491a31938acdfcdb9fa60e260dbad835c74bd945e37cf9fae5c4c3f5532e001640bfb4e551b85a', 16),
+                    gmp_init('0x15534660bd9d8a90f0992a7425af2dbb1d19619502988d67cb0644492dfc54946dbd4cc7977b81168b4179d0fe5959fb', 16),
+                    gmp_init('0xd5f345b4f3164ec6a9662e6921d02ec98470020e7458b7e95d215ab4b95a499a45b4f2ebb2ff66e12c6ccf5307f3a2bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3ccb0da713e648572a32ca6a189df80c0c462c401825e85157fbc86fa6a574e0edcf46f268bc87f45da8e9d9a5931d6', 16),
+                    gmp_init('0x6d0d78fadaa59a0e24ce46576e9d7796a55a166ebfa918efd161c14dcd7f4d63e89be94581a96f59213a55204b2fcad6', 16),
+                    gmp_init('0x6f7d07a4566c8dd90a6d0e0f881cea53701e67adbf77b028d4726c5298152163297a7444f0688667a8b0391ba5c28006', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8bf78a9d5aa7a3b6403d8e562f2becb5ba5dfbf58ac8b034d665bf7d4f430dda8aeec0b9604bbe648259bbb46d94dbd6', 16),
+                    gmp_init('0x6e6cc585ef1be6cc9d6f0d503bf4a48ce15f7f0fbe2586c6fab9d9e28281d22bd3229352201a06fe39d078701368683d', 16),
+                    gmp_init('0xf2d7a32286423f9d93fe765f0c2e61c29357dcc0e3a33be0c32018bd4e0e17dc445afc4f4efe5b6e15f88a96d7ee1758', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x97ef500ffa7a4a118f1924e83a84c0c61b39e6a2f71da5e59de2363860d63d78a4c33347f30c71ba4053ad643a2d35fb', 16),
+                    gmp_init('0x86e74059abb65f4d9a042497288d0bf5c2c4f91835d68847299e4a47c532c5cf87230a40ce076fa53339e9ba406ac9d0', 16),
+                    gmp_init('0x76fd387e998b460ebd87abd4f984188a7893dfeab3a04bda6efda3adb8bf8b872fbeaf0099992694a8dd05a79d6a8a58', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e94b3ae14f7db6f7f25caa26dcca74a9bbb04ac8c3a36307d1f57a19363a06bb6837d0199013455a5b488dbb2cf7ee', 16),
+                    gmp_init('0x1b7de8c481750121f196d595a8405908ef66c6a82a16d850f6ff97a0c49d77db39806d8c9a81e3d017252d0a244dda0b', 16),
+                    gmp_init('0x19db6971bc479d7199aa185392ed9971776efa8d5eb7e949d1c833f8d0561430b88871744ee69bf70223ee84edee2099', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x871798fdac783ecba849536bc622f392fd82d308e013e889bcec4b218d988624efc087da7acebbec80737e28309431be', 16),
+                    gmp_init('0xfcd972b3b339fb75c5773677ef50b67899db4b6eca38cc5896c9c1cf73d97e22de72dd42eb72aaeb9779a249b7913b9e', 16),
+                    gmp_init('0x3f7e3f186bf543fe966b0d3c323623d0e04e5c6605354fd260baf5c8b479923fead93d080f5e9ec81eaabc502094aba2', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x219277fb47777b2197a4b17c662aa2f229f2bf2a37ba41e4ca8780e47779ac035b1548ec662dc31c1d8ee76d1fc45ba5', 16),
+                    gmp_init('0xed638316d19b9c0c3b3bf423d00a13b531f50bfb440ba47a89b10e3bdcaa661cebd64de8c7ebd0e0f2d30d89202c7b4a', 16),
+                    gmp_init('0x1e3edaea0ad0fb08c1c3b1bab09c99f586fd0a7e9935d3125b09107480f8cbac51129c77e4d807b2001eb071af5c929', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdbba0d20026cf1de30bed7dad7ae5d1867157373784031c3add4826ac9c1f1812cce7e24d90cafbc9688c0bcdd7dbe85', 16),
+                    gmp_init('0xc6d4fac840b7aa3686f485f324b8555076892c32df72048256acffb64e405bb7325090a1f31837ae41e73bfc49dd4309', 16),
+                    gmp_init('0xaa2e34a1bbacefc57b98fd06989975c927925fac25ae050e65d81cb9cc1aba819644ade5fbb3d90a6159c8a83598c6f4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4a5b19234643d16ce99803d8e1adff35f9ba9e469b91e3b1f3120e2154c22045d0a7e07a35fc0f55625354ef9a0bf6e', 16),
+                    gmp_init('0x3629e18a92c8f8f2081561505294276231e7406f8b0216ce068ef86ed0831e0926600e3553f4d11335cbc50b68b8fe7f', 16),
+                    gmp_init('0x4d7a5339c8de1cc03f397d008e5f9285c5148d314efbaa0bdc659e5bc9319fd14947bd8d7e89eee74bdb5e03af90b6a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca74fa9452b32784a9dcde30746fa7d5b18365082b09cd39b3792f5c4c43bc854de7fa2349ca01a880f137d29c72ccd4', 16),
+                    gmp_init('0xc6b55538047c188178fd3bf59d8ac2b9b8dda952b21728766acd7ad5346b7d29361d07cdf2b0bfd0ffa8e072393cfd5c', 16),
+                    gmp_init('0x800eafcdac398c6151cf1218784d04b2486930021a83e16d11ce67937f7c2947c38f05a1c7ac88802b82bceff38d10e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa0a8763aed70ad989c441c200c12d6642b46a9cac10fdf8eb3fed0ec1d77fb2fe50ca4f2a850ca9b4705a1a13547eefd', 16),
+                    gmp_init('0x8271bf6f9efb63caaf3a74a37330eca11d12963cc149baa8956a40b94706c564e41b03a4fc4782fe2afa5138c9ca516e', 16),
+                    gmp_init('0xea31d3748b8b8608beeaeb7b7b0aa86ef952c1cc18439d4823db692127e6b850f0cbeae132911b08fc18b735b146a0ff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1b68e847011f4f56688b7abfbeaa2bc9a8706417e3d6b012fc0b297ba8dcb45e75d3f76aa6319a0e4f878ee4141833', 16),
+                    gmp_init('0x75d4a2d19940dc41b58417e3d2e69adb3106a031a0a5ff23f763478c6db20411ca7f02cf12e10dd5c398378f745288fd', 16),
+                    gmp_init('0xccd51d195ca57b907ae35377450a8ccf44ec107139743fc431847b3ca96c703c9e7cfb012a90f9454a2c598083b8a9c5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaddfababc16b74eff698ba32a504410a9017c4e67344f3cd6d3617277c0520e4f38e224fc44e5c448f6d3d1c6a3c146d', 16),
+                    gmp_init('0x57b910d75d015aae2456621f74fb0d96a7a16060e47ea0b96d84aa1383cc8276fd2c79b28093441196be01e5d9fb1875', 16),
+                    gmp_init('0xa9a33deceb5f411389a2d551c19f4b30bc39c455d484071dc6f83c28653b72bf999776e4284f771e43aa903af137629f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91d73524673a39c36a40196b84a0705335c75fdd00a8d18918ff3dece2c2476f0cebe55832bda0737086e27bc563dc65', 16),
+                    gmp_init('0xe5174a0795e787c1cf156943ac510ba9aa5c4fb3653af5eba061ab1b04391ea33e95e8d20efbb02808c1ccc294285554', 16),
+                    gmp_init('0xe36f176a10bc837737a972ee317dbaf8620abf2684c717c7eec4a772471dd1101323e5389aaad2cf4c2eedc15f1f7599', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7da7a880da5c755e6ee50e230293c94901245db6df2accbaaff3a5e1433675aa8ca84b187612767ad3c683718a30c889', 16),
+                    gmp_init('0x7a071540a2c9be83540ddfcc4609c0863cc22b2adff7a6d75ab03c11b4b698814f433779c6ba73a38b9fa2dbba3cc899', 16),
+                    gmp_init('0x7870edef5cc3cea846cfb0c78613cb79a14537023c2f1ebb94b11dc5aca98ed8e42b2490b3e3d1f8cdcc3c823f278c47', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe45109b40559ce0c4192b50142f4f052647912eb4aac5d2dc7efb736dfd992d941a767cebc3775e202aa94ccf1eb422', 16),
+                    gmp_init('0xd2110b22d77549a5b3bf005be0c339b6443b89da2d6f331549a28c0fb6fe18e10d00c87a5292f8c3ba84ae6d87dd5c71', 16),
+                    gmp_init('0x2fc221ffe2d49e64549df20012c3afddf524ea72253f2de846a7f43b413f89c6dda051f2352f7751aad6f84adcefdc03', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x98f4cb186599cec33775d68c59d680e30df9a29b614a5903ee234649f2ac65c104d8bce3079346d1bd37a0ce4752db24', 16),
+                    gmp_init('0x2f3f503d6268a8f0c33fbd356eae43cdee73534c4c4057c8af80736e82c76fcd83816498b585daf02b88785ad1ef75', 16),
+                    gmp_init('0x91c65ba453183d150ab79792563af9610f52c2145474edaa76f6518193eb773e72242151d2baa7320f30185512a3ac95', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeeabada3c829b1e55adcc45f28b48b5e0b66a537c4644f4039f7dc18dd041f0e00c0791b337beb4fbe017c4e1793bfa4', 16),
+                    gmp_init('0x81202b5db4c7ec2b373804ad0cf6e31533e3e6ac64d2aa84c2977ffa00c00dcdf755125cdb16a5894902329af9a7d205', 16),
+                    gmp_init('0x9ba5f65e222880ce90d530a624fa162e842e28d179296e622eb7f90dcb473b84c79284869a0b2f0511bc7a53d755c849', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb4ac5ddef2d8e2cc8d58a8d2d3fdf38d2cd1bbd578971f6fb48334cf32a760308d6ec2464c89abbf76d33c69b03d862f', 16),
+                    gmp_init('0x20a9abd8c4e6f25efe55d4f83e2fa14d55a6ca2236ccd0aa08385103368d2321412d58b4d6a04c348e1f90b5fb4228b7', 16),
+                    gmp_init('0xcdd05b8d50a2fd2c4b8451744b8deabeab960c66ea6b7485b6cc19c32bc04fe67525f6db8b689409a9c1e3fcea9cc53c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2cefc1d4a5d969253a833efbba0119996c7cfdc7ffabc83f7a38156a2299d5cf916e0b8e7574d8ed5725d80f5e7d389', 16),
+                    gmp_init('0x969b77436d95c7ab3b80fb1b4f0ebcbe9dcd25ea73679d4748e2bc5cef88e9d809aa607fc86c66d9a7bec50ac79b2bfc', 16),
+                    gmp_init('0x349748408915088e5bb73a85d737d06b4b1d15796a9a0972607f1b03139f437f89602cd7bb6f864ddaa90308eac18e90', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3a63119279479009eef104e48f260f04edd870382e52ac1b415572bb158ce5ca00950b35e168ae071ee5745a3d8991f', 16),
+                    gmp_init('0xf8eb3b6f9228d2166092d5c9700d84662c8e143ce14f84ed70167ed6921bbb5b2f75c98954d2c7053896e53ff0539d7f', 16),
+                    gmp_init('0x17cdd3269b2057b2e344ef2d0a2442b6e30b30f9364bfc8b260c77f2ce6dafe5f11337ef9a19ea3841f65ba121a2ed16', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa961d34a91e42e97187e4bb161b47fa44efaa17eff3db40db5bef0ffb17fe63c0f2d18e3226f93689d024b8c1a47ff4c', 16),
+                    gmp_init('0xc10fc434b967ae7a1da4e052b3777a4fe32dc1853b5b4bf367fbec24e97c730f6d49b8712faba3105fc04d301f7d312a', 16),
+                    gmp_init('0x67c9eed6b530a8080900588406fa350f98af513495781283caccaaa9a5dbe336b011b43db6dfb44e78f4c90101ab2a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6826a3fbc68295b3bd1fbc018908c8e6a1bc62376239ac88a189dc024efd5218e1c5de84cc98cc464d1431791b1695d4', 16),
+                    gmp_init('0xb6c77bdb7cd73882baeaba8955aa5b4d13f8b6a43043a3586c8a3ad2b5262193c3edf56fbf39dcd444fa49abb99907', 16),
+                    gmp_init('0x13654e4f94c2239adc1966f0fca47c7c3bd10fa887c6f41ba101e57be97df75f8b5d9946f6ad8d3d70485481ab3f460e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x56344cb887f15320fe74277ea38251f18daca98be95e1cff361ef302818593766df034bb7b068e80198ecd49dfdc80c8', 16),
+                    gmp_init('0x54b523155ec23ebe4b48c97c41bb4f1e99bedf69a550cebaffc46c0a0e994a9ef12f952051e9c120cd1fbe8333567325', 16),
+                    gmp_init('0x1a53f1b323d471772b9eba26a93bb25bad1545b48b584ec5b47e08746999aa9678e6fd6ec909fb536901298d7b3a787b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x255b165b4abf19a749c2f472a484d09ac223c76a4d37613e9e7cd3e3406f92c239c65470d072c0f488d8f7e525e2c84', 16),
+                    gmp_init('0x34df4e11545d27c8fea591a45cdd9ffeff44cae0db84febc277fc5d3b1f6650b28340c01bd3b75b50d2d0eaaaaec4a23', 16),
+                    gmp_init('0x17ca4c10b6796dcc68876c9f443c7350b0596a911afa6bf1791687d603631278db7f1fc41eb2e03ea65e68fdb46e4772', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd8df0d089715dfe114e779fc56e867515cda3ffbabf3a67adf581bb51f917d32e372170d9b9c2d0c43401faa318ec59', 16),
+                    gmp_init('0xff2db64ba213d30315335de0d761c9aad8da79623434fd910f31f23135a5a38200b2388e116fe690da3bec9412da8139', 16),
+                    gmp_init('0xcd1cf999c0cecb4d0dff9b00ba7832c1700204f9197015a90ecb3e5d411244d4c4e77d3da2e236984c8e1b7b5043230d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xad41dd8db5aeb6ab330ee3b88e57291435f062d28889f188f611263768a3f2241ad11f9590fc09eb25ef35da6013ba49', 16),
+                    gmp_init('0x6bb440a0343b49716e0fc218b484223b8301e4c4020792e294960eef6f16700a5dc32dc92c3585a027f0ce946ac5e1bc', 16),
+                    gmp_init('0x1cdf091a667d5a50fb1ae53e6cf639f393db5e8fe288f7bdbc72353f79105e764ae11ced98dcf5b7326befed3045dd3b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48a16a4edcf53369afd92b4005398c7f2698ff05b85f33eca2bf72156a9dc6805a0c93562bc53649d61d275f6b24d898', 16),
+                    gmp_init('0x941cc65281335d4567266cc93765656f27dec22ac096fb60d7d2fff7e0bc508fd5b51abfba67738fa595db0257ea2356', 16),
+                    gmp_init('0xd53578e333cacb0a774b22b3faf919121fae6282c9e3c491bcb75a298ba7a6d49bfcd054192a5abbe9e72af16678498b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcce1dcc4e26bc6494310d513ec82c2a1749590a88ed56343b6fba5a3a2b82811e5bb1e4a67f20e9e5d8bbdb447dec0a', 16),
+                    gmp_init('0x2684927dbe5d1db1fce0881f45678193e22f4394ec3626b2456521bc782b112ee9e62c9862897c95b704596d5de69e3d', 16),
+                    gmp_init('0x86126279d6fc7ef84bffbc95af3a6f7ce2277d0422b57cb6c4d21e4a3806e693251b0a9dca280fb1a652652a16de61bc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x47b7fd76e7bb1f124fefb1ba505af97ed04c3949ad17525210f3664317b65ab7e4aec3bd8dd521e9d07839a3aca3f93f', 16),
+                    gmp_init('0x78a1e552a44b6dc483ca6fd32e8ae172bbb771a83423d37d3255b06cb56538c9ac6197c099783fdcfd699f6714da86af', 16),
+                    gmp_init('0xbc0f51f276bad145b9a04d1fcd1ab96706a74ed932de42f12f6d700bdeca687f0896950783b2e4636cb4b2dc92252831', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x16d5865ea6f6fc42bdcf407b4ca1eb5b55901619357f17149a475537d30403b8b059508d4cacb7b7be7dbc351a73dea2', 16),
+                    gmp_init('0xcff882a91c7c30d7312dd76704e6ad7da9c58f5f1a8a02e058c54e99e05d9d44670b897bde5045c15d197000f6fd2518', 16),
+                    gmp_init('0xd441673e49e822488b75f15e5261e887323f910deeab93fdfe661629ad825d2bb8f10cba330e92d015c35565dfd22411', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2ad2d203aea2b70032332127a96ccce84c8fc62087aae3708dc110839a73ea6d6fcbcb700f0753ee17dc723adf55d96', 16),
+                    gmp_init('0x5d0b6918ad14a2ca90901ed94ba69948a063aa562634a3c4985c8f92dfc0cb0d7992bae748bbf6d381bb8764968c9899', 16),
+                    gmp_init('0xfd7bad3875e6602076beeec04358e26e75bc4368dd15321d55c974c4a6aaeec87383e4d0bffdcd0cb55afcaf473e4206', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x58284823b3e71dd490703c6fbe06b661c0d447376f31d6bd287a5ad3dcc87544e0cc74a1c535bbd429101f70e4d892b9', 16),
+                    gmp_init('0xef6b5118cecc0ecb46746b145582122d177cc06c3a6c7bdd13d1624f2df0259d91fee055719f9cb4637c5deea8f6f24c', 16),
+                    gmp_init('0xd2d2d343187112e28887ea4ffc86c5650456801867e2c266b0910b5c5d743cd5abca5d7f125073937a8e219c0fbe06bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x948336858a6cbdbaf870144cda0ade2b2ddb95fc1e718d1b7194f7b701db5361a0e95bfff4f3b92e70f5b8fbbd5d5d1a', 16),
+                    gmp_init('0x54a341283861d55e819dfaba3649bdacb7191a3c6edbf1154c3025046cd2497bf1d1e309a6f3ad9dd15b45414b67d9a0', 16),
+                    gmp_init('0xfb2a7119215dede4516504eec036a6338278009228c73a7ca0dc6ff2d6fb858996159077931c712434dcaa8178ebefac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfdf1fac41904c60eb5fbcee53414fdc500c247b98ac27ff8e96af51108000b3bbedf8ca279401494fafcb03e2cb93a50', 16),
+                    gmp_init('0x674347df5b441f53c4dc430208356b83aa8754bb789ef4b3f919cb9170ba9cc07b3255361a300f7cce9d4b164ab95580', 16),
+                    gmp_init('0x4822e422367cc0738263024e72159ed76b3511607901875a81afe230605ddea3017f7bd0d4e2e4c580f5ebe817257ebe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb1039463967c3bad1493a1083fdc06d1d3bcd87a77d3c4aaf262451cfb50bac1a990efde36f4716b93b38a99f2304995', 16),
+                    gmp_init('0xb734823a802b54ba3f17ee21344152267e546d5b1fd4941e3cbaa8f6c74b0325792f20c95a1d871872550635ae1bf93b', 16),
+                    gmp_init('0xcc878f8242956b3da88562598557677ca57ce94fa9d1523e7c7ebb6293c849b221857c85123911c4c6a80bec64b87dd8', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xb51846c11f82c481f114877f24760c5adc4dd6f00429d6c8fb986dfa716703ecf3ecd815b8e33bb7dc900740a4b36783', 16),
+                    gmp_init('0x16edd71f61e417addb4ce02cbda83de3a0cce6eb397550f461db64ab69717e3c672ec4361c008e00fe3ce5753697656d', 16),
+                    gmp_init('0xe4c0c28428acbe69723889adac894308394f0f4be7e963f9bef5a6ac345fe2137d5510c463d80cf9b271c334b69892e9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe4fe899d216927f85da5b98e72f20c6e717e8e618d7fdea386a3bf5e68860fcb8b702f6a96b932c65f7f6291a0890733', 16),
+                    gmp_init('0x9ea3f8753da466918afb52a1fe517b370cb6b029b2c737176c4a9fb86bafd1fb17b2b3fca9d2faccb0667b59dc4126c9', 16),
+                    gmp_init('0xccb88f51b664e72198a5685a70316b2a34138911f6c137305f103328c20c86bf62597f49ea4717bc876394ee3e9ceb92', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec7e2d281759ffcc69fb1a33d054768a06f33158ae8314950ece591c59ffd9e36a6dd0f05ddc89bd4e2a1874d910e1d0', 16),
+                    gmp_init('0x9920cecac19ef428931369e512f03e3ed9bf902163c68795a85e42666e821910d1f5c173cb0da92fc18ad2a63874bce7', 16),
+                    gmp_init('0xf15a22386f2383e774b1a5c67f7d1cbbfe64c8d4eafcaa5ad3a416c7863137563c09551807a13618ecad9b2423f46237', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcec66410b11db15ccb780f2d8298a9a143916f7113b4ea847fa68c7ac7cd521ec8020fe629daf8411e0b64b352816d45', 16),
+                    gmp_init('0x680bcc030dffa232147f4a50417f1c6ebb67e2c4ba556e7da7ae4b1501e05da41f011115bc4bbc31dba1abab5cec8e91', 16),
+                    gmp_init('0xd6cb144d416e58c196a83c7410f9662ef2be947e4ddd5b147977d3f441fe9a881123cd01018dac92d7cef07e2feca4d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2d0922dac4609870188ba66dc03b39d8b9e795b6315339b043d654eec1e236d13366aeb2a9294918c2827b3f9eb31d66', 16),
+                    gmp_init('0xfe6895e99972c5098cf59f3575bb0c456cf1a5c08a9f49e4e788a77e806312d8b1dc82e29d7d9d3e8ae8a956e1627d66', 16),
+                    gmp_init('0x86b4431e4eb73e7ffec22967219ab807df39df9db64519a829a90c39ae462d3bc33554b34c8fdd616772f28994ed2a4b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x451cfefc572d630afada1b52220626922199128656695b87312599b4bf65138818ce17d92a67bd16bddf8a577618f7e', 16),
+                    gmp_init('0xa44d15c9fd02a603530af4ccadb3daa767781b8de269cb6ce44fb8d00b2f826885285a83a176e0b3f6d84510067e7cfc', 16),
+                    gmp_init('0x5e1560c6dcbadfc1c6d1c021fc63d52c6597b8f35c2975bd3a2b7c2544aec66dd9868987615d232167a811f69be31e79', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x839e354ca073fa22966e16fa71aee7599d19860d28dd2aae821434721ee207196fc3d1da898377b32b017b819ee43004', 16),
+                    gmp_init('0x864c6a9278aad6bf965ec6093d5adab089124901746470341bcdc8cb85a02e636758d6ceb7b741498caa93ae7f697274', 16),
+                    gmp_init('0x11f68446a61140a4faa871280ebe942965f656895e6f57d1b66921554e96affdb369a5cd23c9d26571b3d8edf2f5b77a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa175775ae9a3e27ed8958213d6d917074b3170b5ae2b2ef0232b9bb70f9e18ea55f6a629633c9f7cdbc74dbd58e0e864', 16),
+                    gmp_init('0xbcdcfd67d039801455f4e262f5caa653e97f90a53a97b890b8936e9f8b216f4cde199db8a478a35d5bc87fa90034ae16', 16),
+                    gmp_init('0x2dafe1bf6cb1e21b97e9894de1ca4cd305d607364da3daf50368e31c376289b2d8903d95f6f35b0690d27a9cf4f6bce0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc134e38a0cd0627e74694303e889bad7335b2335f4cc2b07851a60ccceeeab59d35127c2f2ee72db5f86bab885ae1948', 16),
+                    gmp_init('0x5524784104b62093a881ef5980d0da2d856aa6336cb4fdc6c79e196b54e5f0195df6991f6190f4c39d1e3dc4c2be46', 16),
+                    gmp_init('0x92a402bf0591a7860eb6bedb550c36cbf135cfab2e4719b83f70fd166fb3802f246795a48b2605c98b76b06d05922bb1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1676130a89febbe352a19b2852705e034aa02785a90c4dfaba7214e2205bd5e54e2b9c1cd3b737dc7a79319e4756b218', 16),
+                    gmp_init('0x60e42620907c154728c9fde22a66dc769e5ef95615b9f936a904287d9b066fcf92d2f4c9154c340a4b0bc86285ceb61a', 16),
+                    gmp_init('0xe4569f99e2474c6c3ebb893a64db6030e913aca5d38deff42dcf41d4e86b4e1403d6c7a8cbfa32c190aa370c4acf65', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc410b7a5182715def31916c715fd8b430160c3240649843e30565286271a6371484ce71affe9585d489449faab101569', 16),
+                    gmp_init('0x76a1a76ca7961955250b393faae5f1673446b509f956886735775a2b7af45aeaf5c2bb8c33f6e78eac56741db94504fb', 16),
+                    gmp_init('0xa81ec04be175e1c4caa807925572224cf9b17245f986981a75562d072d1fb9223f45cb5993d2439ae7f1efc2d46d9f6c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5fb6626d2e2afda5ac64af6b9510384936df86d261d65b7b934d10d64daf4b1b7ffae8ec5058352c8dcf5580e90ae976', 16),
+                    gmp_init('0xde0abbbdb9515f3b07afb6e4028fd7d091033a4a31ec4596b3ea5ef041f005f3ab1912ea830789a877de57881a724409', 16),
+                    gmp_init('0xe5c6781ab4dd0a2e3fe9a7b079c3d35daae38dbb6f9efac933314804380c8cb8be447f47e39d7c2b8c2677622870fe03', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x578cd27a7b05e765660dff2331885ee6204e2592e9280cae3e7ccd20dab4d32cb5fa5ae3e8996d1bc2b86043ec41b3f', 16),
+                    gmp_init('0xaccc26d8b662e0218f400b8fe8ea2ff246a47a86ed49b3f1960a17dd135604263a633a82c228576eef835da0840d5fb', 16),
+                    gmp_init('0x8ee8ef622169c6f74bd9848a93394e61337257d5c032f5b1af3d0a38673d1f611947b136a97a723bcf14c1589a7eea0d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8a4cb0c0d72f6fba01afa9b34bfb62b5f7dd166559637c3d01bea19c539c46143aec7d44711c5fef21f8826a63ada28f', 16),
+                    gmp_init('0x2eef4260faa42215f65d470a1fe6cf7d076f0c9dee5a86242230d681d8ae3f4e6a092415ea40d673d1caeec317f5b04e', 16),
+                    gmp_init('0x6fd7bf8e976ae82488288238d8757a424370867d3929974810dedb0061bae0daa173e75d22b090c93d7f56d88e038512', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb9e47bea4c123f5dd6840af46f98798d74c9dcb2c384fdf6dee442764a0fb3cfd055486ae9199b775aa3d805cc6b331c', 16),
+                    gmp_init('0x691645e04e47f75dd97197801f2c7c38b50e35914e041df19f47a60992edb87d912cb5997159fbec7debdcf1f55989f4', 16),
+                    gmp_init('0x112f0c06b627b3703d6f7fa4f19bb7042cc808c10d4b0b1ec7202694c1326f2d543cf9c042c55f6413b4f9a98b82daf7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xe6d57c895f7b603577592417912cc977fcf2b753ca160f05cd6649a830f450273f22f10191dee8b5622567cf0c8474af', 16),
+                    gmp_init('0xb1407e12440686a8523dfb6671a598399d34d53f046a2c8de5617caef6e6e89405c37dca843222e9e0e99fc11399a33', 16),
+                    gmp_init('0x64e767168b5660f384425f57892f2d75500ffb7f42252ddd35c5e3fe82a88829d22d220426b945c74054624a39a1baaf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca896dc346b36398d632ffd16897371b7ec8daa2720a2bb721306704b82fc571d5dc4602fa9c19760d95dfa80c92d05e', 16),
+                    gmp_init('0xf474b2a575f0d5165fecb2d69d859d6cd037d08e182c538730fa9d67d78745b7bbe4e953eb535de40b231c447b3c2151', 16),
+                    gmp_init('0x2578e8232483ab70d59f5d511c4ff02b4fab3fa4498812ee36c49a04945c7d1e461c8e8955809c37dae17dfbf2f3fa53', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc3fce8ddf5611fe881909b7baf3694c3730394f131fa51d449e5e7c9e56dd017c7f8341f4d8012f907c8f07d59e0d7d0', 16),
+                    gmp_init('0xe84412d0950ddcda61c834eb3a7f27cabca3996412fc37211c2a4d309e6a09e164e1509b2939f403095cca2f28b31f7c', 16),
+                    gmp_init('0x5601f48ecfe0f710eec40cdb0880ab7ba230fab3ad4f769c139b4acb2a18d6c884a2dbeec3bad613d498e7683281d878', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9f51ac7e2b8fb250ff4222f2e5c143d9bd9a9db9d06afc4571a07d81ca2ea599ac40e26e066a5bf08ed23a9d7e574169', 16),
+                    gmp_init('0x53e2df614654b82e88484d36595fd8cc3e547dd2f9e245af970123fde79ccf4cc834afd0dba94315d87b562b11558181', 16),
+                    gmp_init('0xcd66b44207f7c2bf2be96f7cb9360a6d4771deb1ed413446ca39c030e03e2ec9f764444e03c3299f92e90fcd9965bbd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb1cafd8a647b1692f4db747004e9f3fb657d4e47e74716a214e9638db41ffc41843b26c79e4bbcbad6285971cbb1daba', 16),
+                    gmp_init('0xdfa7567a42c554c72a11726d63179999b30ba8bb941a70eac029d51094d475632da4149988b492aaa4f527af6adb0e63', 16),
+                    gmp_init('0x7e643b884b7660f59fef730e57dabebda99e025cc98480c52686cd4f56685dc1c6f4234c42b48f51e6b3ed03af9405de', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5c2d6f08580aeb751908b18a95fff82609f73867be73041821ceb246bc099a9bbbfafdaf841e96b8ab22d7935ccf1e6c', 16),
+                    gmp_init('0x4c156274f35e955b3fd120e8b15ed0c7990ee20b8b76f6e71524bd7676d4e81067bda1a2689c3dd4cd3ea1738bdb60ab', 16),
+                    gmp_init('0xe82763a58ef78e48e06cf038255675d7dfece8c93a06a290f029117afadca9094fda31668e834fac817ee85ea0446398', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x936de93d861194023e7bd4cee588d18f542f8f2f1ae0ee6d072a3c9ff7a4942958bfa851fdaea10b008349f871d72a63', 16),
+                    gmp_init('0x88549016754ee1549ef300e2ac0a1270b2ae37b03715eef346e003b0f9305a6a5632fc991901a4f5b5073cc7582f460b', 16),
+                    gmp_init('0x85f5d7f5bfdcd97ab06066254764a23a77056a37bd52d2f23a94f6f29ebf420dc722e881ba64a28e7bf2fc8e97d6c4a7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5bbd1455f64c6c5ea11a722e3f6e424b9cef3a462daa84faa5f0d7b538807977e205d73853ab78126298ed6b6b711295', 16),
+                    gmp_init('0x65a900fe7541b240bb58b6267a42a33d03ae3f0a56f28ae81b3e1d24e0b36c976dcf5ef9e0ea34897315446c9063ff63', 16),
+                    gmp_init('0xf694fe2922072b07d4e4d6dd808911d3f586a1b0a2100a3018dabc44e20d34b6b0c2e6cc419ca0af86349afc1ad20caa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbb5a12b2bac5bcd302cf11ffdafd123686199b8c679365f0430dc617a2c86b1aaca928ce02354dd0ff8e86b21dbcc95e', 16),
+                    gmp_init('0x75fc73c5ae5a539b54ba76e89143e68d2b076a7d45d38ec9ff89715b4207b35f6921a1fa7411466b51e06dbfb543d854', 16),
+                    gmp_init('0x46ad5eebfec8c132346684bb1aeb1ef501514e6cbcc96c008a2020e585d302e793f2c76bb1af07e9d928ac4d86dd8923', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2954cfcc64bdb26e03631e3b1105c3a461fe949ae661161778af4173ca111d93e452b3d90a84bc5a72fc3f9aea5a4be7', 16),
+                    gmp_init('0xda1af1ab3919c600376f4b706c8533c5a3cb3bbce22277efad1c65974009eb92b3e38415fcf04270a06661e87a053a31', 16),
+                    gmp_init('0x23d5fcf8d30f335024fe1f150cd8b205bd9fff0380857bc7aac257dd0ef5ddc09c7637c18d1be7c7c5d2ca670b5d4f5a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf795239e56a7209c52d2a89b404cc7fc847b7e4eedbac9c01fd5fdd247f2de1a3771d2bc1b88633678b9ed9f9b198ac1', 16),
+                    gmp_init('0xfba56e80dfdb8ec84fc2d993e789b7187833f2298df6f4e8830c45f78664b8a083ca1cfb35fac7a8fb177d4ca6d32ad3', 16),
+                    gmp_init('0x6f03ed215b0635ba5f01f6ca4095c9b8ac5eb9be3a41c82256caf7093617d0ca14f4b86351ec2a26e822ff5e793ca9cf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeafb0d8824e34c3987497e5d0c175e1d29a8a8941c00668487ac5a1fe68b3c265264bfcf833dd7fc24291944e79e104b', 16),
+                    gmp_init('0x7f4836e9b0532fb0f9fb97f7361ec78db58439f8d1bbc6446cf6e525a09ee6effee853677eab20fd4373854fc8a3cf9a', 16),
+                    gmp_init('0xfacde450042cfa938a193b14ed3937009c13a77c96c3c2a43d2f49b40c2c6f7028634695f53c19ed253f7c7680cb79df', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf8fb44649224c55e21a784474fa81e4e0855f2b7146b8b1cf7b6b63da6fb6203ed0133184b62ef89f7f44b63fb39e067', 16),
+                    gmp_init('0xafee99e3fb5eaf5edf5eaba3ec65804427719af9bc36058112896c2e93c4dcf68bba359fd93031046821dbb13c781992', 16),
+                    gmp_init('0x2a4e976c1c4ebe53304a47aedd831b703b11c9ece76396bdc3e824d2e9bf3189dc36f1354202ab0c7526041cc073b3fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd25c82699a4166c45d29cb8d093b6c4877b2a9a1071020acd056fbc98e19cda7264fd21606bba1cff98513f7b70c443c', 16),
+                    gmp_init('0x8622a960d05b6dc788933dde6675ada78bf39c5d65c05e63d930d11707165bdcd32c60e752991ecd9ed1b8c574ae2c09', 16),
+                    gmp_init('0xf063766975011dbbed5d717c06596b8c9effba8dc3cf3de213384667564082b7a2fb325f209b93e1c5ac5867585faeb3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3312ef96ebdf71488df9019b05db139ed2594b477dd051468c25e100f16c75fe9ebc584fe3598898784a61ba386c169b', 16),
+                    gmp_init('0x9f18699d4f028478add1555b7fcad7ee508e17df001e586171dc09873d49c1be6909cc5eb8674b1ac150fdcc6811b886', 16),
+                    gmp_init('0xd67dd52c98fe769bdfa7f011265aa489432eb4e42a624e8d36493cf16811856dbe15227335caaa48becfd6abd2a18234', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x3fcd045093ac2fd99cda62ae167aee4b3c5a28cd494615fd584cc671d574dbf3b92d2ab17b8879d26ff07f495177552f', 16),
+                    gmp_init('0x36b5c0ba32705c9439b266c6112052c079b2057f569da47a8be8956d2550ca03ba1b28640c75b01eb30a1ff9873eead0', 16),
+                    gmp_init('0x661a7e6bdcce39a37a74f97e38cb768fcd1a50e71dbdccde4b3ab093e4c1213c16400e85192af4d784f084a8b9f11bcc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xff0917634e2dc716779e72238d315a9cc9dc010c40b8c55c284643184ded1a14d75d58b4173098a9d96c8ee1b335c850', 16),
+                    gmp_init('0xd418ab6996b6bb399b4b8703186dbda9180e8cad7670e1fbc32a432c13570803cdc84a359604bdc16d3d029547769426', 16),
+                    gmp_init('0xd9b8905254d0d861d7e904cef238c58587c7ebd35d3b205c1f016e69eda4fc8249aff2302972bd7ab277a4efcba2d8f2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82574f70655bdaff80742d9681161e2f130cebba2f194b032740cb3dd2334c6119083759243a97283d431c136d593752', 16),
+                    gmp_init('0x9fed34274387fec5fd955aea69c2b05a7bf1db27d6b9efe67695067f73f44c69185064bf77732ab8830c9266d85a9f42', 16),
+                    gmp_init('0xb37d97a477d61c093f2b91e81999acbc4925e093e722f701bfae28cc82dc17385c04b913bf4c2bc7358e532529f853fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfee78ba1372b94ba5b74766c31ce1bbc34aff03c2d090080caed7547135bec650fb1f9a34fba585022ac01346dde2eaf', 16),
+                    gmp_init('0xc42d0ae1300cc4112d236fc15923e683247c27031be3b6405347c905046142de28df83ca3161c6d8d0482d9648ad2b3f', 16),
+                    gmp_init('0xe4a35acfbf0fdbf328d9c60b270e21f22e210d091545e5b573419f0476568b32158e1cd4ccb2a49a6a9746b67fa605a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcd7011d9b55f9afe79c763c627f33167aac596dd8a8c96d468d9624275434e2751f810bbd0f5dff0513b8f59815975fd', 16),
+                    gmp_init('0xf3c3c5ebef91e2e186bcdd5fb289a34182665b207bff9dab226e408fea5c2a566c4d07e662b9b206cc42aa0068bd7a83', 16),
+                    gmp_init('0xbb273804c67ee88053d8ffa7ae363772f9fe4b3192dca57f969ea6e7a582fac4778a9c46408baaab6eb55279cf3bb153', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf62691178f9d815ae45dbca66cf7ef709e4b848ee4b4147d2aab2080548a79ffeb91255352257c5a8c7f0c34591b2a78', 16),
+                    gmp_init('0xb321367b0abfaa64484d776a5020da1373df5d969b0ed56d0247bda07137082b54102a196b4ac0cd6e330c1bdcbc6fc5', 16),
+                    gmp_init('0x8c38f3105f1034820d93df6b7fb1def58be3bb717fda8b5899ec68471fdc7730cf3b5a2235c014551b6e2377eeb998b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9b3270e38e279fd035aadb536f97e9ccbf47f2cd72e2a05bc535ef2ab1653f86becb91645274897ab3733f446d864bdf', 16),
+                    gmp_init('0xbf2c5aea4dc821eec15c07c9822202108f6007208eeaee05e85f588c856e0600933a36fc96c580da08bebc507d440554', 16),
+                    gmp_init('0x3b8cc2b3920d7fa96c918f3ba1c1bbbdee8ee0df5cd780e88195bb762d408ee721318c2cdfd86624fb0bb66eb909457b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae734bb29196f241a794d2b830506468db7a3ef3a061f70f139df88e7fba58fa5a2c79ac219685fe2d7361248992da38', 16),
+                    gmp_init('0x1df58bdcab67f96c0cfaefe967248467bd33e26bbce99219ad881e656ef20d41d7fac34f564f0d932ba8e19f2e08dc5a', 16),
+                    gmp_init('0x494e3c07dd8c66d52dd3795665a8118dad291f344dccee6ec685ca71f7c7714467ef7bf34bc99f3fa83167c95a42ed42', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc516f7c8c52111f58d912df7371e4973a276097c7c0571f5c1016ae2aa5ae26ecc7072650e2e5b48f833e7d8588927be', 16),
+                    gmp_init('0x2644e3a67140e0300848bdec4196b9223859eed907f8c2d781e108b9d85f23266a59975c3bb62745a5113f0207b38e1d', 16),
+                    gmp_init('0x45f8dd948bd7f7e12e2641795ab5a607537c7b1e71c213a71141548494ee7d07b63a2de95f89c04e54df63b57c5bbd28', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x83057d21590587311a842a047502111b2158d5a957383b5355b7c40cbdf342523318e258550e898ae2cbb85e71385f76', 16),
+                    gmp_init('0x2289ee523e0ae25de9ca52078d07e12a673df85486de9f9482d8beeccc270743163d579601db6907c68521117929ece6', 16),
+                    gmp_init('0x5f88d1bec3eecc64c70b7d9197ee184e951b7587a86afbfcb715f4f17264738b5bd60fdbe936a4542b9b4ab19ecd67ff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbde3864f5a21c053c86f8e96103e50999647e315e0a047e6c976f87a66551bf092cf2109d9fbfd81cd0a76c9fe60d91', 16),
+                    gmp_init('0xff3e3223cde83f34fb2be787a44b1481b9ef036b3cf23a700e2593424acd72a34bb8ed7c452dfc2f5354f457524eee05', 16),
+                    gmp_init('0xe971223eb7115614da8574876519d9a0aa91e173afdc29cde59f195ab1c9db369ebff03bcfb2af7ee150670148566908', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x51ed04ccd2e4651d0f89819b3fb1b3338406d380b555fe4960b1ba0e7a62ecec612d21aea61db911603d7bad976dc47c', 16),
+                    gmp_init('0x41853e1bdda1ed0d5c1a825c122401770d7ffdaa15365307a3a36f27f46d6221725132f4c4ececc6106e4a89a2cc2539', 16),
+                    gmp_init('0xb4fb69d33b44585b976fee94030408c9973022110ca046c6ec8c51ac8a3ed7a2ccb8bfd31c48a19cf31e26e260f2432b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x95a78baa7d4c97ff0582e74518b777409b00d51eff92b96cef660125c846d56d6dba5ba21e94737ffa16fd314e2afe0a', 16),
+                    gmp_init('0xd528c9bbcb6317cb1623db648a0f0c4d6d4448d3d7efb25fa64187268993e8895eccecc60ee85f2f8b525292d93652af', 16),
+                    gmp_init('0xc6f5fba7bcb36c351e09c238271ba09b2160f387e26825144c0ba50f1c5be25e50112a1501cbdb79e78954701e226964', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c295c214303a933a17fde4824c0b1b82238a9b1f3954a0326cdec8e3519b1facc415f84f49d47a341a88cf08fbfdd38', 16),
+                    gmp_init('0x416ba1be9596193206c51a2fde79aaf5681f06a2c4609afaa4de4a8c980fd33d89c0d1d63e9836f28b25f715a66ddb9c', 16),
+                    gmp_init('0x5d9b244be3cc686533e07d38cb62a756cc9d36cbec023e816bbf4c220d46a40cbd533b34b47c6b38583b389a5a181dbf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1070a5ff279971fd77777998c58847c29a714e9d1db4460e76c24cf78fb5be44691fb9594b236c31bf64478f2b6af76d', 16),
+                    gmp_init('0x3437ab1dd5180d855b22d7c1c7fad105a54c9ec30d459c56a1cb8ae3fe169f712ca0c8e1fa6761da7b3b9ae1574ab1c', 16),
+                    gmp_init('0x96ff2972111e12d39261813ae2ef26057a6f5c5ca198b44c1c47abfcde98f6bb350a0b89499005b36c2cd1e9896aa6d5', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xd56bb97fb626da4875d9475b44baaa4ce5cc00b232c914468d0e92d497834652c85945bfde57eadacda8e94af9d5664b', 16),
+                    gmp_init('0x9a6e0fa66d95a79ed71f4f243336faed22a54b0bcbbff2017017dbfb05a7ce0bde8cd29dcf5c2db4804ca89bd470bba', 16),
+                    gmp_init('0xaf3f65ef252ab1cdee450a38c0c985b97ff12d35b29dbcb3dde6852d2111b25fdb967dbbf71897e08f9343e7d5facf3f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x16e6b5f6c14cf40f36654d5c93f7396a1bb3106136f77fb1f32b039cda35d4054d5e05409823e3d2514f01a413d3e3a5', 16),
+                    gmp_init('0x18e25bcc8ed421d74ed992e8d5a662cbcba9c17571f174e0cb4c1a0122f55eafc1acfefd96d7631af9201f2492db78ba', 16),
+                    gmp_init('0xedf8c690168f26332f5bc73390995028941fea00c246f34d717c260d0ed46f50c7075176d6874f1cb4df80a5722ab786', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb7c19b4e6efb67ceba18e5f49f661cf253795d70d6df625c761f136ebdc1fe4382d716910c2d4b8f4a0a7403465d702d', 16),
+                    gmp_init('0x24fabab0df8aee5631188b0d316ce9da9f90e8e43717ba8a9411e23751853b734cd82e6b28277740be128ec92dde77de', 16),
+                    gmp_init('0x395de8778751e018ecd74d6f4392535f6f30340193fd06d7c9aa425f7f97c0f0ad3d54f6000fdd28dfbe93afafb1449e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe28ef13e35a93609ed409e639e4e2e81584ba5a49842561f385f763c7f2803933d005f62214ef7b92e5dfc5238c7acae', 16),
+                    gmp_init('0x56f4b432afd2fb877de9888ea304551a2848250096dce160bc8ad69d2e719195c8f1648ceee84b257282628f80cfb0ef', 16),
+                    gmp_init('0x2658a5e2e82662e1445d648a78c2fe206c282c068c1088f98b554fc92ba66ff3ffa5e417522efba15f6b02de7ae64f4b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8306902dbdddd034a67a2266a67ff17c01b4676a47484d739560da05d3e0a87079933b6f886b21df858e0c7e820bc1dd', 16),
+                    gmp_init('0x8b475469ae4e678ec9e06bf788452952a7d95f3faf43f1f81b08a7d86a56031cf27b04e062feed7401db2175a51692fc', 16),
+                    gmp_init('0x69fee0e0c3b585b806c986b8ec9de0c0e12b7cb4fc767b0fbeb23608107f0978f41daa463bb0c36fdea6e0905be3b2e0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5a3962fbc65eeda66db3d30fa257da40ce4eb92b5a9f6b14bfbb6904f09dec3fa04afedb83342ae442e6a0bf3bd4db8c', 16),
+                    gmp_init('0x4c65f5150656c14c27a89867a5e7dd520aac8ddccfe7012144e6d8ecc0848ed30c36e57a0d43119ff58c9de0afce6f0b', 16),
+                    gmp_init('0xff63faf0688bb2730e963d12400774814cde239475ec70d62247751d500b3cc589422c58cf8b093fd5359dcf49fb5ef', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x37290c3213017d345b775adc3520996a40e35f42e05e490c80205ae68821a7bd24764689c3a95606b76e7117bfd84774', 16),
+                    gmp_init('0xa7dcadbf736287b3f7b305b81a5b401bbaf29efc8fb7d322e4ee6a0aa8399f6ee1057232bc0108cfe59b0549976627a3', 16),
+                    gmp_init('0xa68e6d469f02a607639e579e4f286c7455170242350e93d4bc6c031e117135b7f31697f6032739bce4c6aa55bf80abbe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x80f752fd89c6e88876907ffe616192a3fbd5622feaea655c3853f611c9767b3d90cc4ee56d263f0ba96208ac34080e21', 16),
+                    gmp_init('0x93ea8321c0d5f9b140e194f6e3c6ea7de56721d524c9134b0ff1bb96ff7aac798877489eb32cc20dab16144e79c17f89', 16),
+                    gmp_init('0x3cde1b19fe226459fd335e4f0c8afd3d69306d4b99265fa9469d0ee6ab79132c34d42d896e81932a5e46fc5517570a52', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb781785ce49979174db22a8633d2f3677f63b7473f668aaafb41e1d0d3a772dedede4b57210b666dbc81e8bf71afac5', 16),
+                    gmp_init('0xfca409e3cc7d27bba5fa646055d2b3f3d0d10ead68b33bdef65c1ae323f822d61acec8f9dc93cf0fb8182446aae832cb', 16),
+                    gmp_init('0xa5734aac2f7bf46cb372b8d7dadf5dc27a4602701a1404edd4f3bb13d891af451c805ad6541056f5e1f0f8db61762a1f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82336c7429621f94a8b6af043fbde285403b62de85fa5655296b0c9e4e5c09d19646bbd010eb43f6debcfb4621a9403b', 16),
+                    gmp_init('0xb87d6c3c266cc4d18271be6e798ad1621fac084cef80dfe930b223896f98888a2ce69ed5312831c9a5ba799ea6184892', 16),
+                    gmp_init('0xdd27bdcca0c39431ff828738339d8407870984eb13f8c90219b733f76ca05b9d461de56681b4e2b9da4c75f090e7db21', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc5878d072b975593fa858ca74c56d667f7600524965e27e9a5cd43bd6f1ff84d706339fbe2ccbef91a42ad9c93b9266e', 16),
+                    gmp_init('0x7d23fcefdad3dcd3ea591e5b80f37de3441fadadfbf1b66a68385c5462dbb35f5c591cbc23d58337288eed3915d714a7', 16),
+                    gmp_init('0xbbdccc3b09fbcb8267d9ac7e0561e740986390b7f85a4cd750dca4ca3d92b337c71b410787f364ea5a5958fba1c8ea32', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcf7dff466863579b15a8800eb8415a4199f1e9c890e9919c1293b90cf1f55dcb56d0d9767ad6379b5378e5558a88bfe9', 16),
+                    gmp_init('0xcbacc8e292aac86009f597888c0b7bab5442ccb9536b0bbb39c4f83ced9baea13142eb16995f848b51073ab0a43dcf82', 16),
+                    gmp_init('0x373ba4bc15f177b3e12d304acf47f6ae1ad73e3b3f893715cad2d341c16a10b6fe7ef74835d909b3a10c9f6236dbe3de', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7d5cce5fe2c75d98463379f3bd61c9c2472c1c622c647bef3f800dfe6d5d4a3a8102cee4288e086203eea6efa44a1fbc', 16),
+                    gmp_init('0xed0bbdd711b376b7454aab4cec426182b514a25e17510931d78dac059f9f307986b7cff9ddb5a60761403a91e576b81b', 16),
+                    gmp_init('0x4461bd5aa79a362afb197cc34074c86901d0f5af8b491e29a5a72fb2b064020a911bebf56d0a8ac812c11e31062d1cf3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf9b8339239b03d79a068aff9629f266c8504c8869c56d4c3bc02dfa72e58d9dbaad13b3bf1abf7d4f909ecc79ec4769', 16),
+                    gmp_init('0x29521b108b43d1746bd0f6600e1fd8ed723eadb42bbae5473c32212a0a948f0a5fea8a24ddc4e3a60f7cf438e7104279', 16),
+                    gmp_init('0xb36063dce6db443314d96bbf1dce3800489e8680849554c9ebfdac5d3281f51db4f93ceb2adc3b4b2ebe80d3d7f237e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe04b8e68221308f9331b9496b36d346ba7e5574f03219671a13ca13a3468beff79af432ea3eb55a116fec6431f68e51f', 16),
+                    gmp_init('0x3031fb5003acdb3b94e61c1e3c4ff940b0719db38fa218c26526000991618ed1af0f1dc3648777530b7fdb37a0332bac', 16),
+                    gmp_init('0x8a7b704b6187dbcef08838707c4a241b88e5d19e23ebd03ccf5cf1750cccc910ccc4efeb6ef00453095f626c1b8fb8e2', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc9145490c22dfe4a998079c6e934cbb527826197c000f8015d387e11273f0a637662cb3c9c2adaff1999ed157e384534', 16),
+                    gmp_init('0x4d968823a311bee1d2300f8a13c9c88ce9bf34a88dae53864a9ddb9f0782070bad00fae605919cdfcfcc227aa12e9a28', 16),
+                    gmp_init('0xf5230d8462ba6a0bbaf48f3f7b8ec889942ec4bef8bf1c19aec8a97f9eb5a386a844ef8a6078b2bb2dbb58249ea278fc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe158d83ecef8c355885a2e2a40564a266223ce70b8278e0efd616721f80785239bbd87a2d20f9f984b8e96b34a0f6e32', 16),
+                    gmp_init('0x1113597551ef60049999e7d587ad9701204762c5db58303698e69250a4b800092abb789273f0578acdb549f46e0afef6', 16),
+                    gmp_init('0x773156ac58e0f19bb5515f15f1a6f9ddc6479a08f20030012d2cdc7d9c5831e9073adae259d8fbe24e21731a41414660', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1b94d28f004dea7673863cb4d620f57ab94e9c15493d5e553227bb678174c3e8df8f94b5ac347509b9108875aa57ef75', 16),
+                    gmp_init('0xd60dcf72a21554594891d11c3bbba1df7c04701bb913d8a0dc8074f93898bdef1701189de56743079f241c6c02e83efc', 16),
+                    gmp_init('0xdf7ff552220cb78126c059370101798530bc77fb6ca363ca4394abb6b90af3fa5dc87cfb4c541aed3376ad7fea14d778', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x465799206edc2827d18524aadfb69eec6e2ae9af6472a1caa0d86241fb1676475f2e8de96f268883381aee6c15dc16d7', 16),
+                    gmp_init('0xb8058034a3c3e40ea32eb944161e057314aa251cb2926c39d352eebe0e2922477a04629fa95bd1983e30c3495089a002', 16),
+                    gmp_init('0x7dfdbdd3e95af7fe3f49a223bfa2635d15d019e9671a72eb5cd0526663d997c2a46fdedb4ac00c42660093e1057a5aaa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x32ada0321bebd8f6fa4e4a03ccbe116564199e4a74dba1d8385511512faf5d0011adef4f525d9f693dde490714e627d4', 16),
+                    gmp_init('0x2785472f59cb6df1a693c4392766224d1259380266025f9414d47a19d8228d2343bfbeaa14ea08b3acc2f9fc86ad666', 16),
+                    gmp_init('0xd99491bd36dfaa3a286f7b8163aee461dbd1779dc331ae1dfaef58784836c2c25f689689b5e4465c434660dd2213594a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf35715726f61f754a4f2acf33e8ece4a3b51d3774b77c75786ad26b9789eef05df2b53cfe475d53bcd0961b0ca5e2b89', 16),
+                    gmp_init('0xd1f70c8f443c303d8657a6871f05f8bb17ce98a3f3295b4ccdf5748697eeee5b7cf45f35ab3447bbffb76b70015a4d1', 16),
+                    gmp_init('0x1c4416b3929a6856e8da79006cb6e8d0fab9c7a39b5d4598d914ad116d83bd79d71de92bfd30a8b75bfa619991572151', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3439e28c334089a69835492b50da11e4416423259e58b48ce8288804d85c167db5b979d9610d384157c2a865dc4c09b', 16),
+                    gmp_init('0xd7ca48b716e489c09299ccd5ecb4ef7e23f7a1217a68d4b651e1cf4bc8ca9f584ec37338ef134d10e82f89d9b2e2e078', 16),
+                    gmp_init('0x5bd9174608af2c9bd097bf91d40c06e45ee10674fa0ba00ef25f1d367848897b615c46772639de566b093f4dfaa2bb86', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x400b1a2bf0b37622c07b822992358370a5ead8f6aa16ec3f0208b2b8b4521e24f47de61d25d2b4218e7551401f071a1c', 16),
+                    gmp_init('0x724357e411867e5e9374ac21ac9ad60934b340997b99c926ea97610930c8378c760b5e88238059ed4f9bebab6f0a7886', 16),
+                    gmp_init('0xcf5101302ffe8f216b55aee7aa9ac8d8827bb8446e21e8fb7978068f1f33e762235b6cc788517b5b13e202cfb6cbc4b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x45a1e657a66621f01637a29850937d87746599245039e6830a4dcc7d38b2df7eb884ca16a053918d193116e229d58ef4', 16),
+                    gmp_init('0x8a6da0335dc1397300b8a92387dd3e7b6d725a490af4db932c31161a3d42092183b2ddac057f8b8f37f169c784731de8', 16),
+                    gmp_init('0x4021fbb14e104555cdfbdf43dc8ca70698e4631d23efd47139a8781fb79a86f7f249b5284f20ef7fb09006b5ea763a0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6ff16b24667adcb81e5ebdeae792de3c050cdb95eb5c16d89270b7a9e5e9fc613107e41aeeade72b85926971a28e0d0f', 16),
+                    gmp_init('0x26b97a81e8735191b68505a5d6777ad3b9816bd6b2b17a5212053224b7ae0c3e465ac4d923629919a9ad4035e4811ed5', 16),
+                    gmp_init('0xf1615de794db25daa07491bc7a1df0752c84d1d79661be2308af5398e29ac3a46609ef8e11b994d2ef752feecc45865b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7767cb56b3d50bba9dd722eb8613fdcbb950ed5aaee4971a415df6c8c35cd5f0068fce04353bf46ea0427a25b818550d', 16),
+                    gmp_init('0x46b54824731fe8643a5cdcdf534b3743646a03f2619e926d15a09f168319371013dd73cb2e1c4643f5f493a829dc0d89', 16),
+                    gmp_init('0xefe67a44d5d0b5ae41882dcfbdaae371795ae3a1d65308eefa5fa097bb10a639abc9f87e80b381bf22f982c1bfef9c0f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e1eda740d9d411d6577a178ca0505bf5cb188014b8da30c23d37df1e728d631e52221ff03683cb26195eb8ea954dba9', 16),
+                    gmp_init('0x39c37316d419a9e3a9c320c8792e75413f3bb85113f5f54a4d24775a979a401eb0983b54ee6a73101f8afe45d215f3ca', 16),
+                    gmp_init('0x39d58b301d10cd3c2bfc198f3f8310cc48c2a05550efb6e1f0f48a759702dbde97872cd3e7f7b00f25779167fd7df02d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x273fcefa082ff7b72410df0ead7d44cdc6979e46526fd346f5c3e68cbafa9b488bd9015d350059cc9748046a0c804d60', 16),
+                    gmp_init('0x771330b02d746629645a8129419712758cc94738db8a30d3cadf8c46900e5da29095ea3beb04e423d20e5868ad9f9ec', 16),
+                    gmp_init('0x776fc048842f2e1941854202422dd5df35c9c3f17c5e84c9b122a2e88139b3abda066fc5693e6b8796e6083c491b1e94', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeec3526336d4187e86c85294bf7f73b5ca9587fb750e947c5bdb4c66014785612d2c38f486917db30bce73118459c192', 16),
+                    gmp_init('0x1f075af91c18b21dc046d6656df3f1f8161a8f9c9137ec46ff6bce2000aedee973c2a19b8728296af762c6700a09269b', 16),
+                    gmp_init('0x197319e63e385fce6a23edf244dcf22f113bbee6efb76a12ea19c614bb5314d115a947800b044de739f61c41025dc732', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x20e399cb77f86a25202996173e645eacab40c0928792e08239ad806997c734f7290a136f600a7d50578b7c40caf50ed5', 16),
+                    gmp_init('0xaff913df4def6c56eb24c40dcae8351bf3e1e221d12c41087f2e419d2e5459d9e6d03221f7b8616ec9ac2504c4d353b4', 16),
+                    gmp_init('0xfb0d0f006c495d33c777f0fbfc815a0b049ba64624946753833b7ed6505179133f244a3760b6e756cd0cc1176e33518e', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x2647fb633c55742d085c5dabbb2cec3fd4857b79fc4118ad54aa6e8fda537d894303baa8ebca65df1930de9033e33c57', 16),
+                    gmp_init('0xadb51560b97008265ac819e80580f5d7ee7c1d7921304a2a336d9b977e3e9dbe5c553e443b4d1a360954c8eada07123e', 16),
+                    gmp_init('0x6612619598b6e1a48d0b7b1b074aea73d5b0d0db43a26607aeeb368ed4faba6a7352cb9ce9b6db498c8296e1b8ad1625', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeadb6409e9577ff1126404b93de1f39bd150a7beb96272fa8cc35fe83ea20beb5f16dadff602873b8f2cf958e10c2241', 16),
+                    gmp_init('0xdf479a273ec537950ccc2c289c719bedb2c5c6822f74adb6bb328bef058bc61c2ee752cd8881d6af93409635f2d5ecc3', 16),
+                    gmp_init('0x2fa4d0000b3a4342249b6adcf2491cf403a79fb6ba9c699e6d29d80b7831fbe053a994c83b064ae39159ffc4a2b84625', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x541390cfc52ab0bc41af00a1e88df2a463a31a36d9bcb306fefa4bffe3e415fae6d2f96c42b5edb467af8f27a8af5994', 16),
+                    gmp_init('0x7637c2efc9ce3344d04e9562a9d178b3c863ccdfb00a731adc8d2ed5191f7448c33e0056e14c2ba9ef217e2f9155ad94', 16),
+                    gmp_init('0x11e9ca698c2cafbf19e2122891282f39a9c817bd285f2fbe16ff1b30f26641fac7a7d4526c1f7741a1b74548d66df4e6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x653e9b0a6ebf7288c762744369b076b942669e48bee55bc3be2010fa154203af2b025ed46514c7db119e16f833818af8', 16),
+                    gmp_init('0x2848deb20f94ff76dcfee2217d1f9d7f1aa665c73b32acc7a60fc17594fe9da3850834d7714ff2474bfc0fe08ef7490a', 16),
+                    gmp_init('0x11d24fd007628aa792479057cc060fe44578f9a9585c26be190d9039fc1501de71d6549f7eb208ef48c273120d7930a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1115c56c4b867d0d1219123fcf44bc77c89c92a082a9556690768d6b2fd78ebd512701afeb73bea152b7e20ef356e924', 16),
+                    gmp_init('0x3d68663576cac3dc40163d55626744d5b84f3f972472b87a39eaf891d5ca103ef7eab4791d10130dd3a7d7afe6b8c026', 16),
+                    gmp_init('0xa076deb9b4150c07ea1778f9cf50fae7ead6ca45bb960b0fae911b1bdfa5fbab8b774659fa3bf9befc7f28b9a9e9a8b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb318c67da28780c7dd389465e03875fe4a631785a5a17c366da1aff16e2a60ea958e0e77b92feaa9d31a372de69d9cba', 16),
+                    gmp_init('0x6e5899250825b2a1d59f900e277951f9b951b2fbe72bcd74a208b06cc6833399210431e36cb4d565d714ccf2b46fd7c2', 16),
+                    gmp_init('0x646d0352ef79e5add1f2cf93b02f50e79e86fa84ac5c38414f45894a70f6f9ed6a741288d55da5d259b9580e4657d08a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xddfb3aa21d0f12595d04ca72c51e43e5160e52f9b35b87aeb17294780154dd12ce9350338e8d14120053a9bae69ab1f4', 16),
+                    gmp_init('0xac79431e6a0839b8a78c4b964b3829eb97ed61aec5e518c9a7c7a52e6c66de4a962db0541d6ff342a97105716fc3250a', 16),
+                    gmp_init('0x7b6ff289566faa81eed90bd170052bfad23f51d80537ad155a6b9304b407e3eb1fad1ae5a95d74b2a4ab84788f85f200', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7d873ebd68876b89d297457b1b51bee21dbe3d914ce6498e5966ce6441612ae27f56eb1df78a379ec82c5329011d3725', 16),
+                    gmp_init('0xfc09db6ff05af9efc120b2f36db035835e4973dc45e37b61df37f90911fd1a6da6c5c7a4e674b99ae4fc8e23856f4c3b', 16),
+                    gmp_init('0xb4f37350a2df5d62fbb4575bdb94db95c7d0b1ad0e7d263d4806ef1d40a8981cbede45e152d869a981bc5d22ae0f75f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2ba6d9e8cd67468fdc236400930528df2a90eb576610b226edceea388346e765099a354ab351ba0fa25a3977c32bc270', 16),
+                    gmp_init('0x1b72c24c7efcc2dd7627686afe079b41f4705a07e2a734472101b6296c9bc8ca79ba5f5d4214bda276512e07a0a33be', 16),
+                    gmp_init('0xdf7c9e294df41ee1f0f2af4e6ff26cf92d268b815f4ca803af6be98d6d4b47deb5bfc083b6e6a934ba6b6b565492af23', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d7c823874408598ca317d8a482a6c62d429f1c685790082cab6c72ffa81c5052813a1786c1a529a1fe67c182f1092f3', 16),
+                    gmp_init('0x5de2573aab4f713d2c8578cfd5ecdc976e89ee4579e3715f9d39b29487094270b4627e25c04e541b84db743ca04113a7', 16),
+                    gmp_init('0x3271e01d2e4ecd2a388e9ce78e4b1c06aa278a9a4197597667fac6fe19f4c159da5ccf14b02b064f25f5d0d39b3797b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x19d4a5e1c3119d9c6d449a5202f4e3db7b90945d9c0ccf4e0e260c06ef4ca9763e012e974be05445c9e6a42fe53643ab', 16),
+                    gmp_init('0x4c3fc65e8b2d48d7886fe58855108cbb988991bca99ae151483240ad57ad9439614256c970c2218228e75a2cd73258bc', 16),
+                    gmp_init('0x1c58d83003d1c08aab54ee1a98d3a95c4c118772f45db808a92445849bfbe8ba901c27b5453365fbaa016d70ac4638ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcc288eda09e3d5739a370ceb1319e01bd5a5021b1fdda2e99907187874683376cf13b114759b563ba3999b3b731f9b8', 16),
+                    gmp_init('0xe94a6f44cdfd31186b4ffd614b562f33f6d9f2d19ae6ef12b5e4c0b61f48a5755cd93af2ddc7d80788a141e0ae9fb4ba', 16),
+                    gmp_init('0xbb56e8dbf7ab295387972aa7fcac8f18166346e4b2627016a88054bae8b0bb7c77555bc78861448f56319fbe9ce38d58', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8aaba1f96a38a286ded318c4873dcb3fc5e30742be530b2fc1ca288e5b7b80a700958942a10a6fc1382df1d89e00a28c', 16),
+                    gmp_init('0x8389896f867c3dead56b72af460b1d0619aba631489d3afa0da05cafb019900b736c587210862a49781be6881f5c4b10', 16),
+                    gmp_init('0x12f01196ff75963d0bf49dac4f244ecbc322ca4ab279bbe118d36ec4b9c3364d78bd5ceadd2ebb81ad223ed71d0b3b5c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe99df3d8215bd8bec05ec962fa1362956d0150949060916e3849568804ca25f6badce24039cf0f8e6c2defe1733c3b', 16),
+                    gmp_init('0xc7d865beb67d9b30edad60e2c8b14d26facada189458e72db2d66482465be7e13948d4f094360704dc4b68d1d854a5a3', 16),
+                    gmp_init('0xa8fb47e7be70d1dc9fb953b4574e4863936e033f856a91ce5ec851a57fb33274f40e340f981d94333f066d0b6457266d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9fa12fa9aa0f97ee2cdcebbdf4ca3e9f08a1a611d049b7e2ed640275f9104b4928fae3664d5ded6e7c9b55bd2c25b91e', 16),
+                    gmp_init('0xc6bfddfc060934e2638235f5fc91cca0aed2d76129c9f801982015b718ac253e8f6ed313311da95c5c9bf60799e9fac1', 16),
+                    gmp_init('0x6f81f087f57ea025f38d56549015178907de9359def5077639861473bbf1b7ae0aba8f2ccb022b0abad014458e5f4c91', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x3da62ac9cdcda2eb25cf385ee81ab216ec85e04a00cf11f69a7a700eb523f199fb1a95d18c46ef9aebe1274a438ed423', 16),
+                    gmp_init('0x70d9f82decf7321e8f5ff5735e64163f4c0bf4bd84d62a7a3b815e1e0d36c633cdae4148422ebfd65a5e77df26e3dfd8', 16),
+                    gmp_init('0x580944312e13c545b58b95bce708818e9eaedd272eb11c0bbd8600a38cd838d7ccf347d5b01428d042f94d743294d54a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf0ec36f631c930eeb57fe0637abb3fbc93d269ca57c39b240b407eee6b5f8f75f7cacd17219e1c84e4c0c59702856c01', 16),
+                    gmp_init('0x5897b882967a3c604f214d5e5afd43cc8e1e6db439d7ffabd73547bcd04013952cbb7eba87cf34929cd6d010466ad5cf', 16),
+                    gmp_init('0xf024f648e0f936318dcd81cd22e57f3c9154fc7541d1eaa276a0c170eab1596f5f67f25dc223930a652b02ca519337dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf54fca49cd3b26d11d66f4a65da8322d773f61b60bc3f6c6f1b95b6eb5dce0bfe1f8d7e982b79cb92217d198739a6fee', 16),
+                    gmp_init('0x3a83b3731414a8a50c4c139feb6c5f854e73b8446cc28d3932dda326a5b276fda59e90b90e12773f63bb32f3f2d8ce53', 16),
+                    gmp_init('0xe7a81f55ccd2939c9dbfb7528d9e410a75658cbeccb5d3f7a65de37385cc20a632d384d0c31bbd87f0dd3635a4841f05', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd095a70aa307ca7705a4e4c5b0893c3f9662385ea209c5679a68c5e634233b09b1093c973a0891a35a0e8b33b6396bb1', 16),
+                    gmp_init('0x9e21eb33aa79a67f9714f457b664abcff52d40f5f95b45692b2a5e5cd69188e5a5071a0993369b65f931c5642d44ec10', 16),
+                    gmp_init('0x70c2259d0c5363be5d6320f6ad1cf1986f5ce46061fc7449a4d462970d3ebe50122f90639b7045131a262121641693bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbd3493a9b4989fa9cd46f4a561dc16c1f6ebc8a8f7f68b4c931b0a23c1c872573a6cc84fb7dfa9bc32f27b684557dfaf', 16),
+                    gmp_init('0x76443dd2890a24ae70fd7110ca32b412adf89de3c9cfa72a9f4a94787e0bea0d99fd661e732437053b15394cab855a5d', 16),
+                    gmp_init('0xe6dce5b68dc54458af1afe02fa7aff2f043b6fb532a185cde3f29e54a2c595c0cb7c81613e12a686b493bd22107f2de9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x781e89e9c8f51f034c175de3af5fb0211e2ad32ceae0fa4fac9bc15a3ee44130182d463a7cc1bc35b1b6f319d291fb36', 16),
+                    gmp_init('0x5e27fc72208995f3f05397675a1bf96abc810646cc22ed55b579d255ae74017c9a2f0757a7afe0c512de8e957a579317', 16),
+                    gmp_init('0xe1a81c8a8181a2b6f45e6ed9424abc1f4f1c796df23393f4de331b9183a832d22ac36f8c0ea905f6b8d4932c927bf79e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x675dfc7d0db25a80147a9ea5a5acb65b2d46ba0497faaa4e2d4e57658b3c1ddb8e608756a4d9b8f2ea3fb7414c09877a', 16),
+                    gmp_init('0xcf5f3ad009af48650d805005d7ac236953905f1a4ff4e881adab00bc9d49d6f4dea9556d6e974e4f6b4626bdc6eff444', 16),
+                    gmp_init('0xd1e8eb9c71be30e8e838a81e2983e9fbde76741b9c8dc1588c18c3f47f375ab90632e624fd316de87163ec0c947012c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf43014814f04250556665550a1a87274e8abe0246d869c910767ba01a4fee387fe1cc06d61b97a8a023c9c479186608', 16),
+                    gmp_init('0xfe4deb49a76406bd73addf54a5bc0f708b48763e800722689c266278dc0ed6de41cb2f9b40c43be2ae692be6d2006d97', 16),
+                    gmp_init('0xc2e637e640d133e92fc63c7606b1e1f1f9e34fac776ae4b7aaa0441c9bbf25e4c7c70cb128c3bf6b02ac8f896fd1394f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb731b5f6a71d390a678fcc2429fcf9c818ea8acb667aeb71abc0925ce40f96a5b3136c693bcdeb2ce80ec1166b253f50', 16),
+                    gmp_init('0x8e5c6280512bd42ff6d348c90a8216069544b704258d54431c9a12c2837fecd8d3a55a1c18c005600887f6234bfc7616', 16),
+                    gmp_init('0xec783d6df0ff2d5bed432bf33bf2d8ae8dff996b04ab35c24bfac2ae67d5ecc83a87087a08e751d755eb5470994127b8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3a4e36587993d3839c0d97457c4fc60089e6913fd2ef705a40ac1ad05ff488e953d71de0480fe0bc77346bc1104fdf26', 16),
+                    gmp_init('0x56a0258f3187bdaad0ff35e46374e16073d3088e7e79eff49d7f9c9bf1687a859556ab71b9c452fc357f390a4ce63413', 16),
+                    gmp_init('0xb803d2fd549ccf335409800e6698bd3af0350502d58e320c351f6bc6716ea52cd1b34bef0f746b7beded8794c57ef66', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb8144b17d6938483ad24fdd31dee6c315e0e37e583612d6e8f10401d8835d6bd32398916e4d6bf7d2ba924e51151c4af', 16),
+                    gmp_init('0xda37d47bf92340011c7df0a7496fe8d297e66cd9fe264859026226b2dbba2530f38a601ccdf148478a0985f33c402968', 16),
+                    gmp_init('0x90778e49d92c60132e7774f0f7157c7e70006a76662b6564ad0f7fed2b6577f7b00f412f2c91e4ab17f3f09141029493', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf0a08a318a8f962f0878caf64027bf1b4107667227c1a4fdf4b473e5474f1a7937ee6bb8e24aeb0648d3e21d45ad76c2', 16),
+                    gmp_init('0xecf4bced68485c416381e16584f4046201e950aab09381d67ccaf9a5bdfafa8d34999be703ae8d3ec3277b68d5afd8f6', 16),
+                    gmp_init('0xdb07b69bbff2800102cf546e04eed71df7f27727fa5b095ddf6ca23308b0cbebe04745af0fe1e91208c54fccca203e5e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e250e06b709f563c845ad7ec509d1b424f14635c7358ff4e987c88e7e34dd2e4531c869b40d32d88efbd074dfcc2d19', 16),
+                    gmp_init('0x63981b00c44947814b717ffd8622d0803f5b30cb7c91cc4e65aef4745096f58881ad0e40aeb8d43d6894e322ac4ee889', 16),
+                    gmp_init('0xaf82df3ab37a3ff1c9abd399cedce58a1c02ce08d81fbf0c765db9a7c101f8599b51113f24f9835d0f4d2f5f62f62eeb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xacd7e37e1c0d66ecd639f8e544f24fe3ed5dcb21bc524d7747f75f6b1d0b4971624cf962ce7df57fdddc346aae19c05a', 16),
+                    gmp_init('0x8fa35e23f4e169d811bd2bc4c19ae3ba4ca22675a9213d1061c96d027d97c6978ba10f8c74fd8b40537bd16517d08e9', 16),
+                    gmp_init('0xa3b8e6d1dfadca45394e2f799e5b61f6a0c519b5bd603ea77e2347248d88a3f75b9633f104d9625c3dbbc3309b86c43b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x38aa7bfc041b924258147b66198bce054befe279d33583adb88db1e801d28c8b2acefcb287b88aa12418a60c073684a6', 16),
+                    gmp_init('0xa51417c6beb39b2adae637d2bf5375ccb920d09b81356be2fb3b64355de28ab42816d75912a8977a975444fff1afe5c5', 16),
+                    gmp_init('0x10c99da3e143eaef23a1e7b7928ac342f49cf2209a6e9ca6ff07e07643bb8d4ec86d1fca665611b1eaf68c37098a554c', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x88ba5d1777f964972d15bc349c79a974f6563639f8988be8bbee2a3cc8a255006be4d14ad6698da2b5cde1f9de6a7305', 16),
+                    gmp_init('0x79395d7f33990841fdb232875559fd916fb61333e3a7c588d5ceaeb3d2db61ad322cde6c3dc75b65cb4cf63f8ba0af3f', 16),
+                    gmp_init('0x79ac20738750c30971dada90b849c1197db7a049b39e0107df25989746341e13af7df5a8bbda40b64f2411332215977', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xde022f71b612a2048913b88acd18a05fbf2ae24ea834db61f1a7aab503700caca775114dedd57b1b2556a2f089d23b3e', 16),
+                    gmp_init('0x1fdaec4d8d8da13828b7a2ffb4a300e3a19ded8f7c0a6db6889d7b8d6bf041e6ff092dfe1e1a34aac8356e51b3e9e887', 16),
+                    gmp_init('0xff4bc0df6614e636be10f0b49891e5a38c663698fe0570c9731cfcdb3a4789ed2e451b974d8c3e02bd0df6b09fc96df5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9bfcae9ab73b254a9fea95e5c3d1584d62c20284df775903d93476ead8fa6d219b65740b0a897819581d7c0316814df3', 16),
+                    gmp_init('0x5433444ad7cd7b88564576f3a928f82e9ee220a219382daedd2687d5ddde44796c80bb76af52ad847c1b742c8d723783', 16),
+                    gmp_init('0x5395471228c9be62c393ecd6b3367b57991970c8105a5faa6a1d9b25641555a27f935d3bf2606058ce30baf21b6ac111', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x44241e7cb65457f2018b6e99f240366deb0c1f18c4c8bcca9d719692478849975f83980b3f8587142e393850ec43977c', 16),
+                    gmp_init('0x1be2870c330da48818b93141a5df5558ecdedd4b45ef2367cd41e85cd193fae21012c647ba8e65a2538fdfcb46b22ca4', 16),
+                    gmp_init('0xbe88b8416e6f35bd27dd519ad4a3f76ac8598fc714efce07ebb9a0b58517d7a6d88f82993c1a6d8f455c214e6a216f4c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3228aca4f0f35e865b5e71290ce7e7cd39babefadee2d3c57ea4309d472a100b775427a7cc029dbaeba1600439bbead', 16),
+                    gmp_init('0x539932c35d98e41c330a978782b1626a95348d0c4e4e32bcff9cfc6eed428ab7b542a65d04dd346593bfcadcd45b76e6', 16),
+                    gmp_init('0xff6dd921209aef9673bda4ce3e1459b007a2313d4169f2c911fd025469c7719b1593367ac030fbd687709318d918fc7e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x15148a5824bb12811aa12116fc64b6dd6af22253047ac07cf5f1aca03028d405c3188e21a0e0a3d2f129d66908462f70', 16),
+                    gmp_init('0x5cc898f90ae1773ab3b126470f29febfdad878d40efb8cfa92855e435d4e73c31f8eb077bb40b5c64daf958d75bb429e', 16),
+                    gmp_init('0x4db9ba03d75377833ebf557a6970e2468743d55e1d88495e70fd222bd6110efa93486cc5e12a6d085ce0875d983102fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd17ed4ab55d4f4798f151105ca640267e6d4f071a156f717d1428aa34a507eb31a6fedddb7d19232f9b6cb7ba773a8a', 16),
+                    gmp_init('0x2d3ada1e63d1542b5de6973aef09325ad62f1931cb17abaeb724feabbc609c61c7254035afc857800bf42c1cfe82000d', 16),
+                    gmp_init('0xd090a9abb8263b45d6254f6589bd09c841f5785de31465c4f7cb9d3c7376d71964237044e76fa103a57e9126482e59f6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeea2d2453fd35c635de6ac83f396393a2171bc596af2a3c65315cc13ca83de44cee87634dd852da52266f49d71765d5c', 16),
+                    gmp_init('0x5dc0860dc598a269965dba8550b078b93a06cb2ba2377f9d4804bdc2837079e15d3597c22cab01fcce13c7dfb1344502', 16),
+                    gmp_init('0x8e4b3ce02e989d600f3c60eebcdf85cf1d106a6344373e6f200f825814c3af4c6699f17493f813f6ca3e00a2d76f3a04', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27aec675bd6ed6e8f3ac680de82ce1c5ea24763bdcfec170b67ad98db2074f521145493b97608ef35f19b222380e9cd', 16),
+                    gmp_init('0x5a42c6ba398a80e1d86bb9450160bddc1a8074e6a249d7323b6a31df229e12a23d47cd27edc029298f3bb19a47b6bea1', 16),
+                    gmp_init('0x433fe5922b14bb70df79b343c1053c3d941628ace97d4e3c5b2fa861d71c728f7d01f7398e92f4ee29d3cef04d22edb9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9726771f72a295c6970152700042ffc2ada20091f9aff7d9332ef277f3f945212ddf41bc5c1d3bbe5383de71285b66ce', 16),
+                    gmp_init('0x3bd4d48494154ca2f99f565a3663e570cd7b20bfdf71b1d2d905d459397bd6e149624e751763512f9f6161b7d8927b0c', 16),
+                    gmp_init('0x3fe7a3019d97c9e4434d81b5cb017fc402087bccaf5388694796a24fdf95c98cad36c1dc679c1381c8ec1c7b25e84f8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd93b68f3cf2ac59ac93909fd714086c5eb40a9b7f9f306fb17602b9d3ea6e16feb2b4dc906d42875465539d36b73848a', 16),
+                    gmp_init('0xd979b2414543236b9b881fa181a0c713e8e5e14dff27ab5a860f08137379ba2356cc970a336e03c53dd21ca51e52f780', 16),
+                    gmp_init('0xa5bb5b2218523da004faa05c8f61f916158c776813732e57df364a34e772c02556d1aa7409308ceb2a40d56972217c3f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbd69e29d5358b5a6b1179329c7b4a20d8ad0712b27058f8be11a205265ba4c883cc2ef36c7797a14115ae3635ef50537', 16),
+                    gmp_init('0xac43c5b22abdef65240e87e683d47756530b5c2ee1999397bbc87e1fbbaea9436fa64d5ce1000183f35a296b507f36f', 16),
+                    gmp_init('0x88ca1603cdfcc0f28728ed4995f7df29e0f7bd2f6566dfd78c888f08c10117a53950182fa64a49b42d738e613c73d76e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe821dd7de50ad2208025eb4cabab19c3239478fa72c5b914ca7315150a16c6ea8641b7a08be2448920c31aaacce2d5d', 16),
+                    gmp_init('0x57f33b7e47343b1176421c38ecaffe4e9afb34c0ea73aaac925339610545658f2ca20da7286c8149ea96a864011d176c', 16),
+                    gmp_init('0xc452e086f803848e96ba7e6557731b283ec071799418f4f7df9faff672e5f50a13b549f76b51dd9f528d706264e3d2a4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbc9c78df6bcbac743888814b705c0769838fbea276a72f18e236661a38d903fa6efd93a65b7cfc1b3bcd5cb07100df85', 16),
+                    gmp_init('0x15ca3e3a57b2ae2b4b2a4114b77bf327ff519cec7040052a6076aae972f12c7916c14198fa5e778292ba367a47e39714', 16),
+                    gmp_init('0xfed42fe90d6413cb07694182f73e693af4dc7976d6914d28f5e73c8be7b7c9c4969e112dd326d631aa0b248a6eff89a7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x214483f151cd734638449509d2c99a66c8ce4295331f0da77967f870bfa2241dc00ff7db4036b050b2e9e3845dd88c96', 16),
+                    gmp_init('0x231387a60ed7a06c967360cff789a71498c9f35a435202907b9439f1ccc692bb7ea005227457e71e510da322312687ca', 16),
+                    gmp_init('0xca7c0a36a0903370db51c0fce1ea45db875a61b296a4b94055eb680813808db4f021452547290ec96bfb69a0a7780ddc', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x34d794887095f1a838cc7e49a2301d5590734bfc24cc9911499b3fd961341e171ac2e9bf455064852a30745c160c486f', 16),
+                    gmp_init('0x21647f057c6010a8da54a154081a1c96b62a255ec146eadadff0f13025a24391ebe20ee3e2c66ecc99b5d7865b1441fd', 16),
+                    gmp_init('0xabf231c902e2a7d1999a0b6d34a254e2a4be453e7f477511856b67b88923e9fd6c58e8643e419eeb870d3bbcc71836a1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x24635b0398d6dff0d2294e24820229cd11c1ed99be06a97378b24ff46ce4e2e63d058e83a2d79c3d13248aacd3c96da8', 16),
+                    gmp_init('0xaf97c76cdf8d3abfddfd84f290ae34b1cc82305a80be759ea5e7319193870163f233112ff2f33c364414718c670173fb', 16),
+                    gmp_init('0x4367a6b7378a389c9e9e84686cd6dc6eabebc7bf1eaa2125c2b06a43cd926ab64756b96e85e004380c634697668181ce', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e6b591c3a7965949d48db60178a2d2a4ae936cd50ecf23b02070b1c78b24a45caa6f6a6226333c6486c058f12ed8a17', 16),
+                    gmp_init('0x73fbbe73170b2898a1be6bd3ddc5a1f3b0adb696fbb7dfc5f8389055864494b4ba5c666e991134bbbd224af512597e8c', 16),
+                    gmp_init('0xee8bcb76f7f0f63d5b776c868a96b7d4f4f8bb11ef7a2be64bc49572fc459696dc60f08c266c74578721bcd4e983ada4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xab6749e11622508200682500eff4b3b6d68f569cc7d74164959abacb16782f7ed4d084462be86a299ae857b34f631e3a', 16),
+                    gmp_init('0x2c166483dadbf614d0dfdda1e6b55fc84442b8e7ac26fdfbf7dfdd0eb02bcc8106842552edcb79781784c8d793449673', 16),
+                    gmp_init('0x1514370fcf3cc46285dcbb091475e557e08862a3b2320e4adde40cb3631b0f4642636f1b2e65e0855454bec1d47b329e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7ce240949e74d5e2826830ba647f19119cd9487b62f519600779f594492e114adf5b61b703fac72f3b71c553b0fa3e8', 16),
+                    gmp_init('0x5722cc222fe02202198970d9df1ebb18890a56445bdeca5ee7ff14d1d7217607cd40e54eb63bcc6c80e97538e73a1568', 16),
+                    gmp_init('0x6fc529ac18598f0fa73c37d290c6a7f0af5a4a89d88d6edc72ee3568d54c6c6b9bb6dfdb26840ce2ad5306e05533ae02', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x15c7853b1272ff6585d931a015bea18bff211eeab3bf7420530de9180b3b2c39dfaad37f33485dfa6cce3d04d2ffa8c2', 16),
+                    gmp_init('0xd4f40488a1a42e5ef8f20276d94bfbc53004838b10db3f9a36a5ff4702dbaf47636216939e6a6707788c4da3745b4f23', 16),
+                    gmp_init('0x2138b27c7773568307f289a2d3c007935db156fb024903c109fc8493342b19a3f25e485de1abd0e8c35fc1b729016d8d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe184b0b800ebdb9526c4b39e9b9fd12ca96e6090f5b836bb04fa3fc53ba1789a7f1e5708f6977f9e6f627f017019aa58', 16),
+                    gmp_init('0x9f95cc79ac6376e876d47bfc16139b51fe548c7b4a9998ec0059bd6c084a246a1d058d1a664266cbc7e142b308f94a32', 16),
+                    gmp_init('0x2732d15a482637b3c37ff8a3d99bea0bf8d45ce3c927d5d3ae52b9a0694ede43fe6e9f2027b2aa7045bc991b33752f74', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x56b497193cd5fe92ff39a6e26a68dda441916d6888490e7d0fd821d8eac21164b9926dac70a8665453ce7b79fd3443d0', 16),
+                    gmp_init('0xd074ced3c9ab507bd97273cf52ac46a8fd147e1669d27363d13cd6caa73d4e330e9f4304811bac4c5f3a1cac47095d9', 16),
+                    gmp_init('0x2625946a0049ffea9555bc49f7055bc539dde4dabf5b9a5a828001d22e69534dcb07148771a4a6889ec8d95efeabaaa2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x79066ee4331a654a89e14c611e2c20af3b95bd1cbd93af8635bc4821fe120b4db077e2a269816dbd7fe2862291413c9e', 16),
+                    gmp_init('0x2614bae8d0bbea683103a2254405e4dc57471c63bb5808db3573a9f8c63d69e8b15b16d433779bebd81a3fa574053fa8', 16),
+                    gmp_init('0xd5622b188f9bbcb663d408ddd81240bac99cde316026d6e8d86f35feab91dc8bf809cafa2982341c97ed9db605765334', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x879241149202c752f755817d66fc1c5ee272f23a4f6c6a4d6675f0d4cc3ba86c1ada4639d0c4e8415db34a73ad5f33ea', 16),
+                    gmp_init('0xf7c5fe15c5977d103ec833a8dae0db7116ff3e71b7d4023a3dc88183b81a6d854512830f7d6152b27df898b76f9da08a', 16),
+                    gmp_init('0x4ba5acddb5ebf202546dbc2def4ac46831b89a9d25fad43e37f2896a55fe63c4d87003db86112c241bd2e98d08a8ad1e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57c4e3dd6095bc09ea4ae60fb896fe293e3ba9397e1168e50b40ccb75e27ae521c8f466e5afe0684e1a69ad9e300273f', 16),
+                    gmp_init('0xd30a34f9b9d5872ef465d64ebaf9c46e97cb0217ab126f9525647cde20f63f9d1ee897694f1fbcb56b5ed5fdddc6a244', 16),
+                    gmp_init('0x83023ece149b7c29d246b0a348a10ebcef9603a82548fd30c2ec7e2356b37b56895b59f0ce10a87f813ef23f767bad75', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8b92045b0ee912b3ce046a4d789e8655e5c9e0cf85f27a795a2c5a92f8847614baaa61e2e6dfe45b2d8b7216d813a477', 16),
+                    gmp_init('0x6bcdd20b7919b84ad34ce11292a6e429d09f93041113f1ab3a077c7ae5fcfd2d6e722f132f25f6c941eca2a90cacda43', 16),
+                    gmp_init('0xbf331a602720cc1e4e3de79c3eafb4b0c01288cb78f23a17876045cf3d16f8890e638fee5a7214c693b47aa79873f670', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xff8a393660561bc4acbb0c18e9bd752ac0b1f584674d0d67e44830b55ba7d23e498756105159b8ea747d9a63314e09b', 16),
+                    gmp_init('0xe37162c631fb4e42acb182070ea22c97da8baacd5e269039383dba5df1f43feac1710970272363b86a30b54185abcd0', 16),
+                    gmp_init('0x184cbf7bda9ef4731ca646ed88327e56daccd39585feb8d97556075793f311947f67b69514ac579783adec6883100b27', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x281808e1b17cf70e720737f6d3ee2340a8541c9c093aebaaf8b4a139cb519770f8db53b0c8425b7d49da1a691d2832f4', 16),
+                    gmp_init('0xae511ac9842c0f9edb6ab231a221c1351f8bf6bf39994604f8f1c2d97ee81dce2feee3a25e1c90841643e0188ed39644', 16),
+                    gmp_init('0x5b92d958fb534736a32213323082e14df9136274aede1e5cbeb10176bb636e27e45ef45c6eb10bd4ae17c08d7b16c6fa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7cab25ee50d8ba951dd7ae3053c9f7617189c554e4df3b90583625b3ad7c06b32d2a5587d10ec91d8bfcc86581f7843d', 16),
+                    gmp_init('0xbcb8b0c7b64d65f3a361f1d9cb5975bb15aa357fe3954414463b629eb8a2ae724091b3668066046260255ce61a80b213', 16),
+                    gmp_init('0x78049662401ec572744b3d53ce42d5f4b7874a856d20c318f2c5c507bc72e959d5b37684bae584efda4f9e87c866f35a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8f2c4228e3b56cd2e3198d14b1fdff96667b27f74d0502968a647e0cc5a166a11dd51d242b4a9758f2b68a1237238559', 16),
+                    gmp_init('0xecae529b66c5ae491554af3902b061b52ddfb895b496beb3177f73b2344fa8811cf85287bf571c79137c4a0bd41ae446', 16),
+                    gmp_init('0x3d17c0608121a7b32dd809dcb04ca9f34c281e381f3fbaad00ce3b366cb2ef5a9cdd53e4b79f88e13ecb231d2cd190d8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf93930771a357fa926b87e4a958dc983931789ade213f90e92c8cbe1da4790a3e8e92860ddeb2c5445c3cdac279fc53a', 16),
+                    gmp_init('0xa5d9d059b31aa6e56dc448489e7128c0727f7a1f5f5798b82d9bcd743c199d827359a65cc2e5b01aa5357e5838bee318', 16),
+                    gmp_init('0x820145b4e90eb39442e2ee9c9d43573dfeb0e21655c00ad1cb4118a614d807d8d3172457f067e82200aa1bf1f694bb4d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe32397808caa083d33f9a579d1870219dbdb593e573d7eea5f7296aaa77b8fefdb876297d5c474624245f3149a3256ef', 16),
+                    gmp_init('0xf55f892bd30a99e3b289ba8f73062bcdbb89bbcf668f321d67275039c7eb35dd0af37728afaaba7eab03db89a79eab78', 16),
+                    gmp_init('0x8193b2b54c1500e00796403830f1d14be66e72788e122df2407d0bfafb99968412471437efde22c89e309e92e030bece', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd83365d01b30db98415d91a0114ce03f954559ca85664498ab03c40dca22f299786f6d1e5be386d2b2450d140ce1a0ad', 16),
+                    gmp_init('0xf8a0c3fb7972a8fd89bf88798d6b57a92d8b63c19d5dc0ef76624b0f6de8f3614535ffd9392ffde1a729564d5eb58544', 16),
+                    gmp_init('0x7911ca82efb82a7f8d333bf591fe63e756e73749100fb8fe72ed135ad9ff38db393d3ba5a31e73c14a4e4b5eee97fdac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3619f7420ff048ecdccbe099d41231298ec0b3069dfde967db1458fd7379b93be0bef8e9600541bf0415aebf3368cd7d', 16),
+                    gmp_init('0x6229c4a15bc0c5a673044c5bc31954ff0c2dbb6494395834dec45eae1ea04526dfa91e9fe46c3e61b727fce11ab00dec', 16),
+                    gmp_init('0x3c2dc47e41785edd29694b640336ee20580cdb049197d2f55e0267fc67c6b0040b52f99f213316fee31470dd20cf0bc9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x30e5f12e1e5e02b146ab106a8c653b531464ad1de9a0c88648fa8baabbcbef9a2b0839b57ccde216ce4c120875d988f8', 16),
+                    gmp_init('0x75d4518992af8804c0fe3f606c8f5fa020d241eba0e3de117c008136999854b8de76f1e0f78eef5b25b590df980e6a9f', 16),
+                    gmp_init('0x614af2ac8ec1348ee7eb12c69add589841e5aeaa2a0520b1ba902f778e84c198fe4b94e817af8b00dde1e2c204343829', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf0ec33bfa544efa386555a5ecd7775e4c5f58b7f7e2dcce51c2f341899eca881028c2f75617eaa8d2810730971575927', 16),
+                    gmp_init('0xc3683b18228b2e259648116c4831da18ea32b3bbb307210bdb0d260d8e3a0288724974e894bfe813fd812882c913d839', 16),
+                    gmp_init('0x9da948de43ef6f045f1db73dfc8056b53e3045469447b5dbd4da8a76bc0b5a67bb48697f1c3f2d0c18545ba139a25c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4d36c8114c755f3264483bf78e90a0948ff150972033227b2061426b6e8b2381f34986dea26f649e62f483438d292b10', 16),
+                    gmp_init('0xa52e6c5aed5a91a6f88825515e090f5014115a094f221e91bdcea988c7cacabf2cd31ffe106cbc4c7f4760890740b59a', 16),
+                    gmp_init('0xa9777fbcc19225cab421f63d985541a889ccf9d66a1542edc346af1c091a4d2eb1ab76dbae86222878af82d1e8a56311', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x63d24813f0e31b00f19ace4e24738da318ea55cf10dd49385f7fc80e87a9f24687458ed69e482f331d2b7251763b7d9b', 16),
+                    gmp_init('0x9e1fe11e1787211636617a6633087976ee6896c809f60086b354f29f09a3fcfc560ea9081fb771d81ad9e92a7260c1cf', 16),
+                    gmp_init('0xdb2b2974e1968330145b973e3402deb342215861d3ba9d4b8b213101ad60a9f37a51d3f680d90b16d72fc5b4248563b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4e181d29ddfa1c9f4ddda70beccde18d5b7d91a3907fe1e7eccacce396500ade90f04f98afabd0b4ba72b4d0e2af45d3', 16),
+                    gmp_init('0x5555ee2bd1fa40c3913ebee85f673e83e662a4f97f6cf642d735b0f10305c16426a26a5d389ba46db302b8a64e337607', 16),
+                    gmp_init('0x90456f63753384f412868bcf9145d7e0ac9cca6e60fe9eba1efcd5d842aa930e0a20b8de5e04abb78fc0cd9d46a5c107', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8a6b895eabdae6afe1e935c76eb890e4ba50105329f7d5901b82c326cde839e18c85327b55462cbd1c3fd04cccb14867', 16),
+                    gmp_init('0x1755dafca4d3168a68d2b9aa1618ea10c7bd735c072d4498a8bdd6bb861538f778e4c93705346ba0fd9c1f141bd6ae84', 16),
+                    gmp_init('0x27fa3ab203fed85c016fbf4b5f06d5cda8740f8706b9c8f7e184cace4f97257066307ef85b05d0af4805cdb80c15e228', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc620f339010ffbd31f69ce43e46906051b35b98ef6e0986f11d54a398730e16798ad56a6995d8a4d402b399ffbd90b11', 16),
+                    gmp_init('0x665e49fad56a6f903f9c1dbddb87d92538d2f3fdf1892a1b5f4e112965a66a36ed8d6b46b512e3e53185864aabb8b59b', 16),
+                    gmp_init('0xf5a56146668778018af2fbe33d0c0c12c5d05156a28c8a389893429398530b64e680ae2b8408a695bac1a8d2590ea6d1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x439c9a57585a6643fcd8ea1e30c50f5e4b69c10a1b6bcdd0de80be8cd36b4a90a3a1cdb2bee49d6ebb9b01f0154830eb', 16),
+                    gmp_init('0xb1b070082b29ae440b92145ded0575d4153756a59df072e3d49badeeb6a1e7cd971c5cd6ecf575d23bfb82c85ddd7a2b', 16),
+                    gmp_init('0xea393c8083edff2991e7b3b0eb0edbf1516fe7ba10c1cc0b42d3047406716759ce65ab3d73a08377c532a6f67849cac4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7d2f632f6929b61827853356cf267cde8c15697c5b16da2e0c863fe9ccf5f7aeaf2a42ad9d061931669b5403affa150e', 16),
+                    gmp_init('0xd87a409f1980e8adc74978449c550c61b481fb61274178c75b48d8ecc2cd04c9ece3c1d3a19ec901b5564a06af97ae76', 16),
+                    gmp_init('0x7e115103a924027758bde8e2947564aa9c1ac24bfcb800b771f19da0ca24c49438ecdd4b9cf7e2f4aa771cf7268dc342', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5e087a309d43b585af02ec992944096a314cf61232c9a40b80550e1182e29f6fd19d4dde2395017a4d1606f4e154ee3c', 16),
+                    gmp_init('0xb05dff1d0fdf3b4e6070f8bf76702e3262bc05c3f6be684bcdeef014642e653a0ab6418d70f055e3227ca3c62e5c86d0', 16),
+                    gmp_init('0x6b58fdec75b9f48f66ba91ad63bb05a12eca0d40da7d8792e472e7a3ae68023f5e407d94f7c45efb2baaad7cf8f5c3e4', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x410648fe47c43d7905b6a89d647e96c326e3f18c5755d04b5ee31849042596555bc2f8e07988750d69d9f8ca884d0c1e', 16),
+                    gmp_init('0xff8f5138dd1f64b5837f822f62350c362d8a3ce35083dda4ddce480a70245756ebaad281636b874b48b9efe3ee0b7bf', 16),
+                    gmp_init('0x5f4bd99f237a5643cc1ad2a228161feacd8a6e7db2644eac16d26f68f8a2344e675a2780bef718307693c23945c6276e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e01f8f0842e19576ebd3927241c5983e21ac82694476862f052e3e5023f483a2dd5d3ccd507c0553de12ea124cad67e', 16),
+                    gmp_init('0x261d6ea8f216105d7f9ab33adf7d7e1b691d22d887017da12a149eb32ba2befbbb5029bc9ddf112af36ab3e4014c340d', 16),
+                    gmp_init('0x3e6f305f8f508eb67e4a291f3255ab46d6de81b52d325f9670a034fb49cca9f542267ef629e579a5f566620cefe8ce19', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc4ab604c6d8d13d438152a26797d2a72297a44b894bbd9cf566dde9416b7509cae0f720f6d6273f07e99bb9a7c8ad362', 16),
+                    gmp_init('0xec4adf29adc3f920ba35412f60570c2d58a28af5e45ba23de403c36c3476c9c0a2927aead1880c4f075ae7ec6faabaaf', 16),
+                    gmp_init('0xad61478fd43938e53bcef7c40c209461a2a834aa9765f020244c86996bb48e64f581d6731ead6c7fa28b08ee36e65881', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x41fcde6c10cc9508513ff9ab52c2eead76d71317190c10cd2191af563ee3745c0edca2d29c897856b72da42862f660ff', 16),
+                    gmp_init('0x92471194f61214a6e9f125dd4efb7769ac9ad029f9007c09e267494ddcaa7d9256e188a38c83509915fdad04595e500b', 16),
+                    gmp_init('0x84a14e5c8c7045ff8f0229382227cdd11b22dacc1c9589e62a6dedca29d377bbd5c479fc74276a7c67fe4d3ffccfda3a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x19653df08a7295e2367a63856d12ba9e7d5cf99cf5f5f5fd884bb89d754f771992ee51334381eef22eec1abad4e14d1a', 16),
+                    gmp_init('0x6412a6bdbb2e4ce14480f6b04635953183da058b4188c660c2f58b8f09908ca35742e5b22307356a2610e555cd25517c', 16),
+                    gmp_init('0x66213d95a0a085c50db5ecada1daf9d4855fd14b6e3eaf4e1109c42b67a602baf0d1b3392f3e8d09bd26bf22b913cfa8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8c2eaadf34f06fbf75850d37b8433b4745b7b47a20a8bd98a9e05210c026cb4e91500ee6a9b5b334359b37b0e9f6c3b9', 16),
+                    gmp_init('0xb4a95ade825557a76c15c3fd66dad83d6572b768455f8144ec21086185779d1762771df087c48906ec5bf60ee67bc1c', 16),
+                    gmp_init('0x1b35a9e986973530c5b4c23e9755938804d39b770c57bef12015588f7f9184e8b098809c553c600de4dacbd7cc475494', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4fde71c158a236af9f6806fa550517f6fc9bf1903b10d9fe50911d363338fa91ef8e4b8650fffb5eccaf900c9e949672', 16),
+                    gmp_init('0x49fb5647d9691b048e00bb1c9dad458a9a8efa89f2756dec961a0c42ce2cc6bafd5d3947eb835780b84706057be8f9f2', 16),
+                    gmp_init('0x4aea7a427c2b10b505d6ffac4ca051052d16b89c3e874ddb8440d5dbbd3a47e57a30c6916c27efd8d1e7b98a85c8751', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7391c4ae740bd59ea260fb9863a91424c574b5e3682adfa12b5ed64a00f37fbb39cda6299635cea8aad91c3e589efa5', 16),
+                    gmp_init('0x99c62b3f7f5377f8b8759c9a15625d4d343cf50452062f770c9b54b5ab8263058a772377992355005e74dc3f3d5b9b80', 16),
+                    gmp_init('0xec3ecc9bb08eb8f77290e144c30a1441b6ea37c438921b9eff7da4aa23c922e1405ae916bb0cd4f7d98f4211638620a3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x108f8dd6db15d95d3926b38805b48887054579dd71562159c3fdee3a41736a3c98b47411201ecd7fb0adb7861e392122', 16),
+                    gmp_init('0x947d37204ec15d1defdf1840cc1756c9b50e965ca30818a3fb1959e3eb2d143b10f0bedcd0b96475fc340f4f8cc891d0', 16),
+                    gmp_init('0x39dd373139ab02405263cc8713b50c1cf9101ba863e278c4e65548136cc5ca967f215f6044e4f401b6b31ee7a5d698a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb328e63f928fae0b1a7c97bb129d521e57528f8926c83b892d3a4e2a013c7868f7b58891912eb0f3e4b2ef118d55f81a', 16),
+                    gmp_init('0xbbed3bc039f5a6f815642d8ca305ea2dd8e0937874e052928f19a4f0ed92783caf1e7aa06c5cc0ca033461f5224318f0', 16),
+                    gmp_init('0x1ec864d3ea42f85043d88c259c1ab0b21c4349a2e74559db915ae46dc0c133cb7c06778cca488e384006979026b01c01', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6b20d6b948693c50ec154d12e37b53a338b303cbf24c1393a77c3af5cb93c9c4824424f258d4350efecf9fda77ea23c4', 16),
+                    gmp_init('0x96c4d2a9c47a309863b2ca7035f9ed7969cfd0cf6acc6b49b894fb8d75a7662f4b6ae36b445fa6cc510c14d86afd572e', 16),
+                    gmp_init('0x2496b0f9c61708d031f0913e15ce9b7d72e3498b3a2cc654d4627cd1ccbfef400c7692e38de689acd344b33d4c2b7af2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1056275fc55683b2faab5d1ea521fc06a0931a761c93f0a72a2c499947c86fcade00bea0e337627ff1097f39740a62db', 16),
+                    gmp_init('0x21c38354b5781eb2251e3d9f36c6974fedde5d576effe984523acd00e557e6727cac76ad6eddb40ca39000bfae48659a', 16),
+                    gmp_init('0x8054f27084a34f78c5721a4f6a469bb0810317d830fa6e7a08fdf8b3a851fc2aa249da11a462322447a589b5cf0ffe48', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x23fc4b7c7ea26ca462c12ac9394e978b5bc9184e046a821f41ea1c213c7760d382133a565f9d9d5d0d4f31629c5e1f85', 16),
+                    gmp_init('0xae06dc875bde6020d3ce7309181d01d20565245604a8bcd7ba4659847ce02df5c46f3e6205ab6315f280e849238f743b', 16),
+                    gmp_init('0x8a36b1e07bf32e9170781923a4a2321684703b2d12fc29528cabcfde5ae16323dd8d5909e19d1cbc51122a88fbd33f6d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x217dc3380f827751d4c5aff54c3b648666d59d789ebcae4d2e69874baa51cd28760695ebc60ef0d9a8890c1530536b0a', 16),
+                    gmp_init('0x3d0d3be1d56d0dfd9d2d19356daf1175051f624da1fbe083a2b3677c68044c0e396877437b820c89854c246e5b7875f0', 16),
+                    gmp_init('0x2dcfc4fce1e2181e9b606e52ea69d0e75dc55f1de19df38298cea50cf5bf3547dcc47e22a44dbbdb058ac9043a5f6d2b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x61f76105c30e67693061d5fb5b7904d1339ce905a8acdb097490e8d9e5842e53b0eaf6badcd4a4cfc2451c53318000e3', 16),
+                    gmp_init('0x1bd59a78aa15815528b1aeaff82ab14000a17224580909d508dfe89c83f197ce755da4d6225718d2fdb94bfa504d120', 16),
+                    gmp_init('0x1cf6e5b6c043659a81ce87ac8110b85dcf64f2c4d0f51d9a0c75c0f3bdb6dcc359fb294a9ed9b55b4dd82c5077a765b1', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8adf70b93e54fe226fb5b57b1d79c9773ecc3353b21cfb7178224e69b44953bc6b4ae1d215586f4a0e0f3c5d1b669ab3', 16),
+                    gmp_init('0x6cff4da16f9b56d5b223e61f8ecdb4d7f4fce84a4ff41aca4d9f6f28610f38336d9152ca826369be9cce4cf4e7b05118', 16),
+                    gmp_init('0xffb87196cefae32dec42750e88c121a50563aa2f65d91ded7cd831a0e037c9b3783770f72c4800d59e136d4560e34898', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x26d032144a47d23105d019a1f3d23ea774459cb6f8dfcb9e64c4bc1f09d781923f15453d0461d2a9d3fc553a99ab12bb', 16),
+                    gmp_init('0x49fd941f9c95c100b7ae5ea2d1056be7eb55e7c61dfa25f88530eb5609a7d292eeb373a7e4416697f952992d6b985f4d', 16),
+                    gmp_init('0xe8f6f994e62f33a590a72e2bc0963b9357b44acc4431c82b555b2a47587ed99989fa661758231e10fdea4be310e4f337', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf350d72013adda8101606f129a1ccd670d8b26da8cf1dc4cad1aa818d6cd7ca5d0c1463ba69dbd6ab997d2ceac59b215', 16),
+                    gmp_init('0x567c47a3a7ca97214477898f4984558d548083b2f55bd77592569309e62dfc3ee46f0a045f1711c3cb1328c5e1225c6d', 16),
+                    gmp_init('0xde1c547470fa2c0c8a78ba5bbdde27a8db07d22075a4fa9b03d0e716a11baaef6fe36aa174d75466622b502b8ce275b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa1dd498a57a97b884e13bff3a4fbd12491e7d7ea3bb888a1901ffe8936067e942a172cb41d1fe9f02d4d5ca48e247bc6', 16),
+                    gmp_init('0xf8f7bb91f1bd43f0e55509745471650459e3259e40fbcea2a060e278140649969b2abac7c97002be71c5732a69f0f6b8', 16),
+                    gmp_init('0x51371ad821dd92bbe09bfeb8c5ef57922e43afc13597f7d29aa8955639d31716a968cbff37e028061542391042d2374a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf4563c4f11b7322102ef7190768d7ffb59d4b464bc702adb30bda3afb4ab1daa38625a377fd3c1bbc180c5ea46a7e9cc', 16),
+                    gmp_init('0x850a195e1573add450692a096e1d55ad05b2ca135c789b617a1bd575653743c9023bb79a355f8e0123a60c026f807ca1', 16),
+                    gmp_init('0xb6b06812b411a35523bce25855f4c4e14ae20be8cc059153369069f272bcb493305d0422aadb2687674f29335952a836', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xab51cff9ba1b3e02b0282c6bfd7b5db7d49d6c04fbf691678a2e37c34c67605ea6cdb6fa08843e93a0c75849a2aa655f', 16),
+                    gmp_init('0x10ca924f908660a458c67068520760b848458ecea10cc3e716663023874eb1b26480c8e552ceb9cbb122e3914b608c07', 16),
+                    gmp_init('0x2048aab8cf92d71046c7a50c5f525c59ac81d35e83c45645f37b1b7b5b0d8a7e29c0c8072961b9d48eef6aadc2c85dc8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82aaebac6acc008973cc2ff463028a388277f595bc2c224842bad3418be9299c40f2e5255005d8cf52b99a3c00e5bb08', 16),
+                    gmp_init('0x2e91883a3b5954173c4b92a777514e27287e1c0b119566506d1ad34deff3e7af0af32c554e5c987debf1fba63305c448', 16),
+                    gmp_init('0xbea92130338eeafca3873bc2a04a4ab7c20099f1ed942edfd1d7494a36e60b24a9dd4939efddc6937088b118e895be97', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa5407302131164f273912591ded45d0bb144b26aa9b6f0fc0bfbec3058113a56738356eeb54c494f267bf5bd0621684d', 16),
+                    gmp_init('0x5a4af779872f0bbaf9206602985092dba19adbd94447d7d6e3a7a029b0e739899d3a35b37d21c6bd2e7feebeb04dc23a', 16),
+                    gmp_init('0xcb7ce270df9052f5b57e75b367327180fe0a4d680573aba277a9da6c8a21f5a805110187bedb9b38bba466d455287dbb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf3710e299d8a9fc7df25c33f5abe187795afcb2c7e6c4c736231f24eb8ece6194d23b61c89a39184572745ee34568172', 16),
+                    gmp_init('0x3d14ba7c08c7b06c46e7f2902561fd6025f53a34808087cebbafc3a08ef329059689d1b2597aeb13a6ebe3c1339c5d40', 16),
+                    gmp_init('0xceabb985bad06e1cb32ae0f36d82e1d8a0538998d4d9170b32b4a8404e954b292391a1dcbcced56264e527aa8e126473', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeb11bcb9bfd56a7760c80444fd9a5c56404dc85a416972cfbbedac578f3a376feeb4c9847ef8300352bcd85d50395ef4', 16),
+                    gmp_init('0xdef2524bb0f000caf0615af66ab705a43e0bc482310f74bcaee113fd1857e421db0d9f37143488446927f5dc537dcca6', 16),
+                    gmp_init('0x1619b23c9b64b2ba2e6987b959e7f5ecd3f7b43f30d7fd99a5ce19a65ead45dd89f7f95c168fb94588e3693ccb6f6d58', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x86934403bc1757bc4865fc9fefb53db4f9b1bb19882daf87040433bfe2ff5f52b38575f35edcd9286c98a39598604f25', 16),
+                    gmp_init('0xa3f7dd4d72f7b187c4852beffa7ddbc9c3a1135864b62ef2e76f689af8af72e62a1e208768bd22bf6bdab8cd12188c37', 16),
+                    gmp_init('0x1550fd2d516174d8b4bd0ed05d8f12e52726d506f6d32d6287e59fb1cc93d52711ca64646e311a0b9f46f42357711241', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8a720da5d31a4fcbfc4f02afbcdcb9c3ae4325376074f8f5e69a507177189fff1822977c2496ffbb060bb3ee11be22bb', 16),
+                    gmp_init('0x101d2d705925436cd9d24d3461c52e5ec03472f4a6d066987ed7e06d3c457b325ee8e735ca2b11327f1dfd6239f4150c', 16),
+                    gmp_init('0xf28f321238c89aa312b18f35605029ecf77379579d6ee95190452d9301805133ecdee2a744e11fd7e95c31ff470383e8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbe4397b857b911aa4dc7c8686730597b94315eecfeb83422c6f44d3ae642a337dd3455366b0fa979b2e78443bbdc6c36', 16),
+                    gmp_init('0x8d8eb104a0d93a069ba7764f48c662bda95b6c1300fa4336285ef7a9a03a55a5717eea8b7947cbc80898818019604918', 16),
+                    gmp_init('0x6952599d022bcb51cdfea953edea3120a11b7fa2285278e094a796bbff01ffe4150be3d6e7450d1b03c2dfe1f735c27c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1a1e6b8808a64ce19cbcc183a40b86aa6940071a30f3f61b3174c6933819914e423c06174eea188747220be2c96af030', 16),
+                    gmp_init('0x2cf56de7dcec961c5ef8cbcfcd983474f0f7c5d0162ee0b355946ec7732e3cc8fb51c7a5bf96e4ca481262c93d75d7ec', 16),
+                    gmp_init('0x34c6f70e913ba8d75aac7ece86dd4e9b84afa95eb21300f1f214aa9414380a1060d2c780881ea7904f75cfee10070b2d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x591c6e230cae314145662f8947830101892c7b5d016448d8cca5439fdc7e89ed9b839fd80b5d3c94498186f25b4f2664', 16),
+                    gmp_init('0xcfc670504de602e0b228c7e64a6c695fb1d68cda0ea06973951126244e6ff29f1f0f6275276e0cd9f01c1d22fd6d9529', 16),
+                    gmp_init('0xa204f146d33ab8722e5f7f331dc0cca1b114f4ae99ef2597b9c994ef16bf268af84a0d33220b5b3c4a33679271d2e971', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x767ad8dec26dc174622c3691c9199dbed9dbccba396136f36160d094fd812942bf8d1a24e63ddee082afb06435e41866', 16),
+                    gmp_init('0xd336b3f010d36c8aa2e417143521e02ac20f9f70f988cb51dc8f05104edc0a34ee545a09ff01934b9ce77de5042d5292', 16),
+                    gmp_init('0x7c1d204ce59584508feb6a2deeb29d516e07a89b19f315826bb66e29e1e9ea6e69c5098cd0ed90eeaba894e348b78c2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfbffd3ddb8895b97f30ba1da80a2fb77e68a8fad50fd8db3e595d5cf7ddb5df88c804c3229209a5e62f93c9fc874240f', 16),
+                    gmp_init('0x5ae55824bd49fba95f6f3b9d1ba5a9a2cbd14fb245f55264c5ca0c28947a6d9e421b1d8ef00ea3412330f557736110d9', 16),
+                    gmp_init('0x8fb955a0d03223f43f9f1d2c4b2dd1b84b80efbbfc8b420b573590cc485a3398962703510c4fba5057960545eb39d9c1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5c16c7e63eff716f0231d41a0c4b8aa47b2491b7f79c227d6c5afcf3c007a01d2f1ca74aaaee6788a001f89b05acb1ce', 16),
+                    gmp_init('0x8dca146ba5687ff928c51bdb9d56fafd00dd20cd005349b288f396a7466941aa835b406d9f3f61e92141be2ed53f735f', 16),
+                    gmp_init('0x3e44ce92370fe3de920880f062d1dbe9f91f47f0cde0afebb4f18c870b3870d0e4db3df1460f1a97fa9e1fb294661e0f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2421ec3a4f6acebd8e6cc5cf8921f84a75c0bfa1c92cb029078e55973e457f667f11be6c3f5f96bf2d564e74c6373850', 16),
+                    gmp_init('0x5aff6c791c59daf2118db29592d6b982867749457d876bdf9efbba2c859c8cc0f95f46d79890d625e6a373612bf1078c', 16),
+                    gmp_init('0x2cc0746991622fd6b00e1fcac6f22b77a73bb1fe807cdb8afc2b74c854a1155b648440128a9c3715329a6f923a10cf93', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d20335b3c6c7935b9f961f424731a22a93dee27680d2a6b4ec32aa17b1576c3ced63265e8efe9e1057328da71935ea9', 16),
+                    gmp_init('0x7956cd8b293efd2f94cf02cbb6a2b3380d79d8d23268bafc52b68976bfdff89691574ec4d744a0588ee9946a8ae7e42b', 16),
+                    gmp_init('0x1e221d59556cf2af050b11603510c13d77c6b848f97ff4c1bed38d9e3511ee386751ce514a2e2ce9e98fa81747d3d288', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb835674ac48d88133708b055d3c4328505eac6852e22bffa70d73d967c03be2ccc14cb961f6e5e17d776b41cacd8503a', 16),
+                    gmp_init('0x8e52323d4c67d869921ddbd9e647162ea8de3125001869ff263bec474c34ff9968a7e6f42f3f5d5a9d487aa95510dcfc', 16),
+                    gmp_init('0xa08f535fdeb7da7abb1ac9f3a5cbc16babc66832e26062c71df30e83124ba1d27891687403e24399ffdf545ce140915e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa27f265575e71d704856476d2b3dbf095769a9ad0b5462ee459aaf3cbd66ad272617e2612aa6a910a357b8836415ce2', 16),
+                    gmp_init('0xb4e18a2b97217d670cb436aa810e2bae9530ae9b1b23e8c52c9e522bb23ee1359fd89dc4b867e30de974c8e0d7ed0129', 16),
+                    gmp_init('0xadc19e786ae621850f73ff8d2cac7630b09d691cfead90d0352ef653ba750f837f6418de8a8fb6bfb62bc706974a417a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x26c711fb2b78a71cb4f917c989426be41532de0ac3040589dc4a783d79cc9962643775b4401a4b87435788bd42654c5e', 16),
+                    gmp_init('0xa9c8898fb01dc83b362a6d99394d50b5cbc79a8c2ccd599dbbdcf9ee07da9227b390f9b8758c8d72ffba3044a057c815', 16),
+                    gmp_init('0xc07b99db372f4a16a7e5f0641ec50013b02825310ff1e3108786b29fb677e08b274c85faaed5593fc8381c5c970780ed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb5db3d7a134370423a636aaf75aacd059e3d8863c9265dfcc412e13d0850fd6328f788805249ca2de97dbafb6a9d7806', 16),
+                    gmp_init('0xd7d1400a9ad2e54f81255a9875e229eda32dbd0b45f46075eebc7fc59e15347c6ce991e0d1f6a7b2dafadba15257d534', 16),
+                    gmp_init('0xd55d760d7dd92906679519dc582ec819237cf50472b73902d75d6793ca25b3d4cff200e40cb4038847b08099d1b32e47', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8eef2360519b40496b4078ff89632e24133d3d1a0b7de7667702bf01a81bfe9e100ed74eb23ea4f4049bd104d568f44d', 16),
+                    gmp_init('0xd58129e8d461aa2492acc45d0c0bb5690ba7382cec4a7e07847738183e47e49f1d84c2c2874d228bf12c5b8ecb305d3', 16),
+                    gmp_init('0xa15c76c070ae7554d7a2c0220502d0ca35552acbdded51a60b4157e579e2f9488615dc517d6649fe71aedc1d3eb6d2d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd80692b7856e967226ddbe479098609ede2602c9676dff68936947266e045090f8ca217e2d78900240e28fed5b6284b3', 16),
+                    gmp_init('0x1f88111b3a36390dd94d58a59dae79e53e0ecc48e75a9154e6bcec3e856853e8b91ccf59fd2c26ed286a99d66f3c061d', 16),
+                    gmp_init('0x39cdbf2110b2bfdfd0355fe0bb831010c71844516ab6e83138d274fd8fec87a33f128eada9bec4289f7001c1b151a4b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2371530daf575c9c031d6abb6a1af6e07f696a81ca2864fe3295f9f1bfe79e0f0a7dc7c76f7760722e36f4c9c61f1417', 16),
+                    gmp_init('0xea1dfd5439693491489b7b8990540a3940424abfbc25d2160c1082b0d1095fad868eec35fc15e7ae796273e3974946b9', 16),
+                    gmp_init('0x4fdafd0e279c058045c8e671f7c47837dd8d6ae0f2767b362b1fd249189851b11cf27601a6cf6fb7b42d5c99b2b79439', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca428089358b5e7c2ba93225a4942e51c65853152ed34e440432d4c6c19172b18c2fdc97a66c0a432f5064ab20089b47', 16),
+                    gmp_init('0x4b0306c33b99a8fc559c04bb0bc194841c6affbf134014dddfd596f30ebff91fea8630f71162fce288daa4530b43ffee', 16),
+                    gmp_init('0x568d782f9b50708cdb0398b74f9ca82dee434d4c48b3e5b4ac844ed73e26841da4879765a3abb46485195100548b8f28', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x26b2ba811687600647f33c13b832b9edcb66a8b4675f8f7b6f7979570af19f1bc8b7864a53f07ff7e7220d30d056691', 16),
+                    gmp_init('0xebafd172ec646d0662786d54a8262efbee89f35b97f74d6db899b66c78ab9d159eee30f3a7ad91a1f239a0aea5783f24', 16),
+                    gmp_init('0xec5470fb9b58c580f4097bc5b804f31adc95678b9337f6816b9c898d62c49f1f346c10bf136d52b7359bec7c260a78ed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x758a39f09ead5007db918563b6d9151f9d7aed4470a9b4d9bb9d4b98143a6f43730181b5b7e54c532aa6c8b56b7232e0', 16),
+                    gmp_init('0xc7b8e22e03bedd930fc3037906d9f84f90277a1a048ef3a8077725b35d51a8559e7845350736e9c7968d9b3a643c2562', 16),
+                    gmp_init('0x4727315206ee2185076f0549de196f09766d4351ea48d59410849e8f6d3d81d70ceb3ef200b4492c2c873ab19636b5e0', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x502d261bb7edeea61c94353719a96df4ec82ed37575afad46643845cfffd57b1cb5ae560303dfea23413b6850aa38f17', 16),
+                    gmp_init('0x6745c168de1123e3d4468c1100020c244123ac37353b8e6a74c7d84bb8221220c2658cdf425c8613b779689585fa67cd', 16),
+                    gmp_init('0x69c6b7af4ec45f1045ae9d5c83740d31a620c17505f26f93a503f7e9fcc6df1c790559d0976a0bff3d3f6504fc9c1a3d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7d49c84f940692892cab29fef1c01bb204192da5e8f1637ec0ef124d200998fe4a410d08cbec421cfb31edfdfc8cd7d2', 16),
+                    gmp_init('0xc8995ad7054278d01ac786e53c1edf420123fe303a558159461b562c03d85cd26e18ce57aab976941514b9bca3fbae55', 16),
+                    gmp_init('0x3e4773d5957b0eaf03b860a75a6cdeac6b9aa22f661bb820e0045c239f6edc7fe769dfb6790443a3e867ccb1ee5c915c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc8c0765caf918bd7fdec91226bd3898bfb8839efb3997870797f127a782fae23abe45b4be5cb04daa0c97f574f077a20', 16),
+                    gmp_init('0x89f26019cc65fafaaf90420267c7e0330d8fa6d657379905e6e18e35536c3438ad38f9f09cbca153e2750eb1dbd4b855', 16),
+                    gmp_init('0xca53827d7f60a2fc0478a96a63a8c5435fe78c041747e71d795533e0e428c781fabce1a2ad23fdf1f7914a16c61bfbe7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x23c6df30a420ca1341341a1c3ce3280ee5fe38661889f40a113a3ca7c88a3cc2cae8d2dd0fe23d06ad2bd5a211a1254c', 16),
+                    gmp_init('0xb2a9a0bb3a00eff40bc1e7756dbcee1bf388a5259319362ab4dd4a1a848526a102521bc2e64092ab000aad362dc9e43d', 16),
+                    gmp_init('0x20342b9d85aaaf02f7febb07e75b4a519396805a2a73d9a1fcd09bb3090ab76c2a8b1433620ae07574ae68d3adbda7cd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x76f54c5bc6013713a1f35796d051ac1e319ea1c328764490bbb14bdf8d8749b3bf978e449edc3f44d1a025fd447489bf', 16),
+                    gmp_init('0x25e3245d67a966bae56a85676e856ff73775c456dd164ac3a71e34cf853298157eae3fff4daf55887989ecfd13d0d4fa', 16),
+                    gmp_init('0x3a2f09d000fe420326cbe3803cb8a29c832e32c5e1726810218a1d108df184a01c0d6331fd64d40313e56866ef8f9fd7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x391ba83b0f49dad7df9a0116be851785b68ff77fd9868c14f32b3a48f15a2f20847436f11b99288bd2ed0c6885c6a584', 16),
+                    gmp_init('0xbb4840bb7f77e64bfb28f5784d11c305ed3f13e8970e641a68cf0ac913a2c8225562e1887f9f6f13823360aa94a90555', 16),
+                    gmp_init('0x325588f5fec4187c224feb863d4c2f7444d2a9b63b48f16338324038c8b12dd52520040f8ad2e7d58cd82f64870449dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa5d9608f5a6ec85cceb1ed009485030fe91e748e8a4e8a7dc398d245581675a19a4fff050eeb9f92a53d6e469c0f66d9', 16),
+                    gmp_init('0xf93620945a385daacf6f0849aa0a4f361b112c27544534528e66a560d8ddb20661cdf963736351222b542d2723cc2a0a', 16),
+                    gmp_init('0x4e305a9bd24cef601514b561dd4ec94bcdb94877871c548820ac2ce9a531304fcdb1fa0ff3f47f7ec2afa36c14a95bd4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe8a42a4e63c73e80f765628df13c86f72d73b310cc2de56d52d096c9314c36fb5c4b1831d244716426e3137cc60beef1', 16),
+                    gmp_init('0xe8872df04d1dac707920d5a139a3a87c63a7eaf50a18c0d48176d12f0a52fb6d2265ce93b5cff2082b598247907a080e', 16),
+                    gmp_init('0xf796efdbcc271297e69eeaba59a667ed34f9dc912d10809fcd07d5b32c568c2043aad31f6d9bbd58272617f0a5c9b46a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf7af02bb911bc5215834d9341430ffd8d96ad13c411c1cb2f0506b694aff7e4e6b44a9aa31a70d757fa85fcd5bc91982', 16),
+                    gmp_init('0x24de0a381d9823c6374bdeaf9f608325bc11f433b8e6c902cd6a3110fadcb5c490d58b00cbefa6f907b28084e645f7da', 16),
+                    gmp_init('0xc874e0ebc08705f82988496a5ce84e706179bf4a05d0aeef2f98c23ce77290d9768444d793468e2da0f47422c3d83d34', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6fee8c5957988e18105dbf4c7a459ee8e31328104bb7ab9f7e53c79e0f4182c78cc806e9794f4524f6df32f96b028ae8', 16),
+                    gmp_init('0xb758795a27ebf1675c8465f587cb90249aac479b9563b996961b0d5e301a935fe1dfa24702c5333f867dd285e195947', 16),
+                    gmp_init('0x249248f7b58c3aebd8f3cd2021f36bbef823945482a026d0ea660ee4e5bdb23804faeeb1b5bee51ad49fe771082486ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4a8a19c3c9545d74d2a198e32809d2347a345b8713fc870fcb0c62b36d55cfadd39bafb1fc0b5117ff942433a8fce216', 16),
+                    gmp_init('0x87150e1c720c9f36a67783c2210222c9f6667829ffc9c25b3789e250c36877c468bd615bfec25c41b6251b2de9579ba5', 16),
+                    gmp_init('0xbc162473cb9b9ae7a213492ec4194e262523ced11e1311038b028600cb51b8d4542db34de9759d1a5c5a8ba4e74fd417', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc74d73f6c4e5105334d8891acfdb5629545a885b0bc21728db6e10bbba68e3cf0e3dead82d8cad53d0faa02e85b2dd88', 16),
+                    gmp_init('0xc6f8f7948e0ed0897d5b38e517272bcde9a665ebe121b479bd639723953fe73e9485fb88e41aedea5e44c75253599c1', 16),
+                    gmp_init('0x103a8a284859e118950d395cc69691e9ea28d91a4c67a56822313b7efee96910adc3c1418aa7d36c2a05d76dee8ebe11', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf16aa42928fc5a5769dc42b64012e6c89c138275d089680f3e8388ec1c52a658392092b8d554b0ef4703831e478886d0', 16),
+                    gmp_init('0xb5cffce83d2bc50c638b67fa5ccc02447fd979b23492d0271b60aa8a07b94e6afb80b8c522ab8380ae1b1dfbebb95bb6', 16),
+                    gmp_init('0x93e021f79c653ffe9610a8bb6e11fa22e669a0e005a3b572a0d047c4daf60268d4d3d3d0ce77f058ee6e65e77087483d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe299195ac0973823da6fe2663c4338663c73ca9ed7f54f282b71e958bddbc9e3efd520616b6b1cfab332a94c790c52f0', 16),
+                    gmp_init('0x791d99be0254323fc6b0a09ef5b21cca40688b982d196bbdb30765408fd6eb2d4f5caa8ab9cdc02859c46ddae2382baa', 16),
+                    gmp_init('0xa1eaa783fb482c61c8d71c5a7ae9fb493acc112169783db42807b43be1fa6d89840684281f681dfad266d54c0f384fc1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9ae5bab76407b157eab99c6418ab98293288a72d73ecbdb264a51f67e6ae4414dffeaf2feb48c8908ac827139cf5bb78', 16),
+                    gmp_init('0xabaa6be25f4d6d98466bb77189b1d827f9b08afaf113f2cce4ae40d966eadf020500102278701859d7877bc9767126e4', 16),
+                    gmp_init('0x35939ccb93117b35c14f701128f152af1250499f803462046ddabf93f7bd14350b8dc0858b253e62ad93f71213f2cf6b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xa37545c9e2fcd0c8f2156232fba01589219988ea8daa1a0178ac58f1239fd64f4f44d0cde505e98b2b9914657d9aafb1', 16),
+                    gmp_init('0x8964baf340b8d767a5557e39b193ea3dcf2103782fe940607e6ca9bca2300ff3bb3625f0724dfd55311a6010bf5c6bde', 16),
+                    gmp_init('0xc3334149616bd737b043c5baf355a366d13118d52ce0069e187dcb872fd5aa5bb44ec482658787e2556608fe0223d3b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x568ce5994d014a2a53b9d84fffc479a1639a5273a48911854e90064fe1919d64a3fde4bbc0c93fb34a69e9ba051e848d', 16),
+                    gmp_init('0x43af064091f382fe0d4e3313e2830b62e0df6c3c864f16dbf3c1be2911c35d4ed6421586a554cbf083d7226a67fef695', 16),
+                    gmp_init('0x1cee779de5750a966fe99b200294b4a131a3cfca16d87c6f81c0b60ba6f27adb952fd18c42776b2caece19ed05a23000', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xecf3f017da48f13557eb0eb8c3b2135f0d3828d59d29a0a1ca92144b47cf6efeb0fb1bb03a1ac2ce3de5f993b00fc4b', 16),
+                    gmp_init('0x311e654472f5362c02b7b07302b1a991cbcade0fa02e2637282ea86852d271eb69b8874b3726e9aece45574f1f80a77f', 16),
+                    gmp_init('0x32ed7981ef9448ff33a0e9468c72a48683692218410a8b327358eecca65ce0c3ed014644356c874f44ee576151c054c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x499f623fdcd319df8311f3e5cfab97557c1f6d698bdee3e82e00d99b0147ce336e3c5e767d4cbec2cb4b1d6436a80ad9', 16),
+                    gmp_init('0xdba32e2c97b575d0dbd08804345f73e718d040d6946fe84bc1ba1d4752c895fc5c1c32ee5b8230cccca7c36b9b9cffc1', 16),
+                    gmp_init('0x1bcf559e6546951b74a89f439adb25225bfeb88a7c1e32c2d3721802a129f385dfc028f8fe8720ac43ed02b17c042509', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5f3c9129c8c66b8fa09296124e498bf4a4fbf26ae8ddbbe6cf4a9cd4bb36b077218439590c254ee4bc7a8ee87b093614', 16),
+                    gmp_init('0xd0fa7e32a6c1f71a923adb5435cac39969d602dc302bce9b4de4afc269c1733b66b96a3fdcc1b6898d4f55ce80a62db7', 16),
+                    gmp_init('0xd76adf9837155906685981d20987c0c672b5b8f82e73683281247541e795be847a0c5dcc0401d6cd4d0c280716ef754c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9dc24ba81913f582afc223ab3538ba9be690951eee62353730b323c5e2e02bd0c4862afe4f91594b3c4c4e9f93541017', 16),
+                    gmp_init('0x33b5c42784050a7bfc85b9d8c6594c4a786815d6e42acd2ae79f2d14a0d8e2d8454b96a2980e213d787eb620c58423cb', 16),
+                    gmp_init('0xce94ea02b01d864ff1be52d62f0bff3ac89f25ab7547bacf34e5654dc465e06d2bc82cc2c25289ceb03e85088a4a0307', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6c9249deb4c733610112a255fc68a3e3b4f93f6a492ef45b75cea60a3ca6940971ca3e6d5327dfac64150ea63b97af24', 16),
+                    gmp_init('0xcb486cd4d3f91f228084b9d47fe9acfc2a690540618c94c3a64884abd88bdfd58a9fa8a12e11c25ab541494bd366f62b', 16),
+                    gmp_init('0x7319a8663731dc8ae8991ba4a1ee660a55544a7333475690b91edb7c3fc51f53bff823fcddde12ded97891e04695bb4e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa616c3ac2c04d64650224b9476536641c2d9489386a752e7d64cb0806bca4b7c08187a32547762d41eecdcb3e8dfb87d', 16),
+                    gmp_init('0xf55d1e45db326c8b6a45f7de3ce47f63c62653a83a062be6ac9edf18a88d36b78bc53903a2b22c1dfe5174dca307aca9', 16),
+                    gmp_init('0x6b7883ac894828af7a77baaa215a4ab751fb34ccf6830e33bec6e61b7bf87ab87da45b5320bd35924562cef96eea97ee', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x80fe02f5394b34c7647bfa5355958a8318ac003e03d176b07909d806816e9e7804382412fa7ea8fc51432df8e6c255b5', 16),
+                    gmp_init('0xee26be87403a0b05d14aef47aad7b922a4989ce6587cae840e5473856022917c5a2ffedbac94ac82e89ed7a7d52464f3', 16),
+                    gmp_init('0xad4f20c1de6f1daa3c542ead94e4ebc2ca0afbaa82c3df1b5ea2ec60e84a2274eff9c534d2985be9ca111dc5bf2bbb79', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xee80bd8b71b8a070b9e0672cee91bc4868e4d12f2e1039f7751230b630bcfd7e36523db0c9f289aef9562f93dcda3910', 16),
+                    gmp_init('0x1b2e3cde521016595965da9de45b1e97b2105e84517b7f741f15bd890bd15befba7d06ba56e92a9c133817e2f89fe87', 16),
+                    gmp_init('0x7d341da289fbe14c90b514dca62efe53c9d45cbf54443a78e81c6f370be82d95ae6bbb0ac86643eb839396a212e084fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xca0d93ea2162afdc3d235034d0000cfc20ccc26eeb327582c7b7845ebb9fce1115a9d9b501bda86003ce5918dbe83d2b', 16),
+                    gmp_init('0x7831aa207984db9c18d9245a43f8058548fd82d3b02f59be5033374f1a0c3eb4e66b54d2b7a5e4496fcd2bd42dde03bd', 16),
+                    gmp_init('0x2d84b9d2059a534dc5e62fd0428beb8801486cd64b9766321440f1d7c49577aefdd53f310922b569b22acbed120129e5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae803db4e445a5281354b2dff80b3903e45b5889bb3b5cc13ef8aa469b2e3c3e2eecea3d394826065498e5d7f8139e13', 16),
+                    gmp_init('0x440e897ebd8c6b6fd5b1e26099ce474b1c628695271afbde32c38b4328ff3d1d61fff2d621861fc359a75cc11e471c91', 16),
+                    gmp_init('0x9f1dcc55becc78b3bafbeb99cb31cbe5cbe480dfa06c0a6bd000bf63e731d0e9577ebb7df6fab947776fc8f5529361eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x932604420c42d9f4e4ac3789ff6b9538ceefc354121a0695188b78f09568004c6367a4d10bbf7abb73994240651a9ef8', 16),
+                    gmp_init('0x14bb73dd4bcaf7d686e9e1f3c37e04953574e3d0815cef1112afd3f33adeb760aa8e40f65bc242265ed64736ee6a9fb5', 16),
+                    gmp_init('0x1f603bdfcd5cef99961b91f96f18cffad5e707286ff0fac60e40425abf884c1c41116599826e44954aeefdb7f1d2deee', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2d942818893887e294c8dc1693fc9952244676fa27c4a8dd645de533b8bb90e29b96c33d18979e910d89e151f5b0abc9', 16),
+                    gmp_init('0x1b48f70732149fb7bff852a3eba6bfa3fdee3b6dbef1ab329843197eac31ddb404121ab93c6abaa8e31e5c69c36712b9', 16),
+                    gmp_init('0xef9dbfb48e1605dd8c921247d912ec4bc30b180dc06e0ad3ec43e094da421eb2fc4454e9f252370cb0addc01ecb5792', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x635ccc8bfc8267d308b0b441400c28a8ceef10ec6fff30e7efcaef77dffb55624b6d00820a0e4f243825efca6cf31d5', 16),
+                    gmp_init('0xf04fc45758cb5f3297fbfcd443cfbc12f235d6c3e15c6d37ef6828d6b1ee289c2635a0b2adae6783770026ce1c01e93a', 16),
+                    gmp_init('0x860078b27005642ce71a4105f918a1e98edae85bfd4dd93ebf58dc5bc40404b92541fcafe7219e9ed8c338f09e0ab401', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xba6097334bfc93a3baf437b962f22804ee7ed1a43b9c75a64520a010637059d84bdedc6ec434637f4ee86c8277d20b66', 16),
+                    gmp_init('0x81962ad01383c3eafbbae246a51d7324fad9031905737a6369b94892410e0ae378cbb4240de6ff20241a0ca71ffc35b1', 16),
+                    gmp_init('0x3701e45353c3750588eab6ea0dbbe6a75a8c5bc237fbc1825ed9bb2044fa6a56a5b4f4374b34c31d25b65f0f694c1676', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x85937459195c0411391d4f91199c3984c559b838e60d3ef3c659e38ea71039b5fd2201208bbd5d7b1e5136d78dc0e896', 16),
+                    gmp_init('0xa7f7472caef59e6abc20404ac1f90dd8e9968a101f03bff883d686a3091e36a1981cea2c2a1d27c1d177899ef0667ed7', 16),
+                    gmp_init('0x3191b2027c8a1a0a00ac7065850c7f24b564a2396300de6d270cb1d82e661867d20fd50e90d7cfa762c6c910e9c88e77', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x42799d57f41891737ed848aca4a0c75c7601714de9ba1c81fa044682d150248a2f7f2bf0849edee91690de59270ea5f1', 16),
+                    gmp_init('0x99c85c43b2da7e87a3d550fbc76d6f04a5f0dc3d79b273eb8ff391b6cd99582d9fe8ee122b93dfcbe68bc6ab95e2388c', 16),
+                    gmp_init('0x79e14ea0c701a2858e0c2b5750287a4ee09ca31fd0ea8574a37298415bd8529f9de2ec1cb63709a3040a794dfc20d955', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x23330e71b98eebb26f8f08bd91f7a9ec06ebc94bf7cd9ae9ac34ddf08f0e4a0215f20e19763c435404b48e9ac895fee', 16),
+                    gmp_init('0xedeaf889fcf04bb3a6e8864afddd2e5099cbe2b24528621e39e3db87cbd2637f4f5bea804527350467168b4b93620109', 16),
+                    gmp_init('0xa1e1d788fb4c4ce2d18e425479162ee9e99e6a2165d5079e78dc6e02cb77d4b50967728c92a181e45250024aff386416', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3b9369330d29879e8be9f5b6ce957a181f1cdf797158476c7b81f63cdc060a6dd0f72abbc5bf1f5cb39957ec502f8836', 16),
+                    gmp_init('0x3f51afbf76b5b8bbf5476e45d0d7b2cb1e990ec725b42b2ee049df5883fc2ed67da0a8942afd3b1390d91dc73be796', 16),
+                    gmp_init('0x9c0147b286787d719391fd66dda09ccb45c7b02c9ffc76a547646acee65f864e23313e94de89b0fb8e2c80eea14289fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xac1c9881ee8c819c77ea04f534b7c4e547ec7e539bdbe867d8887e263cd7c427feec6af5f0518d6f885dac13696725fa', 16),
+                    gmp_init('0x58e48d6d25c19452ef192a91db2597ff9daaabf581f8f29438b70264f97896ab2ae3b3e10c432c2dee7462ce5b5e17ae', 16),
+                    gmp_init('0x1747189e2ca72025dad18abd3cdd823165ac1749d5a2da264e7a8fe829dc9a5a1bc0983f27b465cb30444f665401815f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb2acd5381a687e0c0ad6659b12f8ea78845d04e11cbd6644aee7c8726955de1696c7823197ed915421a0c7b6177972f', 16),
+                    gmp_init('0xeaf4727c2d7af5d4c81dd39f268820b3cdb0be90b2ce97ad84ffef7e7f56d43099023cf0030fbe0db2d5af2ff0f06546', 16),
+                    gmp_init('0xe8ba36824c4af3d222fc5772f47994eaa2770b96074504849c21f742846a46faccab91371c8d1807e84bc2f71f472848', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf097b7d95fec6b7641c632aebaa325a19e4a2d10ae56d2635f91131ae9d1d1bf822c9c64588a64cc715d9e834d1d7727', 16),
+                    gmp_init('0x30d602a4d85cf6bec2a52a0eca99b133680f471cf03a829199e49eb08097cf317a359d783c8e4535f614f9fcd9bbd568', 16),
+                    gmp_init('0x97d33fed8cd0469055c036e23fc8d979d82d7847cf7e2da71c89177ffe60bfee533a908b473eb49105d1b57ef617265d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc379fa2b28f27cbb8a13ce6d590970ee6b00d119059386abc543af851439059eb41f9b43b1bf3821da57152339f89ea3', 16),
+                    gmp_init('0x8671478f05b9950aef53b95b1d2ab1ff3db4fec5d3181399bee00bfc64eff9a3bcb21fe0c2d592e8e3b6c2ed064a3e38', 16),
+                    gmp_init('0xa49909fb0dc1f671067ce1e0792e59df53129d5d63d587a565ee04eff7ce725495785ed5c1f658046d4b920f105a7c02', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x598cbcab88f21b6e05f62dd774c9dbe32588e9dadb8a520f99758655da3a27dd046481f586a06f27625c1a5e98630198', 16),
+                    gmp_init('0x48bad6220388690d442b289160e3973e30a5de7a069fbb4b74f5480228fdea2d6fb788eb4fcacc8999ab72dab2433039', 16),
+                    gmp_init('0xd81a4efdf8e2c86a66bea8ec237383825ca2d7099a1ebfa1556a50280bc4aad3d15b97a48099ea5a27478a274ca22f14', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb0f4908806c5cb2843a6108d16cf2820140a16aecd0a288199779b0a21b99fa207a17af9d06d3179338f42b28a32be56', 16),
+                    gmp_init('0x5beac3c211e4d082909bfc3279b38a592d84a95502e2be92c9876e4b95b17d4118ba785da7571e972c37e3e6483d3784', 16),
+                    gmp_init('0xe2c6789b4e858ac7b6f109a881794e8e631a83e98c1831f076c1111a4ab21d5954a88f3c0f6a309e41f5cc8a150b9cad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x131c9b13d5d289d90b5509eccaabbc41cd0ea7bb1918dcd2058137c1d6abbeca0a49f7c6cfd3f3ef4412ded4a2fbb8af', 16),
+                    gmp_init('0x43c7f3985421b7e5e3961811c1bd521e46eb04fd6f43fc914acd615981d4176cf3ed448176b889310066de238522eb6', 16),
+                    gmp_init('0x7d80683f91d7e4006a407923477a08b5ca4b56f997ed418e5f13f47b52c270f797f0bd4162ac10e9f7c97167f7ba9562', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6480f382df64e16f88706274452c6781d237bb947c64c01e0f9c120881748e7f35948078aca4255fa72edc0e57278694', 16),
+                    gmp_init('0x163a3baab47fed63e5d8a87a421712c5aeeb6368a9e1af78235e5c27ba11c32a7658aa2fedbeb263b796e39cdc92b0fd', 16),
+                    gmp_init('0xadd022bd1be4fbffc5eeca25f326940e04cd48a0ad70f56d37e3639c365bfb91365aa675e9af8a1e234d9ce7bfbf7c88', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6121e10eb287326cd29673c9682fd2b3a11c0eca631fcab17576162221126042c7b97173e1f804805081a9840777fb3', 16),
+                    gmp_init('0x2818a874b769bc67bf3e49ffc503f5883f55f5d07070026a5b41df3f365ff4b25770cdeed1dbef1945008e11b54bd58d', 16),
+                    gmp_init('0xb92e0380c859e3868d15e2f9c0dcefd5379418e56036e20b21992e27484fbce4b5f47db841907e1a9666621e9bee2b93', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf90aa7830fdb4598e3faa427b9b85d304d34fbfacd8692ca72ad75e4536c53090453b40a2f5b6556dfd3f60ee35313ec', 16),
+                    gmp_init('0xfd3538da2d403db4fa986349f7e2574840bdecf62521b21acf51acec9c986500e443fe1bb05c159cb183e0aa17b87c4a', 16),
+                    gmp_init('0x81a82e364312238d10aca14b548714ad69c0a9bc97c190835952f7f9f0807a4c456745eeeb0a97f44463612e32cc30a9', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xeb75ff66c43868b35e116ffd3b00bdb1627e65e7831c32353bc7efc1329086a95ec2cc25151b231aa3121180cc591d92', 16),
+                    gmp_init('0x5a245655c51ac718c0170d4ae5c1b3d6e4250266339b8f9e55376cc322e205944cf82b6f451b3c838031e58d67f5ec45', 16),
+                    gmp_init('0xdbd95914d2f5ad32717c8af24bf7d807527437b1f7fd20d9f9cd91248ae482ea0ef41b785ecb64fda37518bc40b1897c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7ae65567a8f742c80431c448e906083ccafda282dc9c3c30d8acec4c0cb4902bd76a2d78fa1ed8e04a4c4b0de8954d07', 16),
+                    gmp_init('0x4763613e8cfb044a9c02538318ca26e6654fd94ba5c107995ef395b3b04546a1fa1fd38296a8e7a1faf1b4914ec0aef6', 16),
+                    gmp_init('0xcbe4fef802929b7191bdbb5452ae3d433c7408bd0239e6bdfa5eca0517a154c87f88afd06a909336d33acd9e73cf06fd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1971a6ac817bd1c937109bb7e68c9bc3f2210390e748a3ac23d162fafed55eb3b38bfc009dd646f2b5a9b6ad5a1b1939', 16),
+                    gmp_init('0x757b9074d839c7fcc2b905d8d45a38f1d8591b755ffafedc817f80477fa92f73819034b12ad2f5e35c8d0f0493d0af68', 16),
+                    gmp_init('0xf2a1e69ba76934a9af959f03b9c40cb13a6f5eed618ffdd873a26ddd5ee5e0cfa126ebaccf4e16a6a7664d7a111a19cb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3118c69f6570075e58c81dafdbec1a63eb52af775fc30e25c76ec30e4a0b37fda93d7b0bb5f2423c8ed3e59b23894c64', 16),
+                    gmp_init('0xbd8646c4b0e666393effcb22e450ef1c3ea84e29aafa813f1ddae856cec30d60ea0ec82163ba4195f07f693934e16be6', 16),
+                    gmp_init('0xf475f12d0a1b7c93cdaf70eaa820462f759fd19a5ccaf4ef00d213f39e8d42ed08fdc63fb7fc8a84e257ebd972957417', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2bfdc62307009416aff847d90b664230b87a95e572c3ae2d9ac88fe64881be29ea14600229d9214023575554f06c65dd', 16),
+                    gmp_init('0xaddf2c76a75e3485821e69e40383980d06204021b1721738caab745284270ce3bf371d0852b4369cbb60b00a85c1e178', 16),
+                    gmp_init('0x4e908e0502f9214d3d6339ca7eb556c5116bf5826cb2e8061f91548675a50cff0d3caf2184b11bafa0915589e10070a3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7bfdb60f9fd933d24e1a3f9aed4354e12d23791b950f4398fce28343ba56e56417557ac5a9d75eeb17944c690eab547', 16),
+                    gmp_init('0x343698786c6302cae93ac32e1a20413f766024a4e5b2ded5419c86b54cbe71e64ef0398e6c03d88247137319f782231a', 16),
+                    gmp_init('0x3dbbcc74622cc4590f459f2334d9bee26aa1c13f4901de7290aea93ec3228b662366f58837dc0f948d8b1f3c66d49ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3c0502b4f31f5b5d3eb055bc7fcd11f99f33842c8eeca959b63feba009234a28666f7c8707c23bd122358d24ff964650', 16),
+                    gmp_init('0x862f4e7b7b182cfc326ba5c46cea08871032323742fbdf9e4952f95faf8e4f561b72ed705b1a6e5e20461c4f9cdcea9', 16),
+                    gmp_init('0x8914360463031c5e49d3272984708f2e8097197ad6c6055ac1de50f258f6b9596244efcf3175d632ba1890fc95d7cb84', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x879913eebe97fcbbf87bfc7a877610b7a9a28351972d7e4968e241c4af59ef67b399df9a438f614538084caa7e93fd21', 16),
+                    gmp_init('0xaa7898258c933c3ca426bd2976f60e61c3b93170e09133c36d3dd301a395c6b3b1088fd646ce8b3d273e003a13062345', 16),
+                    gmp_init('0x44285dd4cc37bb5619a185834e7fe3ca876ecd76d5ad87a0b0c2aa0c00f033714475d2270e45ab010724effb087a63bf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeff9e31dbd9633248a0d585e1e6ef1112db800970fa7a62ac1ff060bb530dcd503cd7eb0dd22a7f324dff5c95a8f1fb2', 16),
+                    gmp_init('0xecf0e47b596dc4f2478caf335a7507b2f29e48eefbbb32b1755fe9d718d85bdb0cdef1e70a61dac9f50baa8cf58216fe', 16),
+                    gmp_init('0xad9c94d9a9f88c2293a56a27c15ed5f37f4ebc415cd8780423ba6c9cc5445074e780bd96fa28db56c2ad2356ac22898d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xef036efd09869d6de2c7592cda4a810e039d8c55fb8f6976006c2063566c53a28416b455f6b376bbd29448c174c3e022', 16),
+                    gmp_init('0xfddbf7bfc1bdc1dd3281ca1292638d16cdc575418ac53eb10757ba5b71f272d5ee97200894b84eb6ee6dc77ad5c9d8ca', 16),
+                    gmp_init('0xdbe3a84f26a56de63768cad80bef521838a9c8eb61c26695e183aa073b159f29b763993ce83f6a37985be4d8c43f2ec5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6cdb7ca2d1ea758ae560c6746ae87409820d141329a7668326dd89529d3631e55c06b038708c1b20f7a1040d4144d58', 16),
+                    gmp_init('0x9f32f9e0f552eb5f5c98fbfcd99452949e11a1e3d8bd63fe440264820ff1ceebeac995e5f4908159b2e1e7c774635e8a', 16),
+                    gmp_init('0x84818a15f64e265b1292b408737e1440286fc41fd5b6de26c775ac15df144f484d02931e8b5c1f03fb022801527b23c7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa743bf6386583772abbbaf287361da65173aee4a01f5b3fc1c71f4247ba457f132047e78151efa37e31d38e075b2ea5e', 16),
+                    gmp_init('0x3eabe22bcc2680cd53094aabf5e791fab97ee69b2bfe8cacb7ac9cffcf64172b101b16630ee849b93762c01404eff169', 16),
+                    gmp_init('0x794ea4cc37604148bbc7e8ff3ed9dba39bdbba2fe10c54be09abd788826439b860c93e0038b07de39e96b66ddc8cd28a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa3280444d505f4d270eb6e866f07118f5000b919ccfb92bce55cec8c69fa2dc87bd2fe2d73459cd0703a419f027527b4', 16),
+                    gmp_init('0x25fcf89b76991cb1f364034ce57431eefc63a515a1b162757bef653bff7c85876c60f8749ea972e9b9303db62d540744', 16),
+                    gmp_init('0xaf46fb0220e26e0a03dc89e31dea94702aca5c4dba33a43247daa1f80f94e065de588af61e5361d1f231beb072eaee61', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6b7fcb03d5ff0cad545d787ffb31b6458212d7cf05455c8d0477ca8d1cb69f11cf67f8fb7256c8e2340a947593e782f5', 16),
+                    gmp_init('0xeb296667c46e6e586dfb42d3d88b89b49601eb83359fae51d70b3cbc22395b54a9bd3deae0c05f7375ccf105e8a6633a', 16),
+                    gmp_init('0xa167122f619a7a922fe40da8160a64231cdcf04953c643e144c0d66e59c629f21d16f17aa4644ec5b74967ebc311f7d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1bf78ddb7687d5a1fe6519119f73ec52f53604a3977129cddf19ccaaede7d79f044ac9395a9c8f8dc6d704e9592a15ca', 16),
+                    gmp_init('0xc4eebf6dd8f01b8b53a0ff6c2243fef685996a5aa4b7d0b80bd47c7fa8cdf9d2c53ad15423a9a5fb057fcd68a19560b0', 16),
+                    gmp_init('0x96fe042806a25e39abc41d3adc5d3979727889a5ba0287789c62a5b450a6ec25e7b37bdd94e02a994a2fc3316472ad38', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc6b27294527ae7f0cd3b92a17a276f4e1c6e1313aa9c5784da9717dbd757028725e023a8de166ccf7004bbf2503e731b', 16),
+                    gmp_init('0xee69b6e16ae69a2985ec9f432cd76f3f6fdedeb0eca3a3785d299fc45576366923c73a2ba341ce1b2cc019f4a6cfff1e', 16),
+                    gmp_init('0x7e53a19a833a082e92a5b8d54480de2f0ce95409122cf2cd696c338f5dcaedefc0c32e2e79c84486759c2e1ae21e3e64', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa8578ced94f567d09a0846ae1dd8e613665a152ea3cf30ec0f528ad88c391a6518b69208ee680daaf4faebd5c35ae29c', 16),
+                    gmp_init('0xe125ecd26fb566454b810a2098438f42c99292d6cf66c084f8103c07cb0bcac8905a81ed6bd88523a25fa9de7fa01f12', 16),
+                    gmp_init('0x759811e6d4ccb4e6cedad521cefb2dcae32d465139135820e45db36910e998f8e55db1468943e4a43669a7c595a30ea2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x97a28cc5c0e3d3cc5fb461728ac11f84cbfa48b11518c7d76caf5cd055cddce1eab768a382b13d6c8b8f748deb043017', 16),
+                    gmp_init('0x5a5a578c7435a42e4977ca73e34574803ef3d7c94617f79a52329d596a4be71ca3676cc214e5d17d650392f75c7d5f6a', 16),
+                    gmp_init('0xc31d38a97552421b041cf615b5f877b5442ffccd45c8025644d9086c01b4c90319e39c67119721805892f88df718095e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x69272b48395653eba155dc85c089d4d2ed3a5403ba8270c67dc703fd616659df434078c84c2b0d9c05ff50691c6d50fe', 16),
+                    gmp_init('0xdcacd5fd854b6e22453cd3009e7e4441efbf9fdcb9055bbcf6e21e313913c943fc483e55a7c46b52d47bcab3c6c30c13', 16),
+                    gmp_init('0x971474126b6cc3737c75838d1ab13e700289a2db6be5eb124a8d28d51f1d218f555e75cceb585589426fd29519964fba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9f3e6f356a23e8dca0467e33fc8f8b3a51eb771b9ef8fcf12903e9cb28fc954083c789cedca22e4033ae4c731a73cec4', 16),
+                    gmp_init('0x50e47041beabfaaf2d8b77508a1bd3dbbd0d9b3e1703ced16fe06bb0fe1b1695299c2e524c5bc1ca15963fb60554ceaf', 16),
+                    gmp_init('0x51ff6fc07e917b8e6a28f88d1567b2682e20ce0f77826c76ecbc2ae3f0115a0cb328954ea42db6915136f7fc8eb6dc9d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe78ee094490258aa2b9ef9614783340433f74e0f3ed19e6a9066fb12c9f4db8bcdd42bc7d7a17ca982ac21eb0701d5cf', 16),
+                    gmp_init('0xfb2ec4fb43b3d6f23ec61f41f1ca1f59484dd3cd58a7c4191a077b293036c8cbdc8e9694de2d68ce795c331c71ef316f', 16),
+                    gmp_init('0x610602ffcb89fc2ffab8bf93ec4b47ec4c59d4b3e7c47e80811a06d0087a3094be7a2537fbecee1810f9e04211f20485', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x67f1552541de583f4e576599e97c0d346a89ec7caec0f4a5da0f25332598e0d799d87206c2f5a2fcc2bb37c5c08002f9', 16),
+                    gmp_init('0x6a8fb11f4729b54ae9e40a0f1d958372bfd182e0c9150a50e6d99a5d821eaaa24a026b4212c0bcbd10b37ccf3713ac33', 16),
+                    gmp_init('0xfb3b5b942f82701666d35f68954954bec48d5017571162cfa1eb5becdf41b7fb425ba5e0a0790ed12bf31f4ccaa5b22b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc437a3e0a3e1d3d1f675df7249e6f2ff9c6dff1bfc4b3011ee60e8d6df00aec995e09c1c03c32b4453fbb059aad31077', 16),
+                    gmp_init('0xeba6c1880abc80f699e0caf6df35ab542995269cc9c92bf027faead03d6e291eec93db628d361b9f463f345cfe896101', 16),
+                    gmp_init('0xbb1eef2d9cbb5c4f03763dcef5b4cf95fb535f7a0a65a60d062a868674e3e07c293bd29bc38bcbf53af6d4612a83dc95', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4ee4f4d4f5dde1c3febd8bd7d10f216870ebcd5750d9a6d1e19373a3118bfbff733609c473c644a52269903c805580a7', 16),
+                    gmp_init('0x985b1dd6afa4d823673a7abe06057a13033f75e65879f7ed99f57da838a99c2fc17a06587a7fffc219591018736880da', 16),
+                    gmp_init('0x9df616c45eebf688afddce51912749359e477d4f2c0a0699f8b6a529a3ec550836a563c70fee7eb34477e3ad32fc84fb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91ea17f0d9c3ac52ac23f1595c6eaf1ee043636c7fea1e46fdbb02eca9d5b563751ef2594a6745c74d97c358fa5fed16', 16),
+                    gmp_init('0x2f2a846df70c2d474548ffc7187c31ee38f8f66f907273737f6c2a866d036d34c342dd4b1ad9b721867abafd9ce9c1db', 16),
+                    gmp_init('0xd7a04eccb1b8dfa6560e624bef20e5c551f66d2b5b64c101d6ba771bbf7bb6cae2e576710f480eeddc20f0b0a579351d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xab1da0e3d9e4f98442d69791cbf23dda7db7bae92f9c53dbf075b77f34e4a651a7fd462e5f9b5e3aee6d7de8304b9f08', 16),
+                    gmp_init('0xf04ba21bf419a5ecf07f51630e169d31f0a973831dc35864e1185d20d04bad37a84b67962fcddf350279f939a0a1db8f', 16),
+                    gmp_init('0xbdc63a4a0494448c6670e62df52ef3ff5713daf211fb16ff611e6c72dc7e92670a6d59a268da3ef90161ea9dd67e98c5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c5571decd0dd9f3f45a4c9b09dadd3c62559bbf0742b3d36f68d4fc75b658af9abdb4721888ebf043c25761a4d70f7', 16),
+                    gmp_init('0x44a6db32ba60f2d2b9d0dad0fb7eaf5aba4eea31244870ce4022f48c6d56cdbc02de138a75f5f3ad79091f7cf02cdac7', 16),
+                    gmp_init('0x6ddc7e0d979a913bdc4ae1f4d8dac7d37441b01a566a50c8899a79e5e08e96993603d95ba59e93b718315e48561dcdf7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2add70897cba2b6a71afb22ee19ff14fe2c0585726e9ffa0692d111ebeef1d980a0e86c60a02ca024fbf8a9f2f7e5c47', 16),
+                    gmp_init('0x36e251b7179fcfd372e6f3bf464ba93c8b799bf0df2c4d9332fc0595ca7371dcad88170909be7f916467c294461bb711', 16),
+                    gmp_init('0x61712a59d5b23840f878624a04fe1a1dcb9b7f5e1326def4b6fe2ea13db0314e41e77d1388880fb96f44b93567d041bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcd389b2b9fbe3aec553e5e72e7ca178cee7264ab1a2d0a1912fbf19f82c7ee1062e22096c06905a77e5503624f4984af', 16),
+                    gmp_init('0xeb596189ea29d9c00d2b4bb33babb5b93e455e731343372bd014a26e723738d292febbcd7f1bd9aaa886f04e4d670c7f', 16),
+                    gmp_init('0xf4e6b9e60f09017de9f80f64ecf51254c8b9ac6e6598f422fe08043e3071c98ade14f02f67c7c38717bc071dd26905d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdba68c0bb0663bdc4b9b67b7fb208dba4dd61071a3a7a262895ced8f88b53a311c65394392a57fc90722b492b30b01d7', 16),
+                    gmp_init('0x4f6e8d2510a94ce3d195dc01acbc87901996a7359824c5341a3e3cebd4746858e2f78669bc48463543410ed2ff422331', 16),
+                    gmp_init('0x1ce6aa14b931d42eb4b9d7aa2b5d6d31c02fc35c692b6239fd0231d531e4ca8df3ff7145def1290517b91641cbd5906a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x487eab709aacc2c39c008f0a00f19be1ff7b865491d7aa3e959bfea709f6ea1a248aa7631a50074d545e5eded4a5bda3', 16),
+                    gmp_init('0xd7ea640a9e21df173eafc0f3751388842042f874aef00d1fef74dbb8208a2f8a2260ef0581b882f88af94fe6facf246a', 16),
+                    gmp_init('0x354f1ce836b7dfb33463eddd77c03816f4e35af7239e944199736e28e9afb03a160edce70c447c832bd679851477afda', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5a40f22ff7a46cd59351815be11c80305744ab1e0bff2f00e402ca55926e90e9196ec8805d6e5b1bbb847230a07f61da', 16),
+                    gmp_init('0xeec6bfda36206074d6f0a8a01602e0f41eae43c6dad68ea79b6901f690f266997d6b01715b5f8e5cb58d68ddbccc94f3', 16),
+                    gmp_init('0xcad4ee80e0fcb6330f222c5d840dfdeeb123263dd22cf4e90fcc209242974a0034f645c95ea5e903f03a8a975358ae4e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa8a9b1bbc476d77d2994f7c12fdc3d91f7599ce8947cc53bfc3a655404887d4240ded05150fd4c1e4efc8447d37fae2e', 16),
+                    gmp_init('0xe9d8a9ea0940b10617bedaad86d8d249643b52522d8c30b7e20774e1dddd885fee31f9c2241cc3b6f33b72f3e57b1616', 16),
+                    gmp_init('0x75e3ce6346487da1a8e511fe21e9f4b789236f0436190090cb1c0c851374c12a30660fa96cfbb7a0ee6444c244a193d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x64b138a46b870e22bdd3263236271b4c0c31b5179a7cb9bfaf5d5fc3cdd983dca5dfe776ed54cdc5c546625f1c5696f6', 16),
+                    gmp_init('0xadd7277625510b244eac89ac73109a179b3f91a42da56a436299790aacffd8b37327878609f60fe52acd644339c25251', 16),
+                    gmp_init('0xac9e8c19c79c911f996d9f1659367ed8b53439f4a1c1c2b0d14ff7d59695c559982feeb28bb55bded59ee45edf69d50c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc1994fe5b8c26fc42cfee2246e47c9d7cbab98ffb1d623cbe12c592ac0615f3737be2fc200bd718e8a3e960935e4e85', 16),
+                    gmp_init('0xbe0fa33969d117fec111f8aee5d06c19c63c88c2babcc38b870d1cb35b944ea8ad9614c3c9fbbf8d676e3a17a329be1', 16),
+                    gmp_init('0x61a18d1620a6684c5862d88b840c1b1cecd0277ca0600a32ec4872e8b065d9a75ca625c647f0600c833ffa613f78f4af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4249bbbab01b139dba8b30112b6f5ff9c3e7f71fd039a0d20f2d15b1cca07f9013a3b69b08bdbd45f1ffb73dcbbe3d2b', 16),
+                    gmp_init('0x4f47774a135e432225360ce480726c297d6ed7ed250f0165e6cda2809458ebf54250072ebc5574f1aa653a8f55cccc6d', 16),
+                    gmp_init('0x44dad36cdcca695b2dcc45cfe39768081b3f456e1d14cbc054f035a3fc8c4b7ac92672bf12cdd4e385a2f28b5dabe7c4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec633dc59c7b1a45926aea79473f9775001f6d20a640f77a6c8626d674b26482d1d78283368532e0115b957852e7a266', 16),
+                    gmp_init('0x7d68f5aee528207aa3c5fa2b2fa25b943f7191086009a9c60e7ea93f623dad4547985ee3be5bd0a3a5cbdb266d56e205', 16),
+                    gmp_init('0x7cc2f0f224557d56d4ae09eca7e09f18fa4ae3e191e0e26515bbaf2c437ee6ef33e8b400f29a3068c66e5e0d68572ef9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7833bcf2996b8863790600d86859ef54c285fb2ef2951f2e69c1a0b76834e1713d9813cebedc65a1621f599226d9fa28', 16),
+                    gmp_init('0x54f6d9577aac4f6174036dbd3606ec4c5df1ce2fe077f3e12c8b746841b1b23e003a819913f103aa16609d3eb97633e9', 16),
+                    gmp_init('0xb8f6970733866a0d1a462279b7c0ae7f47866eb8b3697a2b75256009a5136d3c0af6feaf689d9950dcee22ad266bb7ea', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x326c127991dd4947e774f1174bf60cbf5b048d1c4f5d1b19b69c9e712bb93d2a0c7d20adaa07e3cffd814e4b76adbfe6', 16),
+                    gmp_init('0xbf5005636620c2262a93f587a5ac586472013208606f4b3c33a4555ea010eaf6c74c41538475daeccff407bb03619628', 16),
+                    gmp_init('0x8347ac19359f8e3c7f62aa614200dfd84b7a4bf2d1e821974a673b7ca6d1fee8ce89d19b9330a93c39bd0a0ae42318a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf1d3a41561554c2bccd61f4a1f984efb66dfb765b8c1eee3b50007f4577f7ea7bdf999636ba5686b8c9515d1bb904ef4', 16),
+                    gmp_init('0x818bafc2bb8f6ab86e1748ccd07af4654884782a4c3e20250ffdb0babf5a67419a137f6390f3b61daa1ec38b96921fdd', 16),
+                    gmp_init('0x1ae104b5f1110b4e6d9ce40a7cedb97be5ab50f8cd1a4c6722189cdfe173f63a5ed759b91d4ca13fb2bb181458496a73', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x721f4cda1a79792420a353ea2ed24bf2df3f2b967b937ce160e3f3f510b99b4964809a82431fae8f7ad69404ea6d8569', 16),
+                    gmp_init('0xa78fcf0549b03cb068e72dac96ee61f665b8f8713d6774c59755de3e3cfe784b8c0de031fed73be70d132e22d9b74bd8', 16),
+                    gmp_init('0xb5c5f6cbb889b0114710dd082ab8a2c735e8435f03228027ad9d523e890262ab381d1d0bb080d4921995f059e03d25d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3cf0981182c0b45657cd71da6e34a931df5b20cc41c2d7aa377e1200ff02aee73fe5ade8cf1a6c6ed5211eb5931cba01', 16),
+                    gmp_init('0x4183ee2520e47381b8cb1f4e7e17c4249d33a8885572b52f645c78aaf3eb776e49eb83a66356abcc09d01ff108f4e65', 16),
+                    gmp_init('0xb2eb327f0f8757695937a241678e2c8aa406afb67f5e7abb20b4308a7d134a4ec693dce2168e22bd2e113df7ec5e085f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x135b1f6f470a0b8088b61a8601651a14c6add52679f36405d772114de56eeecba4e4f6387f6ada040ae5b842edbe391b', 16),
+                    gmp_init('0x41ecc77a2f95a58f2d7cdf420d7289424d0aa45dbe99f3628aa889be5dbc8881d3931379e2fb5d1956b06e5963bb88a5', 16),
+                    gmp_init('0xa54e159a6905d746ddc8da575b4794883c3a286e4978745795a452576528e405c8da808722df672b835fd628ececc5f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xed8892ef14e69a26b94e7ab2d732a31a0b3c6214710ab85081298468a31dea85ec1e788a06069599d257e283937d8033', 16),
+                    gmp_init('0x2d6fda68cfa55d67da8e57bbef37aa41b1f2ccda1ad3a51784fba8d9d38600c160bb44cc4996f65d6f3b876e815b1340', 16),
+                    gmp_init('0x9b70eaecb8e7c39d2d63ff986ce54b0a3b66fea66903a400fde0560b7d2ea41411483cfda0b36def5ab22133f663cd1d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb23faa834ad9dc3600c2be09ccdbfb4142a9f2a8a50c950c41c4b4bf65da211ab27810e3914c0736a648c78788dbd386', 16),
+                    gmp_init('0x8b8bae24723ee65924d99db82d107987f16d5b1e11f074f257becdc33781b5f37195f20a2c084c0548a765b0e5c1816b', 16),
+                    gmp_init('0xdd495756e7cb2a7a3fd5a5bead70f10bbb9bfe1f9a10ac9d2cda7d3a3c757c3a1504197d5dd6f96b8ada6bcc2aae821e', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xfe10b17842254a925ee062ddc5991cfbe29526008004fe874cb1002060e8da7c92ebeaeadb373fa5e1ee38b7c8e9f555', 16),
+                    gmp_init('0x57cf2b5dd27e3949c71c14baf39533f3f019da1525cf826b7951c824376442d3f826b0cce6331b927873369fa08e3131', 16),
+                    gmp_init('0x789cc0c1ad9ff451fa66e7465e198ed204c2e09c3a986a08b56b3ff9a11d5557afc7e6d4fac86fdfa5841199fc54b39c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf5df736fabf9003a6979f9220decbdc2a53076d59853e01ea0af027c3b89374beac33169209c676882e738a9a4188c46', 16),
+                    gmp_init('0x728ce30e492375ec50bd1b7b411821a1edde69f3254459a4e7ae71e609b3f2c891e77b99bb571f2673e0d71cc5ae67b1', 16),
+                    gmp_init('0x4fffe2d511c7ed79d6eab49cf32cc481c9fee16560c824b3c0f3ee910c3c5db2cc1ca92b97c2f8df30b5d5b58fc89c95', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1102e5bd49c410c59f59c3bc442fe77b7b556d836ac318a6f9983b14bff7abc6960491b65b4e57eb6915870eb9ee80a', 16),
+                    gmp_init('0x38390727c211f80548ffbfc3e9637dbd4eebc962a4881c06da40b2770a1d445217c770e65de341ba84684438e3a4ba93', 16),
+                    gmp_init('0xda46d439c9d8644dfadc2fedba01a5dc671f05fdf7e5c6c09e975236903b0bc2d964dc9affdbc5d0699a6600ba9d3b22', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4584e4a9162a4273efad0e3131c76b2c3049096829e2ba9d4224f3b9c485c8d0438d70279c2f10c9c5df5c71b8918317', 16),
+                    gmp_init('0x1c84b763e16ac4fd232bdea52617fe004abc3a4d8e11d6ddad751f7f7e2a6aed1eca9a7c06c78b7ca24ce71134be6f10', 16),
+                    gmp_init('0x402fef5bd69fdbd3650777a7e85b63f6372e3d4a371716847142fbb0cb9415b5f344df7ce2805d62da448c0f4dde93f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfc79ed3f3a282d34e48af6d8346724b242384b93b2b5b4c23e98e9a2d117f80723305f9c9ad9d5d2ac2b746cd11f3225', 16),
+                    gmp_init('0xf1f930393dd9ba51a49f3614f147973d5a1084ed87317c69e4ada30c9f3c5d2ac01d3d9052335d8829db2837773f16c6', 16),
+                    gmp_init('0xf013dd6cc6b15c8d6fb606f9349655300bf8a96af7305976fe4764de5ab75c5a6bf0033d5758028b417c1a3c26d0cdc7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35fdffcbde3990b87eaf3bbe35393a06483c523fd7cdb52383af635c34842275bf02301d0f7e2ef389374d4074a5f169', 16),
+                    gmp_init('0xd5ac7995ac5fa8dd6e6c420ce8e2e7a976f5cb187ecdd6ee55ccaac9e5ed4e84701d18a6d5da3cf3f5e2dd72e05c8c72', 16),
+                    gmp_init('0x1fce2e6100b954306a4d52b2ea9046832c6c86d97e3f2ffaadc5e7bfe4839be10a91617727a04b078b0f2477ad1afddc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9991e426c86effa4dfc92f127204ef0bdb52ce4985c1ca7d9ec0507217ff2b1bd6e2a0cad17cad35eb992a54e61fc926', 16),
+                    gmp_init('0xb7f5184ef4afc4055e802042c2d62b7c6e5ffd66c8cdd8c7ad60408ac4ee354118657c6e5b825d5195ce49ef2f7d0e50', 16),
+                    gmp_init('0xef7fc6ca446f3f40d94847cb4af70ae19d3f727019e49e8ad3b00a077752a8bec224a6d6684919a66b8e62487423d994', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5f47af6cdea49ed130393dc6e1be4312d9c76a5fdc3644efba8cd6149428057b1fa58964295956f47b357091ebccd68c', 16),
+                    gmp_init('0x8250f34d5d200466e767b9aa3c39754bf3be90b2b2ac1fcb730f659d50b6611e00d21be69e4487b101794096c4918840', 16),
+                    gmp_init('0x20fa33400e68d4c02f67af2ea666e5e5c8273559867d30fa16432c628cd947c7c51a8052738d6bf849feab95944408b7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x188aaa3c8b605e6f842a311a8ef05af09b51dd439d4d5b29b6ecb54bf7b8a07025dbc44d13de8d3ce6bae83ebf651277', 16),
+                    gmp_init('0x3773e796d77f08f16a7e2ca2777fb3c930924a3d6782600e9a7f7e334453b04a2b43c9a8da36fa0cf6846a1ea083a0b6', 16),
+                    gmp_init('0x2d480bff6b7d9a2c88b2c55b12dee285df7a45a67bc07904bfd5063c20dc3c57759343853a22d24d235cb018d97a08f7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x434513b302e8c5f83f74f15122c011cbde6b7c43a3938070a7170123cc83a8a9d332614c6edafca71bcf4baf1f64c93d', 16),
+                    gmp_init('0x8f6a3b486cb29cd603e6f0056247d06eaf0039ec47ef7f179a752eedcc7e38468ad580a642af9117bd125a6757c475d7', 16),
+                    gmp_init('0x693546bf9694619f4c4b806eec97eb217c16629e5e2ba80a8ae9ca388580017bf68bc89e477a2476282e7cf3adb36112', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf6a57235ee07d2a9f205eec37cccda45d7a45b860d5451742273fbef10593481cbe853b2f02a13316d70cc07b17905fb', 16),
+                    gmp_init('0x2f0c76845a64cd9256d756d33ca389ba9d92aad1f1fee719b71d677da2170d884f91da4308207626421ad23feaf9eb65', 16),
+                    gmp_init('0x8e2bc5506d4edb16c2d484584d23ff9a73c2ae0f6a39b0f77bbedc6692b8d23b9445622693f5686e373da5ed8c0b3e2c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe56fc9af8bc958b24a3ca170b9168d8c53776f60aa455a34a9306bd79c72e57e6bdff628ae5de60938479fe3962b4034', 16),
+                    gmp_init('0x377f42579b0288c9617be22c3c1cde50206c84cdf7c21530cdcc84beb880cb28d14932406584b28d2c28ac74fed19bdd', 16),
+                    gmp_init('0x638875858b0c910a00e842b085c9d25d278e3eca19d43b8156e0dad0c9ac873018df7455e4d5540e060e0f9661620e4e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x25450fad1db2d76905149285eb8b9eecdd118bbf199449a5c92105a4278dbd09c7ea10a84c8188fd65496aa3fd0cd151', 16),
+                    gmp_init('0xc8ed77e918e135fca83207a96431d56c6e1eb9e900b6211eefecfcc251f8a77c2488a61dc5c4df2f86f1628027a0578c', 16),
+                    gmp_init('0xbb46424c1528c9d6e9e0d37b33c4ba13ff70db237e44e57aa8d010fa26bce9fabe9df29aeee371588cf3f131e54b59b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d3fbd76240baeddd53f86e37605746c90d464b7ecbd6dd9ecee2d75de991f8c74d93f3befecb9a703b9e2f35bfc439c', 16),
+                    gmp_init('0xf239ff9d434fe51d0e5b66854fe4241a15b3ab57d3001a9d51849177cd5ed7dbc5d0f0fa63da600aea57e59ffeb843ab', 16),
+                    gmp_init('0xdcdae6c4e628928d312e255efb76f99f36477d2d4a4c7d26fc3370f359aab9c75d27c00b2c9dc35e7722ce1950176930', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x38b96faff14376adf4c9d6b29ceb8ff3e29ee4c91337f274af0ce73faed93072eaa3ae11a75b4f96e3559f9e469f461d', 16),
+                    gmp_init('0x493009a7dd9516cd554f1b575d897d5838b076b05512025c04c00980dae471484a240e481e1e3322bc624eec91a270a8', 16),
+                    gmp_init('0x6e6f6a425a4de5d8fb7e6923614ae30f5c8781ac838ffc8844fc6b5827a7b93b284577adc057c15afbd6cb84ad095f9b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x7523a1822f353bdcbc343eeb01d80f4834c924e6786305a9131b1b38c1fbf139dcdd003b928946daaddc66fd13a18bc5', 16),
+                    gmp_init('0xf5b84acbdc41fe0dac2cc021b05af6bd9a3d0fed94de0d0281da358abbd868c0b148c3c9e08770e5d25dd0bbfeb1d831', 16),
+                    gmp_init('0xad1ff4cad0ab54d01e5f51ccb4151c7881d027336633d407d59333335fba6a022dc8030cebebceddf5c609f71e76489e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce913340020c9c19578f7a99ee4cb6e436eb7c0e0a8f6b68c23aa0730800c3f86fdea8c76182b3b66e5b325a6ceb3c0f', 16),
+                    gmp_init('0x435b8e2ee1ca2c6aab4e5d48e6a566c92650f28479aaded92633c059c34c9a9696b419cd378dbbc66eab5e5f02324aa1', 16),
+                    gmp_init('0x43d6d8217577756b5988e274559816ab094cc7a5c8a43e3522f14ea23bbe87cf42dd2afa95ba007143b55281e2123473', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8b2c648766701b6da10ea5539c7ea0da5ab2507e458ed3744e3acbd82082afa2c7754be1e3551eadfb83f1ddbf254a5f', 16),
+                    gmp_init('0x1abc90f3d8b61f770f6de9e61654c2301318cd91796a97c67ec401ec12347e3b358f23b0649e2ad402fb1aa408b706b', 16),
+                    gmp_init('0x7f2c06121805b476c98f2ec379c6e37ec6f70a53b24f1cd053298087d4e03a2908abfbd608dcbb0a398c97dc8766c6af', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xedbcb0fa9c2b3187892dd62bf1c34e4dc7ea76447298bb1646cc85c4319fb16fc7ecee8d4da31f639859b312aa2801d7', 16),
+                    gmp_init('0xbfa6885fff897cc3e6e0ad6b0efc10f5104781bf15195f095737afad87b8adbee7f19a6472c4d0c604da80ca7bb1548b', 16),
+                    gmp_init('0x8dc361e57212104fda047cf2ba378b6900541437d2808d606128d399f4b03361d791201f751e6f26fef52c153800c8bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x458d4796a7c7dda32da17dd1364c5fe2d29bcc5bea9d7a453834c7753bdc383f28e1e23c69853668c24de901b2a4bd28', 16),
+                    gmp_init('0xa420cc1895dbba7973ad511fc4efd60bbdbf1f67f4930be155b7857d5c19748a0fd3c563e991a03c5be03ef241dfa955', 16),
+                    gmp_init('0x1aa4cbbf88f86132bc49004e1ab7112034c5e5fe6bee0ea6a09cff2d2855d3dea006f34a90f858f6230db62632e13975', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6a2bb96fb4996b968bf9164cb94356f6ebc7f9beb4053181b573d411d24ddfa72144690c0c7972e2a9a4146a2f1a7101', 16),
+                    gmp_init('0x26ceec165d9bde68d5ca9a8a84680d2981f653e1d709757b89bfbcc630f857691f384c545d08cdb2ef1ac750a2c8b4ae', 16),
+                    gmp_init('0x8f1c785362b65daced62f22702d25b7eea9e663c43f06b362b31303898f7cefb392b47f38f51ecf7d53925a27b956087', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8aa058193e4d4c2e2a5f818c9d1a3316af42f377721b1d7778909029049c5eabea2ceb40b76f220c296e0821c70f7dc8', 16),
+                    gmp_init('0x9025834e4e8032c81df61edf3dea699b98c626c97f72856f29a25d3e73bf8e96628af056313a9a110f38038db50ef03e', 16),
+                    gmp_init('0xdf5c9090809b049e5aa442d45a5e80558978c5ad3d25f4af92cced28f7ff4979ddad1a7fd5f36ca1f627dca8d0c06b08', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9fe94e1e90b08e1241499b960918964f34e5c4b5018cc3506d73c960ef015d436e42629010af977dacd8fad7b695e906', 16),
+                    gmp_init('0xd7aafee18468a7dd7b5e1269a42fe2352896e40087984b403ee910c56f50d5b42aad66ac39b457a133e4401eafc11242', 16),
+                    gmp_init('0xe1840995ff0f6bf20538236a1f7fe7744cf40dfaf1a6ccd43b44c14c5e4689d45af650267366eb129cec149e65c2b57', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x77eb3f7ac1ff93285b39df4c2c5d24606c857bd730a36ed2cdac250b40265440228658108d6156cddf3fd26ec79326ac', 16),
+                    gmp_init('0xdf01074c770b071b242a8522103906eed3cba43578b539debccd73ef89b59c95904660337794fb9e77823a9da7c5f811', 16),
+                    gmp_init('0xb84673cde522b58d68d5cef2ab21d67c3c7bee044e8078a6e36133c546ccfe2718d85a59a8055bbc35bdeeee41d82eed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3cee8e4b438da21f3e02415e67966aa149cb99668b463e9f7277613eb15cb99978be84ca3a69c4957f8ce3cabfc1098', 16),
+                    gmp_init('0x4de3c63821bb926d65c8dc6f369eb8733117b86a2db8f71e86cd0c1a8695c885a575da617aa3aaeedce69b5b0ba03f9c', 16),
+                    gmp_init('0x1ff3c6b607b6f8d7d16248b1d66ad121d61dac32a1fdebce360242b6891c19b854939525b80c94f3bcb4152f7060beb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xff6380ad5646599f58aa0a21997e4da2112f1d813f0f7ba4724144576c647d6db051d9793d691a7bb95e69aac1222d80', 16),
+                    gmp_init('0xcf2bef5b701794a51e0cfa11c26b19945c6db2ad012f1f2375bd409ddaeb3c6fd817d54c42189552cbe5f02614469190', 16),
+                    gmp_init('0x7dcf72331a82e9abd82a69a429af88a03cdc86e38b0a5a7049bbd08c468826030bce9310c65db8fc450c698e439eca21', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x13a679cc2198501a02c8ae03e2951dea16718cba0e3794d76fa623158223a18472ef7244e4e55175ac3d3bd0c34046e1', 16),
+                    gmp_init('0xbc717d1cfa8b04e140d7083a6b473e34aa550a33aa74083fc4d5d989494adab0471405370c6280cb547bc654ed4a375b', 16),
+                    gmp_init('0xea34b61f3c6243b5e4af5f7a988af384c1cdce31d9afa133ea727b0fc5c5c4ea249dbe5064c10e9f6f69d643abc28011', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x190cc47e0417d5728f6d458401dd68a1dbd8c85a6ddea35f933511f770a11dd3b38121430bc5dbc821bed7328eb541d3', 16),
+                    gmp_init('0x5d994d387b731832ab71d9d4720a860ccd4ca2192b88854ee6bcaf019e0640bba04690813cdf6528699f979699d00438', 16),
+                    gmp_init('0x74c2906ab883d7abf157a1a4ea1df885f7b82abf16cf2863adce58094bdd9f9318a1aba724d2c6297076d7cdb231d1e9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x815107a3d0ca01bb8ed42df60483fbc3b099ad350af3dece3d26f562f0679066bc3759f60768c2eda630e5149f0c3260', 16),
+                    gmp_init('0xe89c14a582e17718beecb1c5972261e663d2b070e71342a3ca7966be981c1793daa9810c306ccca7e247bd724b8aa54b', 16),
+                    gmp_init('0x25346915be2408ed74c602ee4bda5aef7403efb85abc27e8081ac07b64fa8595ff40a916543a5a2e67ba5a6fbc05435a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7daba3023dda4c0e7156d4e6a4a5e6486be892068fdf8babed5d2d8cb3f8b580b00f7878b4a83b6dac1cea120febe0a', 16),
+                    gmp_init('0x4c38fe4992e56316973de8c6c7eed445149b279080439bc850913e9bc771ac46cf583b762a5b1e1024ecab07924d6042', 16),
+                    gmp_init('0x1d18a494d2c3a1943a1bd330ecae1e9b8a02074e773f42fe2764264755b899353d8495b19f231db07b18635e7ac38129', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xca69c8ace944924e70f9a7d2fbf99e8e20eeaf7f2f951c6f06b213209847b58e4a7eeaab39a7f0b91f0ebb460adf0ac6', 16),
+                    gmp_init('0x4d5ddffe0628f36f2572f49a666aa6a424f6c38e9ad3186b2b41ab445ec43dd3ccba8ac5632c73b91086e88e13938f08', 16),
+                    gmp_init('0x473e5ac33764c4c6c1ae4a383bf92f0260a65eeede75fd34f020e9b3f826bcde441a226bd513d52bb57cf2296af6eac4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1a0459ac781cafb54ea48939b62fdc511c11e89c74103800ae6c49c48c16faf5c87d4351094e3a70309b941f0ea198dd', 16),
+                    gmp_init('0x3d55976b0b1d8bdb13cd7ae8839e8dfbecd18468d0f2ac16b3344f0daca33e850dd44577156c0d3197e060acbac244c9', 16),
+                    gmp_init('0x81cabe1ecdbdb56b3d9ae2bcac75fad8e00631b1474f21989840b1993222af15533e34c2680d32d57883ca3934b9e9a0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x28c96b9c93f18666112479bca17da24fa389380b76111febc1ad6a66083546fc7262c8e7a36b20ceb8c09966775173b8', 16),
+                    gmp_init('0x6147ae8659eb24c9eb68b947c253254b8d173e08ea35050d9b735db693e0b30dcb2cff14e72ad53418ab17751d31c485', 16),
+                    gmp_init('0xd3ac6540834e36093aaf0729059558dc7a2ed66378195c44901497b9896dcc5ba3d312c6cd4f2d2493db7151d422148b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1a6c50f3c88628a2635e34fea3087b2b8d98facf531dfab61218f142e885cdb8f29e75c0a2e226bd40cb69a2a840cfc5', 16),
+                    gmp_init('0xed0ddec6650860b82685952f6f940dfb00c9bfc9da462d7aa13cb7c7047eaf62549c29dff24cf66c8937629d3c046e75', 16),
+                    gmp_init('0x1a26844cb7126a01400f13906ed5a40e82097f086e74c496b9f1287af1581539e8e031542aced71282758c24d9a5c044', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfa26d40922943af4eeb3c1d325a36d821f05555c041fb109245f5fa2e8210522f8b937051f2b3ee9199976a6265fd334', 16),
+                    gmp_init('0x2f7a681af6217a83630ce8a544807c8370fdd62c9e73ccb56ec71fdb735015a530a1ed0227fde23a6ad72d8a137219dd', 16),
+                    gmp_init('0xd746e34ad8d9b8841fb53fd41a17cba9071eafe248616916f9e03855b1ff8111f8e813088f89ee274cda046bdef79893', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe40e37515d3d7941a4740ec8c1a9d95b091b37f1f924be82f0da9806210141e5539ab4b2bdeb1e08d41936636c15925', 16),
+                    gmp_init('0x7e792aa3f0ac8f87a6d9c00342ca20998a4be78a883578372504e7f4e4419e7b328f04eb3cc41ab54e778ba683ba06a4', 16),
+                    gmp_init('0xab9cca936e867a0ee63806726664560356b1f3f4c4887fc22f1fa39c83b8306fd7ff6ceda7b51f0ca156e2c9e55f5c60', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x432cc5d0b638054bd5e0710e3729d1cf55179a6542895124b7f650b9bbfad6eafdd2eaf2e54bc81dcf0044e104c56a9f', 16),
+                    gmp_init('0xdb0def9b7e14116588ad5542a7f3ca970dda6c0a6e0083489bf7863cd4bd4388bb70c2db36fa0daa1cdbc6ef2a64701', 16),
+                    gmp_init('0x85cd52e3db7fc8916ac4bc2858b4a8435737816c95b0bb37defd0c5a9d43d44b831823ac909d16070ac51a32ac1d0c97', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbbdedd82ede367cde58aa6a30a43b510e4680a0e36a939fa008e52248e192defc72a25af318313ed8d3c467dacc386e4', 16),
+                    gmp_init('0x7c7712be343d46cc38eda9de5f36f8e6e49938994bcc79e6bd1d3f23d3fe9018e21bcaa9518dd9c3940c8bb3381dd38b', 16),
+                    gmp_init('0x78c7936528500beb855334d0dbe7a3401163cd4925e58bf8a978e8ac9f21f28160e74223e22d662df62311a350983417', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x20885ab4c0ad88c8c2b76305b66a416af48473ba6c527ab3e7c2d86bf8ce68b2eb2182d89b8f15ef3e8ef848c3743189', 16),
+                    gmp_init('0x1a29b585cf8668bef1d958e6e371f3094a97347aa0f728189279d7ba57f68179ea1a7337b3e78e632c2bedf4233f967e', 16),
+                    gmp_init('0xe2ddd00dd27840df6b90145234fd530bd7c600354785cfee225519d24e59ee56be68195c8cc9cf41d06e6b85b02efa59', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2985fa823b8660bec0317198397547497effc82defffc1cabf2033620f03925659a54e7c8c96434423bcb43167b4ca0a', 16),
+                    gmp_init('0xeb1f54a94124843381427231e9d7957a4cae1f36f20ca11fb7510dd49e88aba682d6869793c07f219c2eafad3caf2f5b', 16),
+                    gmp_init('0xf1bc6ff1998a023dd3c6609fa43ecb300e3dd8c6015eafa05257f39cf531e4d68789b36153ae2e02e95f9cd39a21887f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x393355c09819d1d67d0f2cf35d897e939b6c8cc523078213c30c27da576951656931ad22a4485af4cc506507eb62deb0', 16),
+                    gmp_init('0xa00e22417bef879a4f170bf9d1db7c9680b6a89881bab450c3b8129a346fe48d504721487bb682a6c8f1ec557d71076e', 16),
+                    gmp_init('0x9257653eef6147f70c7398719734377df6c552a56294ebcd7d703220bcf5431dc5b2446f4011a6bd50fc73c019801330', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d28dcdea6e972c613c8e90e03c3f34fb312b5c3eb7a395f1847cc067a769a58968a381db40c178aa887db7f2a615d61', 16),
+                    gmp_init('0x4266d9da392a08cb64afa46ec91d2a4264c7f4084a09cf779a983332e76eebdada92615307c83e87c6c4368ae805f5d5', 16),
+                    gmp_init('0x3de486cafa1d7b781b54842092d7f01166f6177d5e8412e17c8bfd7c5d556d7d1bd83e93f8003aa23cbab4125b1b57a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf55e1b66dddf20ca1c5a6ad1ffc1067efa8499efd5473b2fe903d5fd04825aef4a58eb39d37aebe666186f547b0bb618', 16),
+                    gmp_init('0x6aff6cf1ab0b8a85a2261549adbf7abec9c380faf668dcfad873e838ce5f6b97192cc733a42ca4d54c147ebfc89ea7f7', 16),
+                    gmp_init('0x7fe09a7362e8d7adb6f80e263096f8d41d5fa46b89ddf2bd870072cbddd595c3981d1032baeb5f243a43f7ca6987b7c1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x88ce31da84d273372a7adfaa3579488b7e15dccec9cbecc411f937747fd3bbcabbd9f117bdaa8b48ac57ccb04dba4492', 16),
+                    gmp_init('0x411e8c6b8ec2dc80fe44135a1debeaa435b5c66acf0fb78a18fe07b4852853396e1e5a322f1f7de2d7f8c5479b97b87e', 16),
+                    gmp_init('0xa499ffec0f6cc60c55cc936263ed3803f27527cd381f4e2707341e23c02a5860653d8b70d14aea96d3c87e00bb878440', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x986c7e0dfdb92390b564df8e79e2bf05f73722425a706a5517ab291be394c7a834a5db8c58a771f57f7f37e51cfc7f7f', 16),
+                    gmp_init('0x71bdf29ad0739555259430b771eb2d6cf47cc8465a8b168662d5955045d2c4d04de5fc7916bd5c2453a31ad86246e4d3', 16),
+                    gmp_init('0x81398b2e468cbea4b11d7f554b346b107700f76ff54f815d4d8520a80872442d9dcedab13fbc94a64816d56138e5ad3b', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x396eb38f4b7449fdabd6607edccacd03665de2cf5256bdbe54b3e8bfd02799cdb8e79ec4d6784bf8b1769ea163af83a8', 16),
+                    gmp_init('0x34309a9129da8fb780b46282853a48c686127682452be4e6fa0adc1dc684d6c6f22f8e34e6bdc7f228f5972d6cc87702', 16),
+                    gmp_init('0xc99f4f0da8212b369aad5d74dbf118c12b7223db13fc78020b8f7c0abc59a4d98e0c24322951e3b3cec8706ab87161b8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2aa476bf52ef137d73323126f06237c9a13e671361213186d62bc47dce523800508c732f2d68194b91ed9d729b076b5c', 16),
+                    gmp_init('0x55842607c31a7e0af913481727c039362d9e08f98e52096ed76aad0518c0334540bfac8ae48712a028b91df497feb853', 16),
+                    gmp_init('0xe35ca331ec9b26632e64af01adfc941864bbf70299b0916fbb18f13ee4b4923c1333f51134926b5225ca2a680cc4e7b3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x84f177f84b6a2a939d365e43792c3ee952cad55eff9a4898bca756863b510b6246e24c828c7e04029ec528e0c2187edb', 16),
+                    gmp_init('0x9a72dc686165217f48de19c9372f6d308539451b4ffb1b3c76ebeaee1d458ee0c1a0ca4001c0940c94baffbf43382bc', 16),
+                    gmp_init('0x6b05461710ebc73f02ca0074fb41b53a85a2679b9f3e9fc395267d5fa25a4c0481e9107b08bf0391ea383941142b37df', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdd5776083af3d7cc7e2d42e26019d1efd46b3dcb49bbcdfda2077d9ee97c4f151f6ffc14e21863e9a973cbadd060f5fd', 16),
+                    gmp_init('0x662917baa34c313f20fd9b285086512bac2f097a81353d8c381f740d182cdd15dbbb589eb692769a952314cb81031cb6', 16),
+                    gmp_init('0xb817e00d5806f04d0a53a17139cba93bcc2de3ecc969a15a89d944032db1e76b7c1c79f2e323eb693900d0cdf792ae41', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x24ebf2e68a5483a0b300874270f7f46b14f81dbde001f3119aa68f4872be3141bf114cdb8d524988d48c81126d7d915c', 16),
+                    gmp_init('0x612471f321fef49b7bcbf6a0a6acce9906e39ce0901c346e5c48d17c1e07fdaba176edb81ba353a4be53d0ecfb0bebc6', 16),
+                    gmp_init('0x8a456675a9e26413a83f6ec573d64e20dd140991c8f425f33397fc4507879a2280d7a112aa33c041c20d07bba8f64c0a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa9290860ba525b04f384ba88b8fbf81e6a5ad8c50d8cde712b53d2419c188d1da84effe80a47fa37518967bf0c07a50', 16),
+                    gmp_init('0xb52fb6637e0792376873ccfd201449c0f1a15a6e839ce9400af613c6cb6ce7b3c070a32fc787620cb7f1b51b3b99162', 16),
+                    gmp_init('0x1f029dcab61a79cc4038ce8f52bd2335dc303d32119ebe868d49b6925805a3d39ff89b2ad8fb1ee557a67454e523d71f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55ab481fb714e4c18a99e06d40ded2c30e2354a040764e0733a6c276c2459543bd569a557a750191007166c90ee9d6da', 16),
+                    gmp_init('0x8c1d9fcbb6b2f8334d067a849b1dbf29dc3a83783f51219fa92ac035050c23be754c5a56fdb6223a3d705230c4136c33', 16),
+                    gmp_init('0x99068b52a46b9836d0589224413bbb1fe02c0e5a1276b7ca3c07777b6e7b8aeb67a24bf4959bd1221205a32e07660664', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x94200f976b6f297bc821dc111edf73be9d161d6ee967e6ee46e7cd2d78acf3eda566503a46544b613bcbfd1d4b72464f', 16),
+                    gmp_init('0xdce98372be797c1132a9be02452b8efe84ec37b49d7e5b2abd7f220207796fc57c201e3b2a3527eb06d0a5fab3cb453f', 16),
+                    gmp_init('0x597d9379112d5e32711fe90f138b6083066c22fb10e13d94eff717094f491331589cb0024efa5d9af7ad10a3e5e9c7c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x22c8e97dfee62a2e8478a1eefe0b2a6f312625d155bc1244af7007c022f4c652a21811111f1a142cdaaa1dd3e5393355', 16),
+                    gmp_init('0x96467f7823450bb749684b0c63bc9e6ccfc2ba5f51a1f036a9eeca2fd3c4e1e78c140dda2423482d4d99dca05ecf282c', 16),
+                    gmp_init('0x7f6425cb0cebae889570b5e791910d067c3ed342b1627d382261f6edd1d0c7cb32120f5cb507d0721a5150e35a9fbee4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x133159c9d7f8f31e9b062f180914949daaa23e7a7590f06a24a6530c22ff5b28a615563c83e3ab1fd4565afd75c5c58', 16),
+                    gmp_init('0x2e5cb37e6564e4aeccf6dcd0184b265c555ceb3c373b4768af9a6fe8a5305f4408261449da468012da2a175c8902da62', 16),
+                    gmp_init('0x28911d0267ad3b67bc105d8961799d7007daf8a217cd3328f428047d97d80487adb09bf1adb33758f67393547acf1f6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcaf7120d598a040680d348def8463a3f0878226e292aec7e92b24250b33417dc34ef7df666c88d4a5585453ef89f7282', 16),
+                    gmp_init('0x9fb32392396e20a3e599c31bc742fdf9fd4f62023febdbb5e0b0e4bb79217cd1fdd81c461ad067c56a3e8aa3c5077d8a', 16),
+                    gmp_init('0xa4a744006dc081f6a7399d9817532f83a05cac585e4f5da563f23c12c0ff94ada4e0b66a9566e62340e74d78602ac720', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7677953cdaaa1acd8e6e432406bf260326acb78686717ec0746604f37ee2c2a9f2c1412b741f90d76200d8a8630d4fdd', 16),
+                    gmp_init('0xd42603cd57e72abdf4625c5026f69cd26340df6e4fb219f0686854567d2d49e30785d090b1a2b0a6616b93ecc95fffd4', 16),
+                    gmp_init('0xa691ba4958daf871319a24ac53a67236b2b89bd2c9fcf6a42e3b6555981dff043b153b0f2d9927b5c71480fa608f376a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe26a65f70fd7cef18994e7ddb89cbd895c07ad67c947f7a34f873828071ac388f89a43efc4ebdfdab59810d67415c57f', 16),
+                    gmp_init('0xddd6e80e936f5e09aaa73dd84c2dcf4abd7d52796f95ee331cca0fe011b4013456a28536d1cb51ed49aeb7add45c0307', 16),
+                    gmp_init('0xe95255bdc519b3dfaab90ad7679c81f39e10a15c5ba37f53fe93f8bd7a615f37d4e0fa1057db74fcc0a83384157f0982', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xde44b6dad5067e128ef1e501aebce1727588dda51f4bf20adb362541908860b3a34113e32a00f4269f37d681ec04fd01', 16),
+                    gmp_init('0xc90e52cadac5a26bb31591a8c39b014bafd13b46158b2cd504777624708f34a92ae0bb5f8a68865bd0a5bbfa540ec066', 16),
+                    gmp_init('0x341fd674c5f1ab0ec10e4d9fa8d48d1953de03554ddac6c7dc1c3815bea6b05f1cfce23c428323b0d53f3eab632cef9b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x774d5eeee07c575fa3d7df98ebec054a7033a4c9a654b7c5449b242d72076f1c17ceb42d286b13cc9faef2592dac28cd', 16),
+                    gmp_init('0xa4e7c2c473ec4efec1a10800f0926565f3906706f829403abd7841078fbb96617366a82a94d8f97aa824c954cc37b3f6', 16),
+                    gmp_init('0xa1aed2bb3a08b326d098990f7436d18ec75a10e31d38e2f45956827cdf583f4d53954405fcee8ca80ba0a5a8a3c30c7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x1ad06fa9088cecc18593e4aade019cc731f5a710ee725af6bbd1606d8d73228a4097019c97ec4ecd033e51414fbec08c', 16),
+                    gmp_init('0xc3610e6ad5a85e85330b04279e8e240d9172febb496d5a1c6d65826c7ee5372f5733a3dab2a394ec732b901b219ad077', 16),
+                    gmp_init('0x120ccd024a3cf1fd157d1d7c5acd828ca8da0b152273018c3cf58624bdbacb02b83dfeec7f9162ab0c42598566c5253d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfc5005704b887673cb26d6971bb490c3bc9a104c435c2ff535a2e679a63c7fb108bbf1bfc6098d2fad7e1da00f607254', 16),
+                    gmp_init('0x82c77d5bdd6ddefd71194163dac088c6fdd2fc651070f515ad5425e50d850bab1387226b96b1bc5cc44a16ea23b1f808', 16),
+                    gmp_init('0x7876da99ccf07b324e54db910a9716efc552e9716cc10156c9bae3caaf93086cad188e387a5c5566848ce6bcf562c177', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x785dc8ae2f48aace36c60431dc77e6387f93276c0d3529417ef017b225dfcd098c4738a7d60cff1c2ca0eba015149d62', 16),
+                    gmp_init('0x73fe8c722815f5569fabce93a9138d1b53964b746ff5ab1366230df2febd72619d46f0a0ad2474d0158e73c7e3bcdf5', 16),
+                    gmp_init('0x28d73c4e49722db80c3e281b94ad05518b8a6e9ed3cbba658e379f51dc51692c5fb477c4443bf0a04f22dd5450d8b347', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb4c252a7be9e614bca06a94886df161586f324fe4778a8fd930f83db42f7797490be32bd67581a95bd1eb838be662ef9', 16),
+                    gmp_init('0x88643202d9216287fbc8d3fcc50e137c539217b3184203aa8721aef9595ade30cbbdf8238f73b21a7e8815289b138714', 16),
+                    gmp_init('0xd85d9fbf6f51394d37afa2154457cd739a1243f14a036aa644e489993e54858cbe42d1479a74e9acc4f81be570ced491', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1f6ee2b7558b7db05e301a9da66f8c381887f7555667ade59cf6fdf873151ac708f1d1354136a38e7d3db004d90ea05e', 16),
+                    gmp_init('0x9fb9ef6a614bfb7c3cf504d2b5a1a51a000f773e1ab5f00d677fc63644ad639bcde64e068b68a481c08c24454702cbdf', 16),
+                    gmp_init('0xf9d3249e4d85197a1402f1cfb3ee68492254f28c0312c1a5f53f32071e1d7e1b0db9ba1bebd37f34d8cfef18ff2136dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7285ddca4cbf942c6418316b9554735960175e3c9518e55f58da32a5e9d4e49b3da443b87b5f86fedd2844e24a7c6c6', 16),
+                    gmp_init('0x91bab8fbf0ab7f2636203b7f8b14cea5c0d1762334320874d6f04f8273a44bad5c62f9937847080c69f0beaf69e4cca', 16),
+                    gmp_init('0x7da2ad02bc2bcb3de10179f3255e1247d34c4e912902e6832b9071d6ea52622dd68fbee8f982fb3c79fc196c37848731', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xefe22b0d39b07c4e53d0d6f5e4cac01c826343390a26016e86d2b5cf17db33bc15800ca73ad8c7e75acb66685c8132f1', 16),
+                    gmp_init('0xf2aa38a0dfd84dfdce0b4b9c1e462da2e3be777c3d3cf244f750ea2c4f497b3053397c7f3e952cd8cc139fc8eb6be966', 16),
+                    gmp_init('0x51b88003c9310837679e2ec335e688dcd7a0aa78da7b1a27b23cd1241c1ac0f4d749cb1223cc17f2bfdb0dd78c32c09e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x118b53eae97ec729b29cb7420b152575952c5a015236a592ed284aef65fbb189b17bce61c1612c0718eea5043aaad84b', 16),
+                    gmp_init('0x1bc7f27e59d7344ab91185a46a92b2e9700ff3999cf02e81bb6bb542769c9b9c8b0c9d297104b569ef9a40fa84a8c216', 16),
+                    gmp_init('0x17ef5c4d0a5b3fa7157d786a29a0c4e5e0f897779843752df046c705cc819f3c3dfbb86af68abcc3be2c014489f428a1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x62ede1f62714b01420fc9736253882bf187f7cf088a4b8b37dbdc1199a6ea101f975e3a6becd21042f2da054c5c34fcd', 16),
+                    gmp_init('0x6fee798e9197bc661d1c40340ca346bd7d71209911c662cc99d7804acac8fe9855fef4b246665dc730da01c051f2632a', 16),
+                    gmp_init('0x737ec1f44a3fb6dc2241fd9e3390f00103900b5492cc015c417c9def777d9075b07023cb7b60385ace2427a74b296e32', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x462001e90619101715572db9519dcee9e68ea92497633f75fcf3617290b48befee778b3b018e48609cd5f4b1c20387f6', 16),
+                    gmp_init('0xe9571a19907c18b94e11f5e565b79ea7e87c96f15e7487afa7f809d097af36f03fabab284f9e7f7f7e475aa4e1a5b978', 16),
+                    gmp_init('0xb9b3025c5996e32500d75f4005a3382732a5bdc66f55b1f59fde62cb934a15b3fb6d3406bd2bee9ebbb8b05a2c4085f4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9eb50fac7a05f76647d1155b5c67e5c8ef0dae764fb746adc150fd5f54a076270ea8080472eeede2dbdf6f200fcbdce', 16),
+                    gmp_init('0x4177ed34b9197b2f2ed1ba6d2f3e32c4073f7866c8f7d73839e2a83ee57ee30f6c957d306334cbe30beb01078be981f8', 16),
+                    gmp_init('0x49f53d7a107628f51ecf332640b5426f28018d5e4381283a6df0b67aa2d8e87a3f3e5afba60910b33c46aa28d461a385', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeaa08dd1df99b85aa9b0af57fcfaaea1164d96cd025883897a99b97d40a749d3d7d100eb2d3964376894bf1c95d43f31', 16),
+                    gmp_init('0x6d161cbc6010250e1ae6a0a5140ac3782895038b15eb42681b93bf4f63baa3e9d4b5ee721765894441e24191dc8c25c2', 16),
+                    gmp_init('0x914fef7bb3d892d44d08b811c1ea29c5648c3838e6d802d8c80971207d00e7f2723cee9e89c2041cc7b0a8181f5e247e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc1f179b224607c354c6dab68da42e2e4c472cee1ee582cff0110c46bab6fe114a50b27fc28a2bfa2af9506397e969490', 16),
+                    gmp_init('0xe1909f03ff7c4a4afbb59c8dbcae34c2122d274aeeef765239b153d93ddb86190e77f91258d905fa986ca50195d57607', 16),
+                    gmp_init('0x62c47b0e507bc5dea3050fd8f83cb511b6ffcc4c6db36b8a6203433d9d5eea6e7cbe67c5e5661fedf6f9450e36854b16', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xebf1772fea1ddb5e2f391246beb21230712b36d2545029d41c1be2961f310ad3c5f94be40ca7ebc878164596c869df37', 16),
+                    gmp_init('0x48388845ffe5156e64549f13d79e5a7078378d3670a3ec29245710744f5216559b73c6a9db0861817089a9aabc3fbd5d', 16),
+                    gmp_init('0x20fea484955b84816d0c9f78596d4584730225cd11fc0d4dcb64eae93f169f2477cb9d2fbd95b299c4a20b3e2b13c8dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c7a9cd8bc20171926cd477f48dbcc55c1bc5ca419cf390f9b4ad1836465e2bc2b2b59203de7c51d7c8c1b91d027db55', 16),
+                    gmp_init('0x26909f0edca019e68f15ac4b50e2c7b493fb0fb42d3b4428fbec020b5eeea5e8530763dcf322226f73c79e949c2681ab', 16),
+                    gmp_init('0xaf8f777a321c8da83835cf6bfb515db5e5765edee20e5ac50ab34b18f859a68e15b7fd4190727e1294737f2e037b0ea', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x24ceed53e16bc4bcc660c97a68f82275abdc4c5d827af4113d8e2fa1296381106cc53815d1ed8467fb0fe5a6a3ad560e', 16),
+                    gmp_init('0xac3422e4e80de7756c0dac35ef0238fdd7b3cdcb23581cadec0a0562e6aa8667b0bec9a4b182a4165eacb166742ae8ec', 16),
+                    gmp_init('0xe4a71b723315fadb659d3868f7ee6019b12169aa25630e71735cede972339b49a9fce0e5bdd33acdfdc0527e5c111a50', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4d19081561575986467cbb7424f01490b0321449a31a032dd3220052334fd2628566145d8dda7ca2abe0f39f11c1ca51', 16),
+                    gmp_init('0x74a2853287138119e565b33a17204c85a2e17db03a64109776a6182c8f9ffe635a03307c6c102f1ab53c091e2b48d958', 16),
+                    gmp_init('0xde02e52476f5d74fb438fdcd31cdc8f6ff6ba2161957201de45f8d3dafb88245e91d6aaa9c2c3e324bb63b84e1692ad', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5dc521372f7ccccb862db9af974220c914cd5646dd692688673db78699096f02fa3b35313c0d587dce63ad086fd177d3', 16),
+                    gmp_init('0x47e7174de101d874c89bd29dd8c7be208e9aee0c48a4e80ba56d1511a6187f3f731302c624b4dfbfc7a89fa50c00c7cf', 16),
+                    gmp_init('0x62872546c915ac03b4a7c58874d74a19853b2e718ebb7aa3538e8dff50e67c1abf013348d307cc9b11af3f373fd57013', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1b6b9beae356ce20e672c1b019737cf555e59c7e1a0f3144a529e3146a856e99f4026fecfbc79c187de2a7f698fb3041', 16),
+                    gmp_init('0xe4ec0098deb3cead21d90bb7d64320530f4a4d309d840fb92a3c5c8f1a61c6265455c85234e7b1460462f8a886c0fba4', 16),
+                    gmp_init('0xd4b6718a3a07dc342281b69cf2ca3340059c7fdb681b7f7ef7fc6d41aa7af3704ebf1a782accc6aa6f3b2586f6d5604f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe97e962c468869f6bb88d85f1d39b03742ce3f9657e6fecfc438c3f22683aaa2eb46e6197484de28026f7d8392e8a888', 16),
+                    gmp_init('0x169d839cfb80bc1b598c70b47b844c6e676a4e649f0156c2bf3e782179e8b848b054ff558fc9d2c3be6ca8950b529086', 16),
+                    gmp_init('0x72802a363fadd3a9c7c48580ac177aa280387f1fc76a7d0c2ac2f40d94f31136467a4aeee49ae376f275cfd344b8b520', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x227921eb2d5cff012c2bb0a358c9b2b1eb66f08b8b249e27fdcd7ea99a8a5ca4d8b260ad8f24010ebd3111c2ddeb3ec2', 16),
+                    gmp_init('0xf56f47df3c7886c2d3d66436edc5348b711be670c6c2a8ad28c32a036432f0c894bdd901816e049915c5389c42fa8a85', 16),
+                    gmp_init('0xab98e885708ba4df2c64f4364790a99f06af99dd34f151bd77e598b057cb737b695602f098335b8814046637224848a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x356710456495f4356f180d129e281423ea6561d72084b33a9c3bc5b32b6653b9360feff4e323d91bde020eed220206ce', 16),
+                    gmp_init('0x8e65f533f8227341682ab6ce72e3836ac19acef9b1fbc4b13377a004d6ec74012b66bae24f74e05cfc91542410435d09', 16),
+                    gmp_init('0x9a6388c029f7f624ecc1863517958d20cba20f86bbeb0e78249c3f923db53f2424619aac65d49f554bef6b297efd17c4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x536c2d84b03a6ff3004ed0a78a3f2b9c47b399f943a9fdbae128080fe019e9ce845500e3b00d5f8720df076c20794174', 16),
+                    gmp_init('0xe134cc467ee7ce3544999a1d15feba423f11afa1226d5219c90f9d7a8cb7b205031c5ae5bf9b7145d48d456ef0b4fee2', 16),
+                    gmp_init('0x7dd372fc946e1cb700f1d462e22986d7be880766da5c08b1b05d31d94a40806d91a0e2e371b78c2c0e009b56c60da76c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x97f95a56b9ec5fbd7f3a1d1b928840bf92795eae0c0250393ddfd2c134a6db8619d03ca7e60cb8dd7b7688e0428aad4d', 16),
+                    gmp_init('0x5b4c5758c56a1e4d098b4919fba3808c779c85c371f85c94e76550f633c73c9817e057b6deb90c006c1e4a369e865d7b', 16),
+                    gmp_init('0x81f4f64344919105c842e623503a5c56cccd3b7caddda7553ab195bdafa037adb376867f1a5be535721456c0ad142bba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd6f2a118d87348a2d6869a6e1d8ee6b5b77b96f635d36b5af5f8f6b0f1f64ef56928c5893fe29a2d56f1545aa08f9402', 16),
+                    gmp_init('0x7adb09ac01bf5908c77d96447d324564090a6abb8fd0f6de6975536b1eaa8e753850a26de1bfb30c0e000eff785dfec3', 16),
+                    gmp_init('0x3203f7fe4c8b94442a61d0dcc2fb08ebdfde6238e50f6d9bde48ac09efe1e4005fdb20dfbfd75a0f580d9970f0eb91be', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x47b301453bc73c11c758dae272e608fab9c3bc4e5551055515011205d2d3f6cf5b47750146dd32673cf56ec3123a302d', 16),
+                    gmp_init('0x728ef63fb4679650d4aa74e3247044e241aadd9dd9dc2becb36f0e22e6116cba69fc5b10f5632e064fdd3754d1f13b3a', 16),
+                    gmp_init('0x4a5359cc2707f72c17dc1e1ade546d773328e9d0313782e52e10aa771a775195f784d18796d666462a453ec234a0872d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x75b93128eb0633c9d84faea09b110ebed0ffb6c5fee343405415afdbe2bf11dc521f54b13c4ba31a0996020f4176d85e', 16),
+                    gmp_init('0x144c5d995351fceae10fc22faa6a2053f349611c200414eb4b2158aabeb89942db8cd585612780aa5b3025cea52cbb9d', 16),
+                    gmp_init('0x7c8d8f1c4222f7b56818271fc7a353d47d318402f051d08e2e181c2e6e3a1206f17c484a3f6306f6e32c03f065bfa242', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x417d5c93b3097257ececbb45fe1cd638aad514ab01e1b1bd01f17b7166038c8a80e12222bf8308490e1cfa0e7cc2abb8', 16),
+                    gmp_init('0x20f790b6e7702b387bb1fc780a7096190543e434bddbd243a5f5a7e8d269181e344b544d386f9e31ac8d89dbe3e76b7a', 16),
+                    gmp_init('0xf55d0f0c89ae6a2412fe6951343645a3bb4fedaadb108716486943e789425e3ac01bac4236d612470a9194dd06d0574a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd1b5492008e106e1c03fd0860dd256ec1edc4d7f3b4a4e8c6de265dee80b046c68a564e9cae291e471100bf3010b92cb', 16),
+                    gmp_init('0xfafe28af9381a37cbc9d3adaeefe09fc6e6a6f581473ecac49c1ff96ec5a9cf80d67537958cb8b5aa7b8d0ed7fca6513', 16),
+                    gmp_init('0x434e725c03d5cd91c9c91ae7c731ca40a2ac536c0a9baf17cc3c276d909b1de0d59f8eeb90c8fb31ad1b6301e3007ead', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd08a041cb555fe1b1cbe2de23fff2b522c2decdaa44af3fdfdc7de3a5613570998536108ba2d4f3b940dc2df393b80dd', 16),
+                    gmp_init('0x371129420742070c31d59a1e31e869cf591b0ec65c0941fc8cd92b919dbd3e35b27628fcb0e6a1b7bb1246799ac40047', 16),
+                    gmp_init('0x5ba5dafb1e2cb98d3dc9cad9b7f68e2e0c130a61b4f996d76781f7816c3c91ad94f5f7d7082e151c4dad2a0e2a8ae58a', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xe5720844e7f974d3c00b901ced17948230e46c8c684c906ed67d99878cd0213f7eac7204679659d4c77f3aa12bc50ed7', 16),
+                    gmp_init('0xfd146a9c52c5d52ae7e575450d604518500aec00e6175d8037528566d651206e481a7dd30117d71ccf01862187b255dc', 16),
+                    gmp_init('0x1c346faedd078922d92a568f8992ea71b0a47e8caeb1017bf1e58aae7e03685f0b534998ab1004921024ed98bfc439d4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x803bfd9a4b75c6f2a26077c426a8b0f0eb4d9b5dcc7f70b45384d3a2377f3d8b32a061aaf3506b92682fce3a0caafc24', 16),
+                    gmp_init('0xc7ad6edeba27a21ae12eac9f0b62bcf41727850e74ef9d9b5864eb89af530ecfced1be168670a37d3f3c44b36e41cfb8', 16),
+                    gmp_init('0x6f31112aceef50c7e11d6cb3abbd0ae2cf37f4f6c3fbcef50d5cc90186e020997829897447d912cd25b3c55ce0085a50', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe717beb0717739694cf8dcaf17e6aa3b30ebe8ff30649a382cf566829a1e4e7e16e88d938fe9d2cb922c2ac532b54a8f', 16),
+                    gmp_init('0x5cb9ed5017f272f7c5d36a57a5d307d4f4e39fde30980a7a8947461a73566f8f977193b7b218b130183fe92868793229', 16),
+                    gmp_init('0x79ad32211b5e42cc6813edb52bb1193cad1cdd2cae60120a4e78da284290d051af6f51ca3c264480c234e4cd88e36fa9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x649ff911a8ef627134f2af78a09c3cebeced942b51ad668ab2171294730de4ad52ade62ee78460a5c075d6f0169eefd', 16),
+                    gmp_init('0xdb660c2ece29d72b00e970d0e29eb9afa28ecb2f96a88b92f61ac5bcc5ee5d6d0b3d322ee1f96de54d177835da104b10', 16),
+                    gmp_init('0x71cf65148828f0a629784b8795867dbaad7adb02bd44b7b509e187aa1192e9306fa9a275b3955896e20ca7e0439f1528', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x257cb84d04aaacdca699cd4ef7647fda361dfee94a4104c46633101982aaace1b40f988b29bc705c517d44f623e27069', 16),
+                    gmp_init('0xebb547aff6d4b058e84274bdb4a4bada45d18e2e2d86c65a17e9ac5557abbe2306dd94fcff46ad3e1c7533a1f37fbd35', 16),
+                    gmp_init('0x28c5aac04bfd82ee598fc9ca312f08c51d26fdf1ad5c0cbd0ceca47119983dae054bf12f19bd021e4f7b11493d13f9cb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc139900f18731b63cc9232ab139ccc932aa1de0720ddf8d267c5be9b66c4b3f9add7167085135451e350c528a4c1d896', 16),
+                    gmp_init('0x581dc56fda962c0999cb517c8bf81bf57093dd460121e99dcd37342ada8a246a4b831a63a37d2f5591eda6ced693ac6b', 16),
+                    gmp_init('0x2ea32217436cf8f0a8dc355645725b0473b7cfc432f46fa36747c8c065713054b025930a219cb6767e107938225e3737', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27b054a6121efb15e1f25279de5a95e500acab1adb9217e1ef03617cd1bdd38f2cf1a43c2377db51eeed59c17111a973', 16),
+                    gmp_init('0x3f2b5d1ac953c609c07c268a8c23a319b2f2d280921d7043be147688fd0e2e163192e08987dea5abf344fa5063291269', 16),
+                    gmp_init('0x21368c9936173e661551deccf505fd4606f44a98f12111c7591ed51d288c05148f0ff1de2f4e7f2d94f191f1f62bf2e9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2367c67112c2b631c84ed75c193360c617153fe1fd54221572c01088005e6797139eb1c01b916c964f68ef33170aa084', 16),
+                    gmp_init('0x2acb2f1be12f87528d07701087e351b5c15373e5a7aef00f936e1eb46c9eeeaf29c15261e0f91b674280dd750b855702', 16),
+                    gmp_init('0x48907d6761436af92e01c7478c924b36bbdecbcdd173b81e61c9a5912673c3bd7dd16c480dd3cd1580e45cffe7c6ed16', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9165c4a208c3da03157e52667780cf94f6e999d2cf069e7526c8924e3bb3821291b24998f30cee9ac3fe74f5d243c1f1', 16),
+                    gmp_init('0x4bdb283d49c69a30076037a992af1ff53d77c366d4f03aa75a14c5d9357d0d5dd2e312041e7f5f4541f389231164d8f6', 16),
+                    gmp_init('0xf8437447182780cdc96d49187cb17ef8eada89c3be99faf02a42f3eb1a30b5aeaf8f4ff79f2afd7ada844ba9015e6b3c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2270f2f57312380ffaa01c808b89ac5d0c371594124c94dc40e91dcea687b7e115e0c3686059e3aaf997c4f54eb7a0dd', 16),
+                    gmp_init('0xbe41f6e6467b9404211e07861caebfe04d42c1101b6aeebe9c509ac446cfc1b07d7eed6074215afd013aa5931d931b73', 16),
+                    gmp_init('0x3c831cfa814e15629c21d742e9d29e74d535bd311f26a040b12fec437deb2582545f73de78f7b059de3b9c91f31a496d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3910ea06345cd5bed57963d9ef945f744cfcaba362bb841ac5785886ac30db9aab308a2ac06e89cede3e8ccc1c1dbe85', 16),
+                    gmp_init('0x9fff53fe6d9d4a3ba5f1eaee5c16ef390233fbc23c2c2351a9a754b7050c15d41506c360c18728a05c69305b66147f13', 16),
+                    gmp_init('0x21120271e59474069a021c19b2da6e7a393951a8bf0510415a8d068c7785bb60c6232c725e78003f263d0bafbde5ca5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2be66adf0ceee421edd73a2bcf880cdb1490bf1c66acf497961d5043acf28dd3699d8c26131469fec2ca19af8a7b351a', 16),
+                    gmp_init('0x7106ab02825fa32dae7da5a4684c13128818eabea2e99a320a5461c1aa3b0e956585614c4ec814340810aaf5411c876c', 16),
+                    gmp_init('0x5d1d104724300b71e5f13601cec34446a6ea253cf5d09d53c3ac3254d68375e05b937be7b4706472c57d7617b1c9a7d2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9f1e541f64a04ec318bb490efcb7cad53ad04e091ed725685634268c34be81801e5b1f67e5a0ef98c875bc28bfad4d2f', 16),
+                    gmp_init('0x538589edeb70544167073528b9db1f8ffbda53d0b7389f093b1460406a2d3298bc79d9a42bbfc7388843d0b239c5a7d3', 16),
+                    gmp_init('0x33dbfea883fd530a25df3e024399e42020928e04cd339ed0752f3ce6d6e0c967a98b8209174e96f15dec154f13964633', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc98e809e8e4d8df35c3966a0a91e8f7bfa0c69acd7e97827b9b61d35226601a6d5c870f8fe239bc67fcf94f92ac22fee', 16),
+                    gmp_init('0x7d99a77e8ed748707661fe45dbd76ac728a5269f03bde34b25d374061f518f4dd97abd6223785966cc195b2eaf3c64df', 16),
+                    gmp_init('0xfc186f08c9e773c236109743a3c0aecb8af0d9c9580e9155c9ad3d4a065d9e9648083d6be2ff56e2728b4dde60b6a24a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xefb4619a06c0c06046a20a8b1d4328ecab6e22a70426df41b8cee23861f1e4ec75d362a6a051a33de00cff2d4eaa9ee6', 16),
+                    gmp_init('0xcf393c5ef1e8b06198a65f990e33b16671bdab5d856257c33cb6d7ee32fe5ec769e2733d77b25643cb1a4525f31d221d', 16),
+                    gmp_init('0xe670f1e1ebab3496709aeee87d4ad1c78faee8e6dae5e2413fff0f1684a7a2951a108c39ce6c1918b0598636387ea5b2', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xb0c0a31704dd9fc46ccef13a3bec291195c98ec473832a15bfe9856c6219236fccaeab829eb099008e6fa3faabda0a6f', 16),
+                    gmp_init('0xf8acd27bb3668a13fcdebd359004298ffddfc105110ec66f3ff2a99ed02547b97fee8fe151c195e4fd2e06b114facbf7', 16),
+                    gmp_init('0xc576c3736660576386aa6e0b165186cec595bee2f97312aebaeab8771e741a0e992521459e0d28b00b3bb73878665c2d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa56f513b79a7d5c09c118d00c5183f95558e861c141101a878dcda19fb400959e89eeba9927cac5c05be04cb11d3d2d1', 16),
+                    gmp_init('0x1887af826366daa27023217b262771d64b2f28deb449291f74bd05a6aa702573e96785b7d158b85cbd00384ce0ff78ee', 16),
+                    gmp_init('0x2954c3f2f3d013286c2adc3c969e2418a0e3c5a6e86982aba793c69e77bb91abd6a079361ad4c55cf5acb2a0b4320c84', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x55bffcd663bef73c6726352f00b3ece78bf7e47ad66d49f32db1e933e1345e38d204f41413ab4d5bef3890e2d835bb06', 16),
+                    gmp_init('0xfaf44976c917ff5a8ce0e45ade5cf6a30d2f878d6a1b578f4a1233e360f1f905654063b50c2e9819cdaab918ee3def1f', 16),
+                    gmp_init('0xf68b077290c2c1b4be2f0fdf1ee4fbb72285d26c28f30d67e6cb23811481a05efcd6b9df0342b41a79a0abff064be5d3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc2a63c14be651e6fe0349c7088cb76f796c9a4292b782fbdd258f3ee50ffbb0c4d812f6ce09cce4a142a7b6fd6836cbb', 16),
+                    gmp_init('0x87bd5887942a74b9e0f34e3cd62deed4c2e1d03fb150e426f725ff35dc63d6c7a9335910b1610855df59fbd3e01d3ee9', 16),
+                    gmp_init('0xfa4747dbb463ec76b2f04502f6c28488d0dbcdba6e1d8c6f70a7afc7d4ee7c0b523ae7051709c8430039a9e33514ee8d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xae2bd1c95355c0acce1001187fff3a76603369488e4bb8f8ea3975060836f8b1c081033e33601deeba58e574e1f9371c', 16),
+                    gmp_init('0x5b8e6abf31b57879864a37368845b0d66db17a4db1fc7a98afd090f4650a0454f539e2173df14d1d7fe7ec1e2101ff', 16),
+                    gmp_init('0x1a66fe4356fe98740fefd2231047e019618f5ddeee6a8de6765be1e1e42ee6fb7c22e635e798f72e0c4cf7f44b092a80', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb5567941457c35da18a8867db4cf6192b142af0a836aefc27c5246d6fa88ae0e63b79def98a18f010fb137b7160a538', 16),
+                    gmp_init('0x22e301978076c9aab3ad4389a6653114e629bccb48d4a599f8d2ac76cab19412a962b37cd706b2bf894552ab6243c6bd', 16),
+                    gmp_init('0x629c78a287277ca2ead950b494e01de65d19956ed0cbe042b10d5929dd74d0025bcdfac168654b71bf58740a5cf24886', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb9f5a98d22a3c463bd8053cf2a95cbf6a52991bf254dc76bf91cb2daa87f55b1387f52c9508cab3958ffdd74b9712773', 16),
+                    gmp_init('0x8a68d278fe8c28d4da5c67da650d6fb8614b3f52ff0697087e611b642b286e3c3b536128c4e74b7680aa9c8b85d74ee6', 16),
+                    gmp_init('0x2784c08887443377c0391ae1367b687f20efb0e05ec9c71e38f475ca24dbb13394758e55f5f0b64613d259b34ddf8dfa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x114cabade98c5ec4e055edd4815e0b2547b0d753249c01fdb39bcd080a5e687f1f3f55ede73b602ce603a214438c40e', 16),
+                    gmp_init('0x7c767b887f5fabe4501e657336a05f267f69ed61a7de9697753c298939f85308fa25dca23c7d9ebda63b529df739f085', 16),
+                    gmp_init('0x52b3fb7c83548d0f5b866d5ca0953bd8e22a3ff4ce7deea6abcf51b9d58336826a056b836edaafa5707eed8bcde98d54', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x19884ca11b32f321569e7b3a7e7216e8e5ad0e4121612132507aa57ea65f14e12a802118b922b3588104200e38a5221b', 16),
+                    gmp_init('0x1973bf4e6e50bd7ddefa7940023260a4e1665ae8232e0a59019a8cf86f63b3a49cea636d173545cd6d1773a4b8dac5a7', 16),
+                    gmp_init('0xb0a996b0963949c53266add400dbb96720fc6acb2eef2c2e324dfbc1c241ff65641790c68e4882f8859c64f5c3927a5c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3f15b7f45b707b4cc5b17e136ac36658557d38e0fa1757344eb4f2b68553f87c333eb4efc72f73460b5fcde29208f025', 16),
+                    gmp_init('0xf450932343cb501cbc48a3a2ed047fb5eecd8023012b889319275736431265fc426d3a819d0bcbacbdae7d380dc86fc9', 16),
+                    gmp_init('0x3674fe4a7a4f603fe6a8dfa44d7602b70fed23b85ce0398641cd98b3df378eae64fdada46b79d4a0d4bf0bdbe74407ab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdb2a470920ccc134b84408152e0b3371cb5f6961851d36d4cb0755a1460d74525ddee5b8d7735ec7a499b3b187fb722a', 16),
+                    gmp_init('0xa80c6568c47a961c9707a1a055564c50a3c526504f41cd11c655d964f793e77b2c792b3c4a473b25d1912b97ef93ab89', 16),
+                    gmp_init('0xd1d264fab633b9624ac80910d86c67f9cc468d28377331d1ea7d6a4fb4d6d143d403c076fd39837fbdb2daacf4e12896', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9e04f314fd829b5831d0ec84284adfefe58191aaf37ad8fed1ca7164651e01b54dae7987f2ab3a6a3b0a550a8fe7cfe8', 16),
+                    gmp_init('0x7d6087a1c3e4819475eab25703e8944dce1c8f3a095cbc7fc0a0ac25a2d5b707afc1e21ef830c438a45856ab2003b7b7', 16),
+                    gmp_init('0xf9d3ab45d34bd029aea7b1d836b67121d8516891ea106db62cfd17471e0fbd0af92b5bbc102f77aa9c1ed11dbc58707b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa89e861c2065387278975fae53319c80d652bb31c99a4b8e46851feadaad10c79dd94f9f2c932dccaba96ba4f44df633', 16),
+                    gmp_init('0x8a6940a2a4629e6bab2cca02b1f57308d967b49ad7938fe3548d1b49723d68a93ec3100166f075e9e3d3e5ec49f45500', 16),
+                    gmp_init('0x121b7b63e0280270f4c2bfb2844459d20fd0f829905432d655f9c700c1bced2c3b29a9eb66d3e055243ab9514c0eb7bf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2d927a4fb9f828e16f66539b50ef6ca40e20724f380c695d931633553d264a047e98d177a2519d5d937ffc40829aa40b', 16),
+                    gmp_init('0x939002e8cd9fd262b0851f46196fcbc992dd7c1de87980f41b1b02d4307af817e9a20df5f031418a22c6c5824893db6', 16),
+                    gmp_init('0xa2f39652f0c30b2d562be5c7525787670c6d9e7adfd16ead6a06c0d80e75b20a12bcd395e705a038e248da8459aefc0b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe3ac6ebf05ca0afe726d8d59cf115e30042cc238598ff876c1344df4161cc633585abce694ecfa7fc83fba44ad5140cc', 16),
+                    gmp_init('0x4b6f81719c66c6de62f9caf3f5d6421d8db86f4d4b8cddbf6195145f86afa4b1681334ede77f322eaa46e66c885b3dc8', 16),
+                    gmp_init('0xebcee076b091f2d71be566f55cc144a9660eb7acef366c21b44d11205eb92aa54576c5d1ad4be44c34e2ca38ed8011ec', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x526c36a717e2be7bb92d7c07ff1db20c41d5ed1bc575ca0c391ad97d8def75c59d2a934484b5fbc87ef478900f99a3aa', 16),
+                    gmp_init('0x21463d230131a468dd1ca745cb7028dfea17f68a869971d5139a0871e37232b839a479e380ec1cdfceb669f05dbad260', 16),
+                    gmp_init('0x7e4e844bde99c65ad063a8b2136399319e3080ff36772baf7312c020734526dbb9f19c266aaa75534258afeeafa04a89', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x811a9b0b1ef795129cf48691468f1ad922f4e349aad7dbbfee076cdc88572212b498f30b1ec17b54fe8d0915327f5478', 16),
+                    gmp_init('0x72da06a6f298fd6c645c07a75b956c1da17c50d97c68b86cda1496276922b01d2a993cbf98af656883a892a62a62fd8c', 16),
+                    gmp_init('0x515697fed76ef059b38b42d30fc75da7d270f0e139c741b97ad3da73675d0ac97c11343ce14322545e308416e8da7e70', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x52866a3700b98a44a4cb3160262f580ba41efc873a70c41b0db19a71d7bf0f666bbb43cceaf0edaf3c5063d11ffed93d', 16),
+                    gmp_init('0x9341ebda8fedb85006e1e7f878dfe9e716740565e261010307d6ad3bffbea948fc179ab2b5bff514ec75b81792cc45b7', 16),
+                    gmp_init('0x4f332825fd08062057192445666154a86fe678c1d59bb5be6a996f84985863d1c1acc45160469e848e716d2c1ca276aa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd535b77544c305f48716f24ce52c07139d76824662170434def23de20f0619d29c6bde696c5228cd097313ee521e1a21', 16),
+                    gmp_init('0xd515b4f7cba8286de51aff8b4389bfe87b3c82e2abbd5543e3bb349e7404546d9c00b30c0fe0359bdfce37583f584f54', 16),
+                    gmp_init('0xb126f690dc78164a1f342cb1bf5682096af899723fe5ab64153b249c311fd4854effca4c249eb728d4792d58eca182ba', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc938c2070b7d161f12d2561ed4c7f1f6c47fe025a83e249a56cacacbbb6cfe8d1d46cc863759ba3a87e78fcfdc20a4d9', 16),
+                    gmp_init('0x1842f7244a4ccf56331935f892ff13530bfdea4abb3d57462104ada38e52c5dd99610a9be82d8568238c4a3353a3ebd9', 16),
+                    gmp_init('0x331a9b8ff2a0dbe3898dc262597c847a7897a71ff80eae5b80301782a1714c91a6447ded2695bf78bd9eba3482600ac2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x95186b27eb52735dac2a0d26a065b529cfbf7452b88bf303967465cdf0dbce9d8745e1da0c15230f671f349643214226', 16),
+                    gmp_init('0x62eb4fc679c973b88de07c62431649b21e5b159ca306327250856f3f4b1e2e6c67990d2934eddd49a58c6e47fd8d8003', 16),
+                    gmp_init('0x43987d710e09f6390b1ad81ecdc1ee93e292dfd29c1d17526f491dd49044060ae5adc39b180f13f2055f2784aea6f794', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x92986bbcca6a23c3c6821df5a6b471475f68cb4b579d36fb34de5ffac8dc5b9e3a7645c335c9d006490d309c1ddee593', 16),
+                    gmp_init('0x8d27b53c5d1360ca25a17a83a5dadff4630b85fcd2260f4c28922cb7edf3bb1e2def6ad9f5805ec5206b4979dcbf429c', 16),
+                    gmp_init('0x22cf0f575a505d9535397899b6db7ac734080b9f35952811a308a75dc0433710f87c5f1dd40332ae86d92613b32a913f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe038941ed9f3353d344f31fddf25cb0e324ae74ab789c461be631438ad0df7fc0da6fa9f4740e76bd443dd5566a2ab92', 16),
+                    gmp_init('0xd712a64652819c5f39e8b231466600e862153af440ca8bd132f70bc9b8dcaea17362f21e6bb7212e943716eb3a41666e', 16),
+                    gmp_init('0x3e770d3f0e60607ddc00360fcd4d2ff04c5a82174a0540a827bd42f096271b8f8fe39642e4907e7181fccfe009271275', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfdc3264e794a8b84849dd81517d6775d5f78f3e9d6c5d6066b4272e5bf4257686f79827b3fcdfa9576efdc7b41f3e09e', 16),
+                    gmp_init('0x43e6ce2d38d0c998d6ec588a7ba35cae3bf81d80efe335ee0765f572316c135dc1339ffdc2cb6f0a44e16b86a2bba82c', 16),
+                    gmp_init('0x220bb066da18f9db684b2ebcad3868f6a599df97c35998f3ffadd24108b27491e5089b4285fe800b216d2f0a8a9951c4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd082f1b363e16fac71eaabe415aa3c8bd745cf4add0886a85c1f4f5914793575acb26262db99a4e3820c578c5fc6bd53', 16),
+                    gmp_init('0x21ce17cecf6e8ae33444c45b507e4127a4e5e5df2c0025b79473f6671d123724893a7712a17461afa6e7cfcd9d5a058f', 16),
+                    gmp_init('0xb7dba528e1768bd98b6d27752e458f4f68d44cca55198a06cd3dd515b14573944900df62aa8d6970485e34dbd6798c8a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x79aadf049a51d98f4331c6dfb65d5c2ae36f3f40bac60b1d42f4d8c3936d5094eb2e735e96f7080c34afa4d61ce7c50b', 16),
+                    gmp_init('0xe81f49a7ab9c3a79cd8d724631eaecb3912f2c626876eced2c7540545250ca9e0f46b12382602ec3eb1ed35db1347e3f', 16),
+                    gmp_init('0x5bddd6ba4548b6087ccb7d821544402f6a3fe636fff6b8bee4141013832e974fd30d9f2e99f27ae121a6f0259de54433', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d0e34f4d44a91ff2ae31ab127276d4779c453b6d8e2da360cd8f4ac59c055f5fd84f020a6d82ea64a5da613dca4a756', 16),
+                    gmp_init('0x51217ce3d0aea51abe46ece2021c9dfabdb06923cc8e9283a5b7841647518802311b761d88429b85e9750d6a7bc8816c', 16),
+                    gmp_init('0xdad583b64cc74fda2750f91a25fd8f83501fa6205297c5e98428fccf426c0f3d32f1ce3a4c701a3cf26bd4063b9f0b14', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x219dd9d99ae15e25318a7144e475be8cc9c35b42e23dd84aacc2bc532cd469002918fb17c3cbd696eda1112c467bf8ef', 16),
+                    gmp_init('0xb25b973baf7f5242a7744e89c916908baa18727facc3cf79bb349159463b578589d766dbeb70171e8c7e03420922a49c', 16),
+                    gmp_init('0x5335976499ef9c475504d7c72e7a70cd2f490c394a7a75fcd3db4559b408654591b9cfb7649b2a1d6482128e13f1119d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82a3b2bf77e5e6cfe5fc17bfd9e7fa7d86b9b767f40c542bc9f33dad7452cad3aa7724fc91bd96af6a249b41d37dec15', 16),
+                    gmp_init('0xb4d5d442f45f4c9331e65b0021f6fd08e5225ef028983f06b94a55a9c1a86852dee2bcbdfc045647cd7de000b28cac67', 16),
+                    gmp_init('0x140c96d6e5aafe9577d285a43855f158c74c8877441cbd5c6d53ba86e2a02740e7b98187e8e3af172c07aefa0d0a352b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x758003088efcdf85f8a8e44a99f75d5f784dafde4bd79244761681d199f0bd4a9876ebcb9f3533a0c38a13224c13e18e', 16),
+                    gmp_init('0xcf7df412ceb07a409a06c3dad9f4d6cbb70a5a6b547ec1641bb1b0bec14f01015281d752439cf1137d8c0270eb9b68ba', 16),
+                    gmp_init('0x4833edae6ae41bc1f8e2e5f25ab2a0f1a5eb389344719a6d39e8df6bb775dbf405e5581d358f70603e57f2898cb44fae', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x70eb66d896149de7ea08018a63078681d34613b0a8ce6d51d1d003905d110939f5c4274159dd61b99b418a57758dd0b9', 16),
+                    gmp_init('0x18dcf2d5b2a06205e2c147540311e9ddafc385b6cafc511fc6f289e5475bc0ce5035cdbbb555fac6e3c741607a5cae5d', 16),
+                    gmp_init('0xe9d1d08ea0a48b1188ec0070302f801ef640f70b84e1a079c2ca5927cc153467097960f39c7d8c2e15b1b9b9621dc50d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa6a3fc9dc927ac3cf09ab41d6aaaa880e2dc3888a956cbd288d1effabaddd45ed282162a639628cc72dfe712bc8b3e96', 16),
+                    gmp_init('0xf67de3db42a2b521cb7e5fa9e529db017ddfd8f250ed5ca08c637e8bb1eff9c6bbe82e3bd4e6d6cb7fe689e561487bd6', 16),
+                    gmp_init('0x866c3088fb7d4464fe064618ab6f6cf73fd2062f9056c8ee443e692673c158b01dc32dfec994b0bec8a2a359477ddfcf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x233b8bbab30cd864129a76f0eeadd370bf7124246631136a6f7b14dea1b3e7f77742a8d52b6e8cd7463a107176a59056', 16),
+                    gmp_init('0x881774f9ab484025446f3b1d7db01b67e81bf7e8c744e148749a0c7beba2ef9c052aa96ca07a2827adb2e4f252e5f03f', 16),
+                    gmp_init('0x81aeb03181ea9b4861e71d8774c04830a57ee32041a736dba7d14fbf021e487fd9839e51f1f02cfc0aba0b34a3af2d02', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1187a846698313079696b10151099ed20d998a2faf122a0fbf60e69e94b7bec94837cd568bdda0d38fe4b02a04e1790c', 16),
+                    gmp_init('0xffe8348029cdbaddfea3bc659e008931b829037ba1e7b2e2645b58ebd4b55a2dc597e77bc5b5b4fea4557e0bd6133947', 16),
+                    gmp_init('0xb36baa3d798d221150f149a453b129651da11cc8daa5bb74820873f966491817b3a04dfec9f6b29bb299adc3896d2141', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35fb334b6bf01829355862f2c12884d0d3677759736b9e575ab737b8850e76ef0ab7158704d4c1a608fee82eecf35de8', 16),
+                    gmp_init('0xd1abd75a10b629937ee7f0191451923041556fa6e1d8c1cfa688cf1810b38032c12d74c19baeddf83b3bfe288b580602', 16),
+                    gmp_init('0x56131b0cd8d761c0afc3a2881f3c102e0cab741c9fac03702141caefa73a821327c29515ca9a39f2b7f6b5a3e01577b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x64dc1c90ea50f35bfac9f44bc2d14f35f2bcffffb10004437bfc8d2c350ad2f5aebe69695907e32612c2d017943b0fe5', 16),
+                    gmp_init('0x4d92cb9058b1fb114ab65aaebc59a53c62c2f3b59ec9a78336e07f785eebe9a89eaa3570a4cd71f55d31153f0c69cb1a', 16),
+                    gmp_init('0x5075b7346de686f9decab6254dd864ed7d5d14066fa0be9d4492e89a8b4cde0532cad05346689f460e31d94a825ef8ef', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1f539b00f4ff602c41f2c1628d965b44888cc12c5affc5165c4ddf5eb95b789b8c975003f989578f1d1f28a05805a469', 16),
+                    gmp_init('0xa276d65e2fa19436181fa505442eecf8d36da3e140ccca77d1169f2c14a2a6b2233947d637f3c53367de1a5db2528979', 16),
+                    gmp_init('0xbe9dbcf7501986350f2ab7a301fdb4df80bebe5a6d6984ee70acbe8f340b73eacac427754304ff6e5b2bcea80a79d546', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x736deb5b75f9839cc29d56e76acc4aa6376874279b026e53560061855f9434c4541ed123a0536a1424c8d2a29695adaf', 16),
+                    gmp_init('0x3b9adcc251d02e86b27743a7d8772c0a6db81f4d0c3f89ff63b35f53c8b1c9e0a32ab78705bb90293b34eae40f41be84', 16),
+                    gmp_init('0xf810e94037f8069acb0f719f90814d5134329cee43356f254f494cb8c3e5d92eb0b9e280767dbf7004c30c1614649b8f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc3e37a36a0c7b99a98cc1d4c7b3e9c1e30d366df74f2e257ecf6d0e3b0a540eca15022a4f278e3a022a475760143543', 16),
+                    gmp_init('0x8fc44e1a9f8c6d43aa2b805bd237c7c27149710a1d5a9243059550bee5ed0cf6122e4532b4d4d67ec9a937312c0d20c6', 16),
+                    gmp_init('0x10f8ab17e8612bb1f3fd2f98413fdb9e7a1049f78419918240d0a3e8be1a0c8ede3d079c172d9e1b5778ddebb13fc878', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x62755a4755c4dcd365bc6f43c0c1bed1629e3e6c059ab530338e4000faaf0edb2aa9a2313c3799e0b1d1ca435d01bf48', 16),
+                    gmp_init('0xbdbcec4557d32b16ae363480ab476186bd6f59856e441490b6f780e84e88618534d24c88632dbb9c862d257e6a41de38', 16),
+                    gmp_init('0xba9c71a1ca729afbf538ee8ee541a28963484d33eb40ee7d9170787fef46e187f992fdf40e176b0c965917fe7f326b59', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x54dbb9cf17146a0e80e6e0c89faba73c0f767091507cc2882e9d3477323dc41eef61d43a59d2778e76cee9224a88c3a5', 16),
+                    gmp_init('0x658c5704c45306132c283045435fdbd6dc69423c8517ab33a5a0d0acd4dd4495af308493583eace44009ec20ae8ed16a', 16),
+                    gmp_init('0x230a78dfaa61f54d815389e64a88d28dbbcd53b21ca2dcba11fe127eb39f914c326b2736379dced7e19817994448084b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc3b5643e81894af0ead3fe05a1745eaf92f6e3ea6fabf375a0f6e54ab92b54eed44ef6fada30a493a776e124b07ca43e', 16),
+                    gmp_init('0x51908a5ac1bd2ef227f7320518b3c41def0398c3c2fe48961d970ea403ca8694928ea0ae14f97c6f2f7f5e0d935891be', 16),
+                    gmp_init('0xdb0772dca60f44cefb43436f223192fcc18ec3938c3856c1d77831403a5aada7380eff6d174873a398051ff298105c3c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x92c30213601014d801b503d3a94846c92507cbc48bea0535162504ce2528a0a889eb48b36b534ec02ac5c6b90b7d', 16),
+                    gmp_init('0x4135b9afe49f0da6b21f37fa611714fd2032b217c455ecf32d04a5405f95cddfbceabb0e2386fe76b92cc8b80731aca2', 16),
+                    gmp_init('0x6e57a1ce288b2a59f88a59339c7951b5d13ecf83bf8bc01a070f1c8b5e9ad7b073fe1003409867c45ab6fb4f911e8934', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6ade18d30a1c4613ab6b89fdd46c7e2f7c637cdf408dc50439ff1ea5bd30aec22e1c55d8aa4003dffc53de834de275bd', 16),
+                    gmp_init('0x9a72a46adcdf0591ec28d67e52642989076bcf7dbe4267a033b49b5024f865776202fa2e7e9a464acf4808eaf3589119', 16),
+                    gmp_init('0xa6df12fbc1b9329c6f5cc5e73098e93ef3fd79e0a760907010e6a3a6f921a16d978e52c401a90b8e76bd43d8325a2989', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3b5da59fa20944647bec5ba62c734ea06a6bf0573d033ec51e9dbccb31fff5384878ee64331d87ea8e0885b49c8716d', 16),
+                    gmp_init('0xab35d20b944e8bd9c40fa55e71539bdaed28085fd4aef4a5f15d517df3d2163597b3820ccaf43ebacf507e24cab940b9', 16),
+                    gmp_init('0xaa6ba53de89da18b40fbc7533e03c4ddc538fd5cc003a99e23d91a26e0e417d2f5b23770f6c9c24f12c2303588407360', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xdc62f048d6a2398b826da0202eb97ad157cbac2c00341a7851859b8eefed05764cc3ea5f84c204945311a8b909ea1e33', 16),
+                    gmp_init('0x432776917aeab6efac6f9d650a813a54c895a2e395f2afc571591ffe325b7cefeb6d04dfac5f226481e8a8491afe3ce0', 16),
+                    gmp_init('0x60c21034619d4f75af30f89b795dd0b764453298c6fd0284d0e977a86d2f89a7d769ceaa85e5fbf003dd64130aa252c5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x88e1965a6ea56c9164c003fc2f91da47feadf49c380e41de139ce7572bc646ddae9e2ee9b92d52e8d071a31ba92853fc', 16),
+                    gmp_init('0xe6a47dbc7e9fa45b4fdfa55411a753d4909d7cf09adf33d1197626f4800ddd2e01b0880a7508e8c9f9adf68cb702dc65', 16),
+                    gmp_init('0xcc6ab0252bccdf3a5af0486a2cab4a96df0fd1330ffcd7905846fd1d3d8feeedfc3acbb692c61f14ea20798617585997', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x570a949dd168cffe91e05dfdda091ca64286d04acdadd9e579a5a9666354f90549acbc9489965fc64e991c90013e144c', 16),
+                    gmp_init('0x1aaf655458cf1c8347b35487c38dac9f1d0b91d236b535a556ad68ce279c205504b10206fa845480e5eb9c10447d2aa7', 16),
+                    gmp_init('0x2bbbca6f6fb4fd3bd4fb57589b7a1b8609df4c82098f3e37696c5a854264298c734b06c7d0e79c5ff9795cd008ea14a6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5f4f93f81e0260ad771c37e837d4b582f72079c6c9ce5d0d81e0e7c1d66972e4b43c5ae86af82d8720e66212cd313f78', 16),
+                    gmp_init('0xf91b0231783db2ec20e2c4460bae7f142a275973958ac2239f2876cf1e6ed779621845376980c3ed42c7b45f5b2e11ec', 16),
+                    gmp_init('0xa06ae4ef99f8f692283daf502829f88f77d25b67f888ff3021be96bc093b41ad757a46244f33389ba7e443df5f339565', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c05c1ee2d11ac4f73f3840eb137db6b23985c99936241d85614238c1952cec1124ec9ea2f0e061532920f5345bc8ee5', 16),
+                    gmp_init('0x7592010e0ba06ac5fc584023892ce8e8b08bad5023b6c39aba2903d3dbc50f1f3a2568e49e58b4549ccac23eb32a69e4', 16),
+                    gmp_init('0x81f2d2304ca20c957aa22669b21ef9f334555c0caa7887802ad518b7ec3109106689d5766d04d3e14210b4107bb4a3ed', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9702a385e4ab44f0336bc043bcbc72d72758ad5e7ab6ad41e2f4407bf7e5257d0abe904244c0e84682089d6d8bd58db0', 16),
+                    gmp_init('0x9fe53077281dcb70ffb87d355dc88fc8228acb0102788bc7e07199df2e11f4e858c6bdcb5f7f5b1e33688e46cfea0486', 16),
+                    gmp_init('0xa4c7d9b1e470419c8b84c883ffd0d415c09d43753f70f44319bcabbd6435d1fe4aa4e376a31fd63db723ef10493d8d27', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5b949ded0c401271ecbe84f31836130a6e104de4f1200903f30df86464eb60bd60c4732a2de46833064d582478795da6', 16),
+                    gmp_init('0x691fbd353a7f91295e76704f58cf56fcb03a0222bdefdc5c7431a004b5eb1ed3bad6a4063cf221376e11f9560f822665', 16),
+                    gmp_init('0xe16580147c538cec11461c04197797be98859d27d2a98f7f89ede8c756caf5779db5b66b4df69dcc42cecf5ba47770e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x35adbede3cc170f593e6b3b3bf0de6dfff7e9451f796eed99257adeddb28fec01c3891818e5a55d1ec1f42159c83ecda', 16),
+                    gmp_init('0x4dfa2e08a0bf317473b118264629a3a07bda48cd0a361e24938e169767a1b121655acdeb7ac4f6ced9cd1d50e50ba155', 16),
+                    gmp_init('0x62ff704137663f4f6182d48dfdab8f49a01a8bf28cfe566646c11d3b21f9ebe5df16eaa86aefcb508de36d5921eb5bf1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e2e47d03928c2d6fd7e8c87fc1f0d3cc27dae46a9c194351715003f0e574edbaebd7e160a68fb999b2c07c145f622e6', 16),
+                    gmp_init('0xf6d43ff7883bd8f4d2c5b0afdd46032506580cffa7aa1144c1a6857b8016b8f798bf14aefaec68f1febb2cfa8eb92ffa', 16),
+                    gmp_init('0xa5087075f4303fad2675d3f47171ca13f58fb54b9066a3174b0aa8a29fc559ac482e108160441352c129dbc57fdaad0b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xaa8632d71dbe4934da97508e191b15ee80fa57b8c42eb38989d3a73b2b6cf77d38b5f36e37a02005a4aeac5a6d8cffe9', 16),
+                    gmp_init('0xfd0c621f45f156ef4f8fd2ea7c4ee1dd71388d6b8d6d5543de406fd4024e828196408d78621961512d5f335ee0555b65', 16),
+                    gmp_init('0x8f059d01dad66b871289278d53b25aea53f7737d622b9b78893b7ec391b2bf001072bf9f3b1343328ab336b3a62525dd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d37ddc9afdbdbe7534d5e13f07fcbe5993e996ea81c7256811b7ff32082bcfc46670607ee5656e5986ebfd4c95a814a', 16),
+                    gmp_init('0xb89944cfd09aad6859599c82894c2241fb74035bd939e2af1302a235ad9c7c7b360c8a2b205b5a1db21976a8d2e35ce', 16),
+                    gmp_init('0x85afafbe765712ae6392c8103d393e9b6adf32d6b01b7cbf3138a26f7880be11c928c1d2ea96859fc8082765da134b86', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa52f54fceff357d8c8dc8b3dd426fa4fa6319d76a221648e19a2cfd785b3ed2da2af7087e0a5ef094eb7ab332f53aa77', 16),
+                    gmp_init('0xcee0d919984e27068e6f301b39bfaee461ff08645953fee68a336d2a8fbffe76fc33b62c06cff288090afda564e18cc3', 16),
+                    gmp_init('0xb1926811449b86fde9ce85aea50bae943a400319460d027443baa9756bb5e248cacfc4be69e6dd708a63b8de1e5b3a38', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x45119aee85696d675bc35889738dade3e35f78879cb9cf20a1395496285dae70425544c78f5fa5794f4e330ecfbedf1b', 16),
+                    gmp_init('0x3cebd0449fa83bca77fed5cb6b7c305c255a333957b6716f1188da88513e93147dc656e39b9824c2fbece02395799972', 16),
+                    gmp_init('0xfb92543c17039924589735bf19f30ad882e322e5cbee83b5a3715b182513a0ce83e075d2b73640459e7938bdafee129b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x252643b73293cde2c87fb5a33ca1c84cb0e71c67cfbb28e4006ff4a2c84972eb65fd2ecf6213eba2a4e155e3cf7aeefb', 16),
+                    gmp_init('0x9bd3ba62c7025e14978b97a310ebead6285733ba7c2d7995f713b148938852d8e3f3db366f10706330088e847264baaf', 16),
+                    gmp_init('0x53b758cbef20be2b0b6f773c47b95a4970ae38e9b223868a97f6656fd55b5a949c0c38bc99b717f5412065808958a76b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x194335830e350981e88ec227907c0f954f56b9e9ab2472aa12ef4f305f80feb92a8b6bdeb5dad1466c33ddb80204ff27', 16),
+                    gmp_init('0x57be95d076e3fa0d45bc4258ca9ef8b9e30d881bf9ef038eefd922cba0848d74f1f2d72a6d07e8e385d1b563df98fa5', 16),
+                    gmp_init('0x4bae93db47c58fa45431683cf14ab4ebe6c8be5e8f6d455a77d301771e7f279f9f1397d384c91e964011514f8bb4cc63', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8c80b47a052d5632da7488b585c8a25ebee500b7021b94e9fbc50e143cba6f81e5e3a70b466cbdb91525b675a035efc6', 16),
+                    gmp_init('0xccb2df73254a8cefc20db4ac46af46bcc1f5d4bac781ecc03abf2bd65cd3e6e8a740f1c568ade966119031a3a5097bca', 16),
+                    gmp_init('0xb87bec56b90b4bcc233d2dfe4a2f5876dcdab92d5e6b48cac9ea2b06936172169f19d3e654e7d372e6a6adfe73ad5bc0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x48e3dcb850bc6cf03f11b70e20dbbd8bee77370446b4e7c530aced9ed6a730131ab9c5338e3b4e6d0ab832d890f20d1b', 16),
+                    gmp_init('0xcc8da916c91ee98092128d703830da225aa2c6b4da075e49d627d59f4f7f0c28f1d7b4fc9f15e302d64afc00443eedc5', 16),
+                    gmp_init('0xb84da0020452f8797284b80af7393e95096757087d01bb3f7897d86e66ae12260fa25147c82f21e60283b04d4b8563bb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x84fc76505a612dde2b0d2d2fd938c2f7eac40a78cc17cfb4fffd2a9010c64da57c6d1c8e1c2d38c4376dc91ef4fde79f', 16),
+                    gmp_init('0x8bcee06ed5ebf226ec6a427f3503b152df7b708fdb794f2c362eee0134b1dea3c7af7dd2ff47846c6a9039adac208f94', 16),
+                    gmp_init('0x6f78be91983da4cf50926a15840b82371abba717c8a4a2d4e7875cc765b0b1a3b4d8b6bbae60f6f7000bfc0d69c189ff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc5b9abe93acdeb1f7862a821f7884177c45dbce93bcb4f2c7d01d2ac833176fe46442fee31953e98c3a2b90de6f20feb', 16),
+                    gmp_init('0x4a7e3b49f39344a90b5b3582caf22f0d1e27f9b707594c7baa9890e33af8925ecddc0c733699bd0510aecf1fb87a08b', 16),
+                    gmp_init('0x89180f39147c6216161d9c79c23a501733bebcee059fa33435cf2c79b767199d067c9355abc21ac1197cfdb8ca653587', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf96435d193c32b8a2250d864df1574aaa4eb3642d778f6ee06cf0fa560cd4ce126f5ec78cab766567997ecd44edbb50f', 16),
+                    gmp_init('0x6b3b0e38679541b36731d024bfd0c40337b1fdf1bd9c983ec26035f86fa8395445aaac63346a742b4fdef90a425ad67f', 16),
+                    gmp_init('0xa1c0a58489999bd91e5ce3dfaaf6a3a61e05bbbae4cacaec9bb3287a3ea02c27a0afa511378150998bc74e4f6eb5f07f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x709ccfc554430beedbefab263f54fc4b8cae9cdf5be78ed1221bbcc2d4c73bc1949057905b088e543f34165b2be5ddd2', 16),
+                    gmp_init('0xc8411ec4b17b618c82974d2bf1329f8c061aee43689454dd4a23794761bd42356697bc0fd56ad8b3586f92e1d5ab3e2c', 16),
+                    gmp_init('0xc957ae4a10625d717fc76d275d08bd83ef95c1006b41c8765c5b31a6fdbcd3066d6641c38b74dec5a44157756351714f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x63c0682cf9b007a168d6694cefd67004530e6e612c8fe62c253ce004bc77e09136cc4170a7b30e05bd99d8bb27d41299', 16),
+                    gmp_init('0x70cc000d1d77995fb3c6ae23f8f443c0671eb67f71ad79e33b459e711bf44882ce74381feabf8584c9de97d0513dbbc7', 16),
+                    gmp_init('0xa03f9e302c448285067ff1e326b23685baba2f64f2177fde32647bb570f013c49f6a0c471bd52f6491662a1705cb44ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb41f23dc7c822813777fd207469d968d290d6d1e5f7b68e88d48559f7e89a5c852cf5add31a95d12b90ad7af997f293', 16),
+                    gmp_init('0xf5dc4da15f938c973a86b7f57cc621571884c8bf0750f9a4ca2e9552e750a3792576060a190415fd0da4ad2b7edef877', 16),
+                    gmp_init('0x9d57751db64cbac044f729bd8c752435080bb8ef691bfaa660bb0d233709183f1950dfa52665f61b57c43b930f810aa0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe94a608e311ce462303982676e5d8f845e8faddbdef6656ab1481ecae6df60877826be37912d239af6df1672e746c27b', 16),
+                    gmp_init('0x96fd0b36e0a486c2e24ce9bc3102ead2343986aeb45e9bcc51722cd61ee62dc4c8843e96270b7591d0982b5c3fb72bf7', 16),
+                    gmp_init('0x205328b2208c59ba1443cd7f6424d01a24ba41174d627574de2234db16ce3fbe2175fdc7b7007d12a01d1a3234039e80', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe4308f84f8f5e2a084f8203bc07e1f569de1141b0b0faf5a055dafeed273901b589ccc36e4f07fb9d9c863a6732bce04', 16),
+                    gmp_init('0x66be08ed23c851b7ddfc0ad9154a0bb88728fc1bebb01b66f6ef45f437bed125e95abd25856fa2e2bbaafc3334e33892', 16),
+                    gmp_init('0x560711c4b987870e09f2ebbfdc7b01abbd6459017c0419d8ed43d8e90163255dcb1dc59c87e00272d1e2e1d3e1b89650', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4fb9424b90330447316595e8c232a5fcbca14be4922115843a525d84a16e4c432f0e04aab4544ef10ff9548cdb47fe5c', 16),
+                    gmp_init('0x83e88d61e8d8dbbd2ba4b5237139c652dceefd1b60be6e4ab35fe04d9d7edae8f6cc5a2ce9918e5ddb6354b20a3f1044', 16),
+                    gmp_init('0x7218a739b6467f23a51b62ee6ee5125a2e8472542a521edaa7d3e839184e8a6edfdbc382ccfb48970e8c05416568d20e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc0e4b671f634523ae8ce279bfb0a31ddb0a238d2108f95a60d3ad959f8d4cf248f4eb352fd7a4f5b1b40ddb556646d86', 16),
+                    gmp_init('0xd35a883e6a5ba0d7f52a157216c562068c481d702e91bf202fbbc5a548637dc71b54a2db2b301178e3b3384bbdd41a70', 16),
+                    gmp_init('0xa2035248dc24dc1b66fcb738f87c4734635998061a28778cbad192ab66609c7dfd084aeaf6b053369e1517565069403f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb522ba0956135f5fb2cffddec83165e19407400c3be0ead8f576f88da9ecc387e3fea6a050e6f2616747bd884ac88b4', 16),
+                    gmp_init('0xe10b89d6cd6715ef6928e9b995c2271a7a0e15678ea20501ee603ac053a2860c169d9458ae890088e45e016d723112a2', 16),
+                    gmp_init('0x7abf5009aad0927a850108e4843da7fff974d81ba32449acf329ebf1024874bc6f47ac71e3a2bbcfe762bb422a89f743', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x27001e3f5b59c8b7a4e1622b54066f23cb9174951dc0b4c8181c1753d6bc6c0a65914c5da3367b20dc294c52e86cf6d5', 16),
+                    gmp_init('0x711f88566c2ed991bac72968101358f9c99db0d5b9f4420d57e45d2591a2b9f943b4feb44d7f459653ddaa763a1470da', 16),
+                    gmp_init('0xe482393f735dbd469c4c1ea22319b3ed98e320fc34571ff7eea778c6bda9fb735b41d4a742692ac9b53d99b7ffe8d00b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1a3c7b348aeab30559f2446e28b1a87fa9e49d22c99739d31acb98d476fd69b84815d090df60cb722ff0387f76cd9714', 16),
+                    gmp_init('0xd3903f342679770fb3cbf352b64798168e9662e0804e9bccdf8052c97ca483c0ff2a5acef9223118c3672359ff3ee196', 16),
+                    gmp_init('0xe3d7f8a624c7503268744a4d185fef9ff97177e63e65910c6b5aedf0bfcc763092e2dbf3e03a0169413160ed105e6bce', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x1ddcb2f2af141953c68713490985bfc8f96fa464178163fa8255cac05ae729753f1f846e1afd92771049df344cac3e', 16),
+                    gmp_init('0xc4651454311dd1ec1af4147dc2d8fff233dc51f54ad88e54053c7d763550f617b8a022e21a444a4399c70159b1ffecfc', 16),
+                    gmp_init('0xf3e0dfe8f8d780e9e2d9e9aa40921e9419957d32a526a079368a265223d23019aa2a4679f7c5ad888199851bccf038f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x991df56d0bf8f052b096b1265c7117ecf02b5f4d62d19f5db3c9251b30054e11351ca9f97138303eb9cfa105ad50ad2f', 16),
+                    gmp_init('0xb6194cb2a2f0180f55440690b64b6eff57f72244db08fc396a93e2fd541200f9d6474927b0c8950d95a76ae0f984e85c', 16),
+                    gmp_init('0x489a5cb25f9e3ffb191ae1dc2670dbcb40d32eed37e4257bf90b322024778b2f45ea9468cbeb599dfd199f07a02bf10d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2a4520811eb53f24c0b915118c5f094c68404210689f5ad3815f80e2a3a1695719dba8bf14d58c22b3526d7546703ca1', 16),
+                    gmp_init('0xcd9a9b91043a2c57be277c8ed6c249902a7b4459ee4a1504bcb058d7dc114ed4281092fe9814dec56ce3779d6712d640', 16),
+                    gmp_init('0x772cb72e1d91e6005f842029573c5fd2a4e846e28391dfdf9ca5ec11e30c9eb58fd3d00690480d444bec2afa30e10cb5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x88be5642381946dc66c6f09272e69c16633eec4cf5a2157fd8f4b79b353e220133fd5963bba96f0e4f3e6569464543a6', 16),
+                    gmp_init('0xaa47202ac3b9d56834b94fba37949f9dca97678716f26a4478ed6d3931e439e416de793720067dbd1c4c49eca5f28893', 16),
+                    gmp_init('0x82d280f624ef2aeae716043c1b6e9d464470f7728a8fa64ea7a53b034c2c2bc61761aab6fc9b5adeffba0782f8e22322', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x617c18d4a97f1b6d18c9e7e9c82f0ace97f6c7252bd4ebf369705e54803522b4e35805c247f0ab8f71e11101ac4a3ef0', 16),
+                    gmp_init('0x82d50948f6c8b98cbd9c4c117aab492b35797d772a7ba7dfad6219813b12a9b7738716eab2d2acbfb130e22e9d06a975', 16),
+                    gmp_init('0xccce3c717b5926d9943a4e16a437cb8801a4816dafa638a8cac7a2a269d8af74ad256e8aa9287a03932509b709740e6d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x62b652a9840ff344de891407c5d153de2ab5b44fe864c53e41a052683a60713af825ed26185072c53bc7ac23af9e725a', 16),
+                    gmp_init('0xf7c469b9e0b976c123907b0e9edafaf49517f9fabb0db7930cbcb494b7874316feb97d395be565ef3aa14a4c872ebd2', 16),
+                    gmp_init('0xa09e2f48288d95538cda351ca807e6d4e8736a948d928ec821aa3d52a94b445b16d49cd99070effba7b57be9698571d2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa9a7c4c86373a6b9d5f06a7fbf41df1742a2b9b77ca58f3ebe0b8e22ec41ad50b980194e442c7350b29e9623a4279a9b', 16),
+                    gmp_init('0x426aba2ae738727f1ea7c7a7a7bec9ba73584797db4c745bbf93c1eef2da6b6caa838b4f1bd91ae7c8c89e3ea66a319c', 16),
+                    gmp_init('0x62923e426a0880f88c29d6695376d0143218f75e3a7fdb147bcae79a84be4a817069494e2705a1dd584571b980aa100', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x99ab1bebd00ccb99ce3561a85ae76b17a855bf2eaa9eb6a9eae79631f6f66144b1a61849525da5fc598232948eb99093', 16),
+                    gmp_init('0x34cd13b663e04516750e32a73a4a62b44b37408fda0097796a47fd0745c2294f835a94a35269caa38c593f6a126b903d', 16),
+                    gmp_init('0x117a9774c1f303724eb3b7fc012f3401c8dabda3bccc917c1d36cf62e6f35edb0fe98c0b43048d3d95b59277f15b04b9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb83a553e64475f48ead8a4aa021f14a85a1c76aca72aa1fac5d03ffe47b7b80d37050218246deaabe71ca8dce43ac95', 16),
+                    gmp_init('0x63bda853617f921d0fa60c1fee36a3609f9239820eea866e5e9e06cecebc4fad00378c1b5b4ea3f2bb73582c2405ae54', 16),
+                    gmp_init('0x61e156a7959bd208ebeb0e700ed8654a6e2c0f1cfec5dd2f45fd5d108b6abcf41ac57ae259ea051ff7edfa6d5d19f7f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x835580b0458214bd4f46890d67eada88f3bc659719ddfa5342ea84285912b7f11fe3748444afc56e8f05310fcd667d0', 16),
+                    gmp_init('0xf84a12353c98fe9de3c8c45badccc6873ef77157972c5711f79fce45b8d4b338d2264bdaa9ac6ec82e2bae4f15645938', 16),
+                    gmp_init('0x9fd0fa163de1687e4024988b3ca3cc02b9fd1ad96b1b1cf78e2de476f3918805dc1b67040b41929ce565429a61ba4a9a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x22182b6e82f5b768c1ba09101bdff7c1e21c8f64adbc0e106388aa0e920c5ef66983a96aea7bd1a5bae1901bbeb33a08', 16),
+                    gmp_init('0x8cf42a15e66c926520bd6a5f171995e00a8e9298b627fd724af91b440790d5a0da73bbfda010dcc868ce61521f30a0e7', 16),
+                    gmp_init('0xc54d4a10957ed01756dea81f96ba8f17b9ac6c330cfadc6cf4d595e8af3adb45df584ca17708b7703151d3bff1338d47', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x18247755a318025a39238696c17e1ee14346cf6d07c1784b66cd2283f91b9bb4c0e1836acb8a54d3ef79575361a74f5', 16),
+                    gmp_init('0xc4f4a4d608b50421ea0cc50f45827b53f64f15b2cd6bde8d28e7cd6b1dddb310b402532949c5bd00b5b78409bdcd622d', 16),
+                    gmp_init('0xbeb971edc3bd48fbc302cde023fe1aad90fb6debe1de36dcce4d1ffc24d8858973d7e2acaed178977a5ec5df20f8b50d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdc30cd5fc68f0ff21a5fe618ac076fce378cdf4a18bdbaa1f33b60f1690dfdef2fe78fa0d1a6350572a191ddab59d3ce', 16),
+                    gmp_init('0x3cc4515dc203dd2c2585bfe682f17a274b8ead8ad9bf54e49b64199af27f8402b0c1c5a96f2e213ab23a3a1240432825', 16),
+                    gmp_init('0xf0566978e923765b6c5332814c67f27d532956ac41c43e473403e329dde9c031a725df8401f9a13cbd510f2875451cf0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x78f7167d39dca937b722e1d57203e38b6ea8242a0743837062b79986268886047e09751bde942804bbcf0e677cb27277', 16),
+                    gmp_init('0xec2329c666a28011036c78fc3a8ab144ae28efa0213b3e42c7dcb3f4acbf39936ce5d24610e7bc951d975b8b7232fd83', 16),
+                    gmp_init('0x4557e70a591efdada7839dca61859a986bc675724bb595864a47aba7f944afa10cad45b3a136c9e9688ee5322f89c9f4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1c0d7596603a2c42d2879dfd47c5ecbf7058eda508c4642a180b3a1431705a1d76c231153336d8fdf43973cbd049b53f', 16),
+                    gmp_init('0x7098a9baaea7704575a90241429b999f8cfc27c6932e133de1ab1b5485062457a958751c1e0276e7227a790c64cc3495', 16),
+                    gmp_init('0x9d38a75a847c8e9b6e2eb791792447e4b9b858b016456ad0c7c283ef9d4d9eba881de64d0a302c030ec1ba63c73fb766', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x45138e5e783741379468d524400bdd1f4c41a7b034666697adf3cde5755d776e20df3e2075eca2c8d89e8ce003b72866', 16),
+                    gmp_init('0x562a5eb1966fb7bebf2a8fff4b68564fd6350da3467e2f84210556b2f1089c881dcf5ff4a6f3cf351c7e4b1c1d246255', 16),
+                    gmp_init('0x60dea059093f3cc1330eb5059e4ee22b615360cb5a37eaf2751ac378182ea7c5e6c17a67ef0f11eb2c205d982dc3491f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3391aa4a211817064bc6f805f64530a43a135b718d499ed811e6b35976df80a1f9fdf6b80715e52a3fc1a88b089353c2', 16),
+                    gmp_init('0x175ca2aeb959452c6fd71babe5e9a459f544a514d7444eb82ea4216d33121c01ae2bc7d4f3db9bb35a86e30530059479', 16),
+                    gmp_init('0x1574ce50aeda7794887b9e1f45b384740e4447e52ad68ae43482e538febb7f6ae9603ddee7552563a05a47f46051b7f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8929f244ddeffb66fffd492ff2474b269c57ad32f058ebc353186abd89050e8e8948f02101799dcfe829c2a04a35ddd7', 16),
+                    gmp_init('0x6bb4411eddd108e309ff6fe6e0cfb79663648d5cf629a3595107cb6a78c300f9c3515808a00b55e3b4acdcd84890a260', 16),
+                    gmp_init('0x9b62cf37c1dd83ec1d9eadc7b3ff0b5db9632b7958c01b4752775fe6a365899608b7de02cd98eca62fd47f63d7403c33', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x858a4c628a434fac069c516e98a9d85cd8cf2828c375f130b1234556fa30a52b80032e6649a995b4c074641d593e20e2', 16),
+                    gmp_init('0x211364ba151fb56279cb9c549345892ffc40154ce74ed42dcde27fe334963b53f01ab0deda4c4f14e1a454e0c199f230', 16),
+                    gmp_init('0x91d379d0074466b0947e4fe452de133ad8a3d624d85be28f0a0acf2098902f453d258b14a927d3dadda915c87571574d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdaf207c7937f078c98300b40ffb81bb76c32c41ea8ce7f254c829dd4cd2127dd1fe293c4568ec0374b71a141a75d322b', 16),
+                    gmp_init('0xf34f0fc3ea9fcafd4e6ec2ae36359edef22b8f3d682bb16b26a986945fe9e58197be680db8b6b5379f9aaa9af6346a2a', 16),
+                    gmp_init('0x42cdcdb1c0460278a37c1eadf80edd48b8c2a9bd58477a90bb5fe0b40e2ddaf7642aed99e5b7dc02c73662395852cb4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x10d3b64a409a60d5e84ad1dcdb9dd8a9766757360934ce20977f918c50e418bc58e25301f4f3d65034eafa9854b53b81', 16),
+                    gmp_init('0xf831320af5b3ee0b091c8f1439e8015096ba37886f94ff33d68a719064e91f340c4aad8f62ae2cdb1c5d2817236bd177', 16),
+                    gmp_init('0x2412a0e8089cf067bfee49ee1a7eee6f878e311304a515ad1783658b439e5bd51186d8f78ecba7b0ab4379d4d55bed50', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb694fd40660b22d3a8f0791ea5d35e5959599fdb9c2f8c30d8e7634e453488a90eb54bdbabc9c7b99682676cc067a210', 16),
+                    gmp_init('0x4b78f3ba32be5289cda2107d2501906be0d43bd0b81efb0403f38da8502f4c5f6ea8cf46d60a271983cdf0cc29839e73', 16),
+                    gmp_init('0xfc44b4b9ec02b5005b2e34cda28d4f72e27265c8ef932b9cbe5c120389242f2a13f06cbc6935f9958448056b005c998', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf18e570ccd3e6f2b8e18fd238a56c05084a657d3f097561fd5241c3519a2e9ec8fd3cb1044a1ab58a98dd7307d2ed83', 16),
+                    gmp_init('0xf0f69eff2e4b14504eba91b85a75a3bcd1d5fccfa6c8e5c2288fee9abcc975e845a225387422af8ef133c74754f35e6b', 16),
+                    gmp_init('0xbed19b36c7edd098ba3dd42473da9cbf53b26b2decb75583e0a4213ed1c0143fdd093fe6265e8e24c2b506923915de0a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x20e9a9426f683bb4bd359276bd0e31babccb1b4ed7ce3e3b595b79ce0c228ab0de92ff7d20c5db750ef8e149e88555f', 16),
+                    gmp_init('0x254cfe3f858e61cb4e8e169ace41d872a9555dcf3565c0d6e3dbadae5cc0c13da0ed40dc78b3e5f4d9326cea21915ae', 16),
+                    gmp_init('0xb3adba631187d848e9fa73a427628b4f3a905d5d5157939e994623963261cecfbd574ead01ef0e5fb0a7e6c8153da168', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5a5809a6bf717459297d1d8545298e8c8ac16a143170f236b325db968322009a9c49a65cf4daba4ef53fd51a1cc416ed', 16),
+                    gmp_init('0x34936ddd2b0b25946da61da2f5a90e073bc8fb2562138d8cddb556686ed2eb8dc8ffdd748d63973f6f2fe0efdd94a1d1', 16),
+                    gmp_init('0xfa591ad4aee0aae056aef2b913c92def37bf70f8844251668108052c013abfcdc71e12914a6eae3944cbed93db2500f7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8a544e8b6d148138018ccb8ba67edc36c992963de795eb89bc69d62384c9b81dc18c3df4f18a9632dce0c8026671d7b6', 16),
+                    gmp_init('0xcd8eca85ce9f19287642926e71d0b2b04b459d03e88446dceefa62e26f9b2570e4efcc73ac1a57d5256efebb1f7c1789', 16),
+                    gmp_init('0xe27b1462e245c26c818669befd8ecdce48f2b9b4bcdd9922de27aa59043bcb918a01b55880331cbaa428bb577fb3a708', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x574c3e080ebe06c24bf6ce692df7f5ea65f2a526ea803983cda635faace5326d00a516587aa3fe9873578280cca6d93', 16),
+                    gmp_init('0x3c44e2cf9d9e823294af85ff6f18a20894f1c6cfec006d8cac07794d2cf4a2df2a4e4c6d5970c7a696d3ebc6589ba541', 16),
+                    gmp_init('0x57be73e3498b35b728d25b0ec74b0b6fc4e596043eb19219104f3bc2e2cff478297f2c2d6ccf0cd7a4241e3dcaedfc8c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x61f2b6ab756a299aa1c867def42a267279b949b63e4b526102db42161b1b2ffdbd763b47666d30b40d9fdeb995d4e01b', 16),
+                    gmp_init('0x9fc4effbdaf3d25bc73a90c652f4909245d2451dba1651ee97da8dbc87f0d0de033b27a0193d002d9873726d1f03db9e', 16),
+                    gmp_init('0xe0810ee5591fafcd6f7c28818025d09e422609c2655d6754165d8d58a522fd5e6bd3f96e73e0f14f1db6a57b8d3e385', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8b85397044254f99363318be813c340aa63827742fbd6bbf8b7d962d7c0abf242e5c8923df7b6c41666d2c6c86f5c751', 16),
+                    gmp_init('0x5d1e68fa8497c83268b59bcde01ebd7a6f35c98aadb04ee07e2d1f1014ea730dd73075047f9b8b0eeb62f55d32e41a42', 16),
+                    gmp_init('0x138fa45babd6e39c21e794d7177545a6fb418f6b0ae00445de2f7e40788c2d9af6655c6d830ad11951bf25a8e858dd8c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc9131205e5a92395f06c6565f98182879e3632757bc014f7e247bf4fe26d43c02e4c6b50fc75ff6c669deddc019d1636', 16),
+                    gmp_init('0x1e3aabe474f0a423cc27767722dae3ea2e673bb36e4b63db449c30eeb6a4105e7bb43e885ee2212af3e87b1bc2cddec7', 16),
+                    gmp_init('0xe138e8c4f0520509a75df2c6f479fcb9fb27f5bb7ab6acae90d3b8a3319a789eaef9869accffa91a8ea9d1131b15a86d', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8fc0e55c6733169a35e34f02d446c02cfbe84723ad3001e10a14b7b9f7ece42de6a88b4ffdfa2185e400727e0813b949', 16),
+                    gmp_init('0xeeca90523a767b40beede780952ec678b4955cd340147e8c9153cf76da47934c808c96ddab8342f26e4e3cbd6d8d08e6', 16),
+                    gmp_init('0x1f6d6e24728e4fb65d02ad89d696232fa4f9d9d22e1b80a757021aa412ce950264700884f938409f03788be532cbb1c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xfbec24171bbce334a5d728160d780b3244c9c70d4846d6e74f0124fb591183fd4511381658135636149a7c06a35db0cb', 16),
+                    gmp_init('0x9ce2451cdbf5b48156f5c7c51f7c8c3c2ae4638483b8311014c3b6db94002ac65d1ce8183fa8d7822cbced88e4e774b9', 16),
+                    gmp_init('0xe911766576cd596274df6dba4bc6ef58fe2cade805debcc8bff0ae6e0d84189ae508af99a01be7555ca173ba2bf2918e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd170d51fb61446c16337b0cc793f47ae793b927930cd983cbb704e312e68683df4f68db4b36e7ade06b52acbae63a054', 16),
+                    gmp_init('0xc48d1a40c153a2cfd9e9c91f96faad4535eb145f723b8200fc088ae4f633820b486c383b3b6eace51647e3af14008be6', 16),
+                    gmp_init('0x838aff0061dd58c922ec2b7defd05bc6390ac5951950a32e6ca19261afe6246001b47e5f7419f13982af364529d40cd3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9958e394b02287c4f607b79da8a59dcafb09d6ab1c829227af5bb2a7293d5df8c8d6d076285d92a2090c59ffd8c3b4b5', 16),
+                    gmp_init('0x914f8c3f0809a937ab9c3908ebbc33617c0567deac0bfc079810deebc1fb2f6844df4ad90a9e1074baed6e0872900adc', 16),
+                    gmp_init('0x24210b54ededaa609a906bd70576723bbb8f6358673c4903d2184646c4e009829dc9c1047e214f156221a3a9511922e6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9ba05b213d46f573ccbcb42766c66ac7d516f65c918ed4b01dfb6e224a2f194359c10d7a28e4f9e89425ee654c22a5fa', 16),
+                    gmp_init('0x590c09072049e2a42e40f83ec6d3eec9d3d9807b9b19610c320bf378900309c1227a16775a9b22c5d6c16dc5e8300777', 16),
+                    gmp_init('0x31823aacb7f8a05e5294be9ba73c340816048af493967a44ee6f85ede66e37eb31547befb98846532bbf010420cd002d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa1658b1d01c7c6afe2fcaac1012f5627fdcff43aa2a4f72c38dca4f7ccb762d68733bf5ccf31b458c4465136995b3c0', 16),
+                    gmp_init('0xac7aa0a4621899c330892c92abd699c4755d789875be5b5304577407f58a8fa33598b127f4ef26dd64dc02e2b4f955d1', 16),
+                    gmp_init('0xdc347a2d5ef167b183bb6d1d227ddd9beeaa00e37086cc6a7b38bf034c4ddc1c8a0649fcf83d86f7b30207c9e626d507', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5cdf83c72400880227b28fcd553a0ab2e501e29fea45770f5ccf3afc3aef89c3d46962a26825c9d889735674065c0c05', 16),
+                    gmp_init('0x5abd6c8d3b743429596f3fcab163b071a5e2d126080beceabb5a9e4b20f2bb36efa1b5dfa5d648592d22bcfcc61330fb', 16),
+                    gmp_init('0xdc99f39ae71caca77cd8e093775c71599a20f9a282a7f74a7eb1ab72748da888c482907195fbd1b1063965b81f49374d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x363bfe2f66e8c0dbf88f751610ed91710c2d69fca5aa31d401c564727fd628e75570a599248ead19bd911d54a3d576b9', 16),
+                    gmp_init('0x4b8a9dd55c122ac1be22a90a0d90187853fd434428506fba62cd6621bca0bb5e07a1cc0d670b77382761ebd56ea61c3', 16),
+                    gmp_init('0xe2e11e957b6c4c3dc23d8c55790ede6c6371aeaaea6305cf5bc59739713cc7326ca2e63ca8c2bbe4a474c52b35e2a489', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4fa0d0a65ef168de6e61c2ecbf6e93cac45a2a3cce5bc2e7cea1178f473c9ddc8d5521aa94b70482bedf17a8883e25fc', 16),
+                    gmp_init('0x123df01792c35ba58bfb4ba18db276a5f2d7327f987b5d065af9bce7095f2e94b07ef3c449b107c87f6806a97a2a3214', 16),
+                    gmp_init('0x315eb2f227b8ad800bb81a255512ac84f701c03e1c241541a31eefc8dbc1525b22ae55d183d82990049ec377684a58f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x91178e42921d04d8ec546c531fc917a47349659dc66871689ee2742c0de84605882e92dc3bd315a3ae48eefd3cdadf5e', 16),
+                    gmp_init('0x78e65fffb51a5c23ab51d303e624679c0022c992b5e227960c9846b8e0cebffd6f9b8c29506fa0d90a9b50b77b3c8c41', 16),
+                    gmp_init('0x2798e21416f2174a1f222294fc43acee9332ff52daa6b531d522dbf7839b1cffda17b737354220e7f1a2757f635b99c9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x261ebba3b635712a474ddf47471692b45aa690b328489e9180bd74577885ca18a1753cd13e420368ce746fe214b41c13', 16),
+                    gmp_init('0xa439f164f22426d308d6814d16d5ffad0e06af2865770e9cac34410c543569f85dc5a4c575fcc1b702c8dcac49a13c5', 16),
+                    gmp_init('0xb370f7ca9415ff29e22be6dde6dc91999857b3b7fc34d751f59ee199ae5b6487f47bb9f2c3a98f1fcdd4598c56b79420', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2efe70c6dd377b7e89f0e00bd10169ca25f185fa9cd249659f8296f3dfd9983d30ac995d0639a6eef012edcdad411743', 16),
+                    gmp_init('0xde74e700f9b38a1640803c625a10f471b042a5781a5e794d76a310d621c3b4065a6cb0230ff46bb2ee406d45d8204705', 16),
+                    gmp_init('0x342c0fa4866a7431c499db06c8efb27b500362863542e06f386648e71fb7219f5f53e5e5ba72db936fd0de5d25b00c9a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x668f99cc4c6200938e165d145061766077ea1f8973840a87ddc8e2bee28903665249ef87b179e4958c40f26eba101907', 16),
+                    gmp_init('0xc3008f2c3756908671c5b0b1fbd519d07182423766cacd7d99fc518638e1b31d80a9df1b929596cfbe7fbb0289c457f5', 16),
+                    gmp_init('0xd7f0a404226a8157caf28b5c6067fb639fe9a74378f16512e084d6efb0d7a839aba0124966d2c239f9fb6708ee77dbe9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce732a48e58949b5a44ba9ded3239f1acde7525b5a701f4be1b4230a94d6c8d8fa70106a414c5a44dfe93bd331a3148e', 16),
+                    gmp_init('0x1aea8998e76557491deb929df9857ef549ab0a2fabb2e17b6db66af80a131f2217d831848c2d03d755c522670455dbfd', 16),
+                    gmp_init('0x5c5974ea3e2088f656feb3fd4af7afa03abfb6ae6b50612b9a51aa259939cd03304c9779dd9dcefd892fdc7bd1d57bb4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf0b56e00625870cd034eccba9481341d3d26d3ba49d92efe5df386764e522ed621ccf169c2c5b8dcff3799332692354', 16),
+                    gmp_init('0x488446d71d822358b0e7c73cd33d01c8d2f25a0d2d37ff49f55424dfcda960975b55f7d1cc8f9735f50758d828746f84', 16),
+                    gmp_init('0x7f5406715eb21c105fedd8237a55ead2864dfcd915386033141e14cb63095262693493676b381f9115fedfcc185b9028', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x1ddea437cf47b4cd776dbed4bed930f13499b1c7acaae31c5844217155ffb48476e444e573a9cc1c37da129495e72020', 16),
+                    gmp_init('0x886ef0cf739dd3315375aee8c870db07a0bef80751fb92cc73039c1db389bd361995eee867a0f0a9154e777e1298ee6b', 16),
+                    gmp_init('0x392ad9fde515a44443b313a5bcd59976ced809564836aabe0618f15ddf4386e07760b34a18834d6408669fe1a3206142', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe2d38dc456ba1ce2464bd82e27c5c221256292dd6b2e0f3112e422a2469dd2e6754763217592e6e04a4129522fb198da', 16),
+                    gmp_init('0x8e1f274dd9fc4d3c60750cdff5a13f88af29dfa6037b38fe8edc5132f3dafaa425b26e8f8ce25ac08146cf3bd6943c39', 16),
+                    gmp_init('0x3c5ab401d03ae76f5341311e174fdf09b983e836c651eb39d15b31d1762768dfc5de993a59d9b4c35e7dcb0e257c7b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xce2580e730c21889ca1a3283e3f47cce1c533a94c3282f6be06b76e971daf58a5f2a1f46c7fd61428a059cea340a582', 16),
+                    gmp_init('0xa5056c9f6d3bee7c57aa91a66e20f8d60cb43229af27f19bf07a47d034da75cdc4ce6130199ec900f26e3de1504d7383', 16),
+                    gmp_init('0x856e95585a797d0639a1813b9dae544ae45d16e2103de965d5051141b9a16cd0a07f3c5c39430dfd1e84c3dbb45bc71f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa69e29c22590125c9a150b26f4ec91c24b54f8491dfa34c7f4e897b3d17a6b9c21492d72084eb67698ddb7dda208f0f3', 16),
+                    gmp_init('0x9a435be7087780e561d14cdf94eee0e75a4766227799cd909f9db5c795725c35945d29123086522b98565dd3762c373b', 16),
+                    gmp_init('0xee6d43ad2c89ba2c351a565e3ee32fa684f2504677ee9f8d8bfa20f5a1c25add48e15f94f1289065a77b95a95cb06a7f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7e3438464754acd7163b653290a1741da51f00ff4f757efb700182ce5e61c78a159a971cee1473c1d69dfad0aa15f690', 16),
+                    gmp_init('0x4a3f098ee9b631ee7f0e48aeeed470cc2fc4bc3102ef8c01b5bae269d8608f75466870bfdc53ef896533c4f23a3a875d', 16),
+                    gmp_init('0x771bb26956fced3fce3a244f76df1dc8c121844a7f607f46386c1de533f02621d22db7800b0cbee9cf54a8bdd705adcd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x192b92d9e684389f6ced5eefea206600660910740892615e85978e86e7ec678d841d810d5030a5ddceeff645c5560127', 16),
+                    gmp_init('0x4f950ce38a4515a9fbf7ba8626c715bb5625b468da787637dab6ecdf181010769da8f83c2a1e0a05d268b7857187d316', 16),
+                    gmp_init('0x1003ed8e6bb727a5882eeabc4d8500c2ad463bd249a369186c523abf7341f04c10fb29f84997714ce083f78ec907c198', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x807c1769d11016a91924c7bd3036a14b41318c8e097b70e22e8c16012347d349d3b38aff888c80499771470949129a39', 16),
+                    gmp_init('0x3a54a4488833a037328103434963eda52f83f71cd240cbb5e74012837fb3fbe8ceeac6bac28543975608fe55540105d8', 16),
+                    gmp_init('0xfc6638392f2c42da23dc295f3cb1e6e60c600ffe5d9394012e598fada6c94fe6a758d71a83bbe9866a19d88085b1523c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda4f480164e0a806076c34baf532ae0917f95792c5be95ed8f41d1bb22960feee6ec786df7b3748e85cf6a19547d5aab', 16),
+                    gmp_init('0xc86bf34ab00bb3bd9f2fdb9865f59ad0568a0b9d50eca795bdb022c240ed4c7fe110b80e068564afc4af1ae171ebd61d', 16),
+                    gmp_init('0x44ddc8ab1c46c7d512111e348f141f5d81facbfef63b41a39c05eefabd401a784453ca9df39be9067d5fd3c984d24b7d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb6d20c33a1af5b4158a4d0f0652ceca9a5cc7920ac3e37aaf4def0cd8decef4b1b1b2f900b2e870cb2038c18737f9b89', 16),
+                    gmp_init('0xc2fe789853337ba31d8469f88da54bd516a1d63f8338eaa74f27e1c8f58b1d6622b56487d565e00755a84d24ce6554df', 16),
+                    gmp_init('0xbb0f87114eaf90a219763fc8af0e3d4eaa1cfafd6816e7968f0e82843e5222016439405ddf59fc48138ca3895245e74b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1abad679952464bdd7ee363c998775be85f5c2b78588958d370e4f5e79789b6beaa24eea1863093afa6559a83598fb5f', 16),
+                    gmp_init('0x6e395f91e713cedde10669617b76a62bee8ddc9112fb9c89127e994082933f27c80d8e55ce5b61a186c5278711863d74', 16),
+                    gmp_init('0xfd9b0f2b27fc18c42901e2b0281557c32b30547785fe95581656b71beab8acb7239f6df5c927e654cf95c287c6de551f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa9e7581a205e81befa384cd599f22dbb061d41cc0ed5a46bdfabe5fec0d7c5faa05f58bda6cbafe11e768af5c06f66ae', 16),
+                    gmp_init('0xfe2bbb0c11d9989cb9831ee5373140dc18f6208d2c3082905bf4436cc555cb4fda318536492213e21607ca5f6639c375', 16),
+                    gmp_init('0x80b709498006278ea3f1e3e544ba1c1b6dfea3e688b48ddfa2b5b5f2d30b091faaa76425c67d37320d30815d69c7667c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe637d130a2c3781ef91346c57b8be6b1c5ee9fdba7fa9b962aa18a4c2e2a2c993d97b56f2a88fd4ca706a4ddb5289455', 16),
+                    gmp_init('0x3f9009c9604ecf8d4704029f24a3ca6e8518d4a94dea4fb197c926cecdc9611239326139c707a9f7b40e14dd4433e180', 16),
+                    gmp_init('0xe91aa49e2a32bba1efb87a66997de53922bf6c3d9f61d759fdc9f1096f1b1da988dc6827e434bd7abca77b29b4a9627a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x76a223930bd208972d08d1e61198206b00337681045bc8eaeee25f883a68d0aa9775b88118b761f47ac9fc50869307d1', 16),
+                    gmp_init('0xdde5ec9b26a387e7c32c2dde97daca2d3084c39cb8ae763f83c078ec01a95654fcc10b545df489776edd99a313307dd6', 16),
+                    gmp_init('0xe47c761d59275f6d7297058072f260135905f68fb30a40889454f938f92afb9e5c72df55a535b8776bd53530cdbd8209', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x61441976a65935921f09a522f47540f209905a9cf85500cb57e0a2804bd745a720f3f780dae63ce5691e3ac4031a9286', 16),
+                    gmp_init('0x19b3b68b33defd96c9cd8f564f38cea1ec17f9940cc2841f37be2cda89ea7851c1964356b9ae900f4633a0635dcff881', 16),
+                    gmp_init('0x6e29adb617754eedee3f5b30014585bac1532725a9579299981761ba2ef2b0e7fee4f707f3358097e79e2a0335008a3c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcdacca141cd4ea16d17e8a024fa9481006ae5d8313cd96bdada4bbaf4cb048b1fe7c2e474c7826924e25d0120aca9bd5', 16),
+                    gmp_init('0x9b320543fe8f15b2b9088fa60f4818b8f1f155f35f8b006d23f9548ddfeb64a9cc1997b79beddd36c1086b4dbee346a6', 16),
+                    gmp_init('0xdc4aeb219afe964fca83c233f11171407bd4b8e6362a8e6bb04c6b123ebcc21a553a015ef1efec507e51bcf1c00fe67', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x34461adc0f44ff087ec381b4887d7963a7a4248c02a4868cb0ecd2a3423e27be1e04d89a039c81f050b0e60eda1ae0ae', 16),
+                    gmp_init('0xe52be7244678eab64e6dc85d781e5b832d1def8dd0195ed698c38f0dba8ca97a2eb70cdfd32c8c4c77d403abfe2394ae', 16),
+                    gmp_init('0x77d2abc1f4f6b205e03b283839bccbc72695272a1f2b92abb23e75bff2c78283400c27bdd69150a70337924135a8b7c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6ee7e4785590e708b7f525406dca6a815a124e8c5405e3b437cb229c53bf5b9801c4e001e1b6b3d9556a2ede9b17688b', 16),
+                    gmp_init('0xc84b1fd9ebd43a65f66e9300dccfd68e645ff5c17c90de600b6126edd9de5693d9e6cca159cb752edc43caab26f7be7b', 16),
+                    gmp_init('0x91df3574345c43e29835c03ebe0eb8de715a82c40b5c3462128242be4fd02b1f2ab8037e0fa65f28285790cd6bb4ab74', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7c4b08428e6f90d25e1ee2084a0cdb3f65b082ffdd69c1a65b43f0f328b5389e10bd71e6d6b8341a2331a4fd555aaf0', 16),
+                    gmp_init('0x9c03e25ba5c1a2e9cd50ed92cfa203d89de4bdeea76d7a05f900678776ade4d723db71e02f8666f090f20bca94e9b88f', 16),
+                    gmp_init('0x42d3ceae913a8c2d6016b5a440229af1920c8cdd771ff3d181a8f5b962addfe9b3cbe559226dc27d927c4a2b2528f8f6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1632f2fad1ad0e8ca9beb07fa15f2c951980cff113204291851307f71aaa3865658f7cf08889b0074f001a324ead20ae', 16),
+                    gmp_init('0x7c33b473574b19a512a624f2e010988f5825077c9a7dd7661dde3973b5b85bfdf7ff10e9fdf7db62231b313713feef26', 16),
+                    gmp_init('0x1114e93e3511d67c9d1bf0ff704edb203d50cdff80c898e443de8a3ac36a5ff7c3937efa0bde835b7f4c106131d37e35', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd66945b3fb2374101384d47d32d030594b264fd19043cf65b1c1747e004d34416057f708de4032d9e89aeed01f642f7f', 16),
+                    gmp_init('0x3c08052f425696af93fb3277e832dcef3aed12482f93b47486df70a45076cb5c43adb8ca178ba7a36985fd793b572200', 16),
+                    gmp_init('0xa4fea75f75b92693616d9391b7be80d05b3f76fb854188a352d10c1c8e1779df284085c74bd8ba583a088293b56123f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2e62c4c4592fd76ebb976ea246cce8c4c3503bf4b3bf4f6dbcd8f749a50ba964b307aa313babf5b0f1c161697df648a4', 16),
+                    gmp_init('0x8105fc732e7100b49e07c6fd3714922f4705cf64959928043192980c645bcd7975a7bcbb4b56d1f236cc3086771ad3c6', 16),
+                    gmp_init('0xdb5ecfd9bb81efb990d8a0c1173fc085949d22ac0dfaefc886418da87bfb9103d97dc19c2801afbe0d73ec41c13c4f93', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe6f3e4b1e689bb8dd011257a1d56d0ec2960e9b581c6c3b01cea13a3b485e0e3848c82e0a940213240a3257803bc710e', 16),
+                    gmp_init('0x4c75e656e33401625fe374b6d021f72937a2bc360c2c8013825f4ea2081cad88f3e25f40461d083b3152058ef117517e', 16),
+                    gmp_init('0xc617da71c383c6f9e21942b9e6a87a7059aae79e29c2cb2fbfbac75f4e5d0dfdd99d569305770706264308e33b8aee19', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf99d153bb449e7e6394f8e6ab1ec0fdea2ef35fb795965937a26b326c936ddc0c9e8165d1eaaeb8b80ec41c557725f4c', 16),
+                    gmp_init('0x9bfc26b40ebc7f6bfff4d0a77019cb7ee7133e8b30b8ada30b984e3156554faa21c56b01a64033791ea6b42d81a1a747', 16),
+                    gmp_init('0x4260b026fc08339984df5adf61a6e8f0cd6a200deef22d4da53682a04c97b665928fb9df7b8b42d77e8e298aaedec19c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd4a301ec42aff77ce328cea73d91f7de25b8bafb3676632b4aff44a6275eb8cc642bae87f437ec8dbd55f9aacad409e5', 16),
+                    gmp_init('0x28c6a7d008a08f7bacb4737c8116bdbae7292fedff6cfb029f9ff45975ab7b39d98e1b5d4357c34764596a1d0de6c79b', 16),
+                    gmp_init('0xf56be0c86c6a8e555884f1ea2de8729d48939cf9d6018d53631db2adce0a262725cb12a1c0b5c23ff575bdc836abf37d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc46ab405f4c677d007106261cb18088978f962eabcb342fd24cf09e3554ce347a258fbf7f302b2c2f3e0c710e50a3285', 16),
+                    gmp_init('0xd52bd08d8fa71c825be212c1ef8eaba9f39c7a3ef941b1a0c3f96e0ed8358686a940c4186710d9c6f6665022f17e2d64', 16),
+                    gmp_init('0x2704ad16e81ae32c044e5276fe000691de9f74594d0ff9b1f80cf6a8a6d05630bec04f95512f1ef4866ab80410557d65', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x876c4ad166b895e7980655e71fcc50394744b1c0291fe0046b5155265d3f09608d6b2e4e3b33eae3199bb0476d708e05', 16),
+                    gmp_init('0xdd8a94c931946ee1aee56757a00199c842e56874a3d863e75e86773b4fd3063d3f3688da56f095d5916ffaec8afd34fb', 16),
+                    gmp_init('0x23d2135146eaa048111453756cd46571a4f7297e45918b9ef73debbceb11cd2b0364d7192c131d5be4e4363527ce17bf', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc40758de0aa97fa1923567fd0b6088c220469694732215e6b241d94808a416a14732293dbf1e18edcba7b4a3441521b2', 16),
+                    gmp_init('0x40d565208a28bcd86e6f3470f931b63665b2488b15a58eeee6f5c96e3a0e2ae5dad29b48f439d5f71b55dfeecb1264cc', 16),
+                    gmp_init('0xaec3434bfcc41f24a5cbbeecbea3b6c5951897f4b9a3a7b0efb5686888cad004f83116fa382b7a144aa8e7fda60093ca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcc37e912f8c47b7cbbdb13db5a2c63264fceeefd1cc3082adb109204036ebd8e01bf23899bd97e44634f8e22dc3f2f13', 16),
+                    gmp_init('0x14c74cfacaa10ee6b9435b295d8b9e0f88a71882aa5f94d98e834ecbe85203d62ddb1b4754fc4d99cca6d2dfc4fafacb', 16),
+                    gmp_init('0xc6b5304c9858bd13362b97744961ec15fedef6438d1a9bd00b8a00b9eaa606c51a1fe1f29fd3f4dd4cf4fc78786843dd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc8e324fd44e2c1dbb7797b4742076440e93bb54e8bf0ad6dfe65789d2750dd34d8acfa635106577408ec8383f7008567', 16),
+                    gmp_init('0x98a535f90814eed457a9e8b3a65db083a6f87ca1a48038dfcf16f497db4f9f41dad4e6009cef58979e660a14aa156936', 16),
+                    gmp_init('0x8ce80af59251c8dcc9b1eb73eae5c6355acf072ece04b4a4bee82b9e65b8c4e3dcbb61fab89f84c5c1311d3973488e99', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x88fa14606ad518130241924d0d40c5d34af45f038f44666847979833de06489d7ac7510ef0a9a9fe4e5aab7246941482', 16),
+                    gmp_init('0xe54d4c04583af6062aac91bef67aa123c828dd6b9a927434e1411d03dccabfceceb829d730c550058d99c9e7e35cec2b', 16),
+                    gmp_init('0x53cb1ccfac9c470ac4fe45f61ffe5c0839e86901cf290080cc73e2795264b190558a058aa55caf87a8853656be3eca76', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x5087c45c451562a06708a2fe3091a55f95a34cbfada59217b3abe969a0da5de3bee3a87645be616fe93a5188ba4eb0a0', 16),
+                    gmp_init('0x89b42fc05c43ee793cad75ce7e8553d5c59158bcbc0f3c984a2a3d3cf12552e7f5faf879b1af32fd42a9e9c419a2844e', 16),
+                    gmp_init('0xa0c43fae49d65233c9d201c0f8997d217b2c03d187ee6521c30685bf1a063e18ea1cdc42e27718e45481989c37891c8c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7796715ed4a6013a0c19a207c78b2606214bb1e29d5106830daef2fd040ba45bad05fa23c6c4973f483f83c527113d1d', 16),
+                    gmp_init('0xc39a83f03e23dc5ac2e8bf70c3a92b91138b1aa09dd5811cda9ff2f313b595445b03ceaace74d5c5fed14bb92487786e', 16),
+                    gmp_init('0x243dc157e1ed8270fb5bec3cefb4dac613aef43d24f912473f7c40f3225f65db13ec8eaea8d9bf38b566f09d38095c1b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf6937db791631009bb22159f227403242d8f050ef59e031f7c81e07f89a5b1765f96cb2bbf3a15e252ce36c9f5149bd0', 16),
+                    gmp_init('0xd22d66ec5eba7ad558a100f70bf8c47d9815f2a4f81a3c71e8a515c006907d51af58c7d6f08d27f6b3da455a72d9a8ce', 16),
+                    gmp_init('0x12b229101f6f570421e74b9ece6d72c6a8488664fdb096a57ba8408216f5be157114c69a22ce461e88f529440f46042d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf37e81649163883b0d14a83dc3c59aaa9d10dd95f4c94b8222b786a61d2927eac6c616e8e5b38650cd3b9a28c086e467', 16),
+                    gmp_init('0xdef2ce3f300a8ef7c39fe5e352c2ecc8d0e208ba716a2a0631e73c6c29c693b812050a2ab2648f25cc2f9f0d142b4556', 16),
+                    gmp_init('0x771fdf00d6d89e43f4f3ae58a0594b3bb2a5bd6ef70a67f31d7710d5eae4148979adddc04ec53286a9248b930b36883', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x52929ef75b5933b8726139963d753a147dad1b14d854f7da1e46b7cc40870e7aedc906f6de24cbad3c7203ce300bbd3a', 16),
+                    gmp_init('0x3050850f99bf5f44284074c4857d4dd60c1ab62e21356897746456a1175b575089f2b9844d6a412ea01b8019a242d85', 16),
+                    gmp_init('0xc91ad567fbbc3fddc86b887c75de576dfc89cde4a57f3a788d6f175f2d8f0289a2ae5360deb0ecd0ea0ca847cdf3db1c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5ba56893468385968deceb6e98f916326484b7be8280d622ee54628a44b75f5f3087e64150d47efb4ddfe6fb6f176217', 16),
+                    gmp_init('0xd0e7b5231677731fad8b042bf3b294e7c1e2c43c379745e9afd2be2891ca4ef05e7feb4f53d9b68fa525bf4eb9e53e25', 16),
+                    gmp_init('0xa6143774d6ff5d4707e45b03147c3ebb2a27f6b9b05d5862e6da352fdc0299304a358ee023d78bd463a9f0c8bf4bf0b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8e7af391c4af70fc23125122fbe141aa22a50905f5936a7e92a6260f1380ed8ae4bf75dac05e57ed1a854dd4326a22e4', 16),
+                    gmp_init('0x5bcf408318c909c6d401938ea6dbc3ec963bf7323629a053efc09f60fa14a26b3719bf7657211af2af93806f6eb9d6a0', 16),
+                    gmp_init('0x3bff7e2030090f73194de2eb82dafb6c0297791e22469785ebd345c096b57b4c36431bcc282880a11019fcad8ec025a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9c632d486d53f99ecb6d2c1a18120ecd4e3bf6fa7ac10c8cebf0f9b2432f3aa4dc720c3c9a4fa8770f3d221f843b2db5', 16),
+                    gmp_init('0xe5724f9e5046452efd797fd8ba9e27d9f06c4152899b6cc2cf166b3d0077584b3cede015453052b9eb37dda28a28d899', 16),
+                    gmp_init('0x51605783d4101635a36cb1a5ea28a56060ea619be760a55e623d455d750e165df08a918755d3ca5cbb245154e03180c3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1115724e6b889548ed6a7744aae5f14c4979357c82d84a425b583b8a4aec4cf4bc10348634432f520c51618c40d43c11', 16),
+                    gmp_init('0x9ff0e7c00ce3d6f9d6261765dfe745eed1c30c456d9eedc606af4456b171dc3e1e4b2939e7a9e1f77ad3ccb900c8f2bb', 16),
+                    gmp_init('0x673bf6e054f5b1d552ec8d4fce4f3a34d8d9448a16b25a1909b13fe7095967cc0c65c7d5093f597921a7a5d10dfb3a73', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9cfe8460ed76cf7e9b5440c173cf8caea74baf960d8625fef996190d8fb79042b91d9a67184cd03ab81139845bdd3854', 16),
+                    gmp_init('0x500e45337250c2481fd81b8a0ff94c11c2785ff691cf86b515902da4ba8ee061afc887824ab48036db65e80e5b89302c', 16),
+                    gmp_init('0x2384d0710b31219aa29e8dda6c53d6336de4d9cb286f94331361b5552e1b219a12fa83a2a11ef451d27ba9b95286abca', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x142f067f2cf5a1d1a0fcaae7e58da7e15a1664b4406bd658f1c4e30b9771298a9525929e5a5b9bb9edb2ed9f682d157f', 16),
+                    gmp_init('0x45ed4963c7e2282114cbe707fc064aa2eb1e484b3c769214a9253011ca0bd7603de2f900f462a062915bd033ec35c3b0', 16),
+                    gmp_init('0x8336aae123452e2ccfb30d5fb39412ec4c69478a38566d924aab804f0d01d3c9c08c4de1668ba69590586d62e9964332', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc421cdae5f8c71125df0db18f4aeae0aa39eb2b183b399c7e1d7bf4cea791b55efe9d7d2445db0fb27c7bd1f9fdeee86', 16),
+                    gmp_init('0x6c798344cec3e4150e742d7d3d1c927389695f1fc2d03a5d68f4459e457289a8ad3877d31103e38d005fde6cca7a49b0', 16),
+                    gmp_init('0xd85d31b3ce2a25893df50a547e39b60386411aecbafb31a919b952def126e4e381df8c6dcb9e760072b606caf9d8fd96', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3b5583bb55bd1de67ad7863c90371f8b73cab9d25b5ba531700a86f2f9aaba09a0cde1a10ca299edcf20a1da6e9f4164', 16),
+                    gmp_init('0x96e70798f2ed07e403d725856f76cbcdbbc826f718f4398a8eb9dcbcc4ee87b307d66e34dc228396ca0c7ddc9145aa2a', 16),
+                    gmp_init('0x77e2e736a2485a71bafaddc1cdad8524257f47a22c1e8fa6caa77735ed1a7bc8795b3cf908cd25a51593b41786977c3a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9fe612d728f6560e0e96b9ba9786e43a8a29be3f9e72af1d5cda59e6086a14e64f49067686357e6ae4a199bc97df1543', 16),
+                    gmp_init('0xc6e5963582580d7cfe5d1dc7ab482584e90b5f20cc0554f71d1d5c5f6c0968124956fb97f1c69a5c35b25156e31254ba', 16),
+                    gmp_init('0x3505013e7137beff7faa38e106fea2aca8b6ce384ffd801a23ef0682cc7fc3301ae18782b8aa416f584a289a73f9f8f0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6129eec3bca5fad0b0c20fa32a24eee2f3e5caec734f918c839bbc32e2aca0db2ab39f86df90032ba9f39c13a5c34626', 16),
+                    gmp_init('0x285b95740dbec54ac2c2737b2e23e5e4385ea0d24680636842208b7a9984e56f90157b8ccfa559151a9b19007223810', 16),
+                    gmp_init('0xe7e03f46e4ed452277b798d432ec1a7c8fae4ea3b058f78093c41e35ca1774fd29249946222011726e934fc38b1e3134', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xc97aea860d996ce015698a17f6be4a11d762ae77614698476773b33073f23aa03f19f31b33cbe548460e05b38d46ad75', 16),
+                    gmp_init('0xaa53c38b02c67fb3d018376d9078f15a05bf9fa35168d04b7089e7b5ef6e408cf7db05bf6272ca3014210567d7fcb901', 16),
+                    gmp_init('0xdce1823e52148d31ac77934c72b96043f7ee789e82a5f2a61b13b2256ec25b39a2e9337310bd27c868354a0a182c62cc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb8d70e672bbcb2334d78ed9386ac779ca1cb003ef58837c40115bc3890f3ade1786294f57999f5a65e7959fdd46ac576', 16),
+                    gmp_init('0xd74d16f98f1b6fd7501c7e731b1d900df1242b2717682a1baddf9c47526f6506577f092697e42256c41f4d5cca149ba8', 16),
+                    gmp_init('0xbc13fb5060ee1255759e6d061b2607f6114a35140a83b0394e3600551410e376ec0de221fce5bb689509333093062878', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc0e476e423a59e36643b8ffeaa9a19c88e1753d4d8383de5059cbfc37863c2086539df999a9aa2a246a748468ea1ab7a', 16),
+                    gmp_init('0x3847a18b8b083625b5e27e0cb7cdb09805de47abf31ed83f6b16bb840828674fe41e9a5cfddb4b6956875532a3652cdc', 16),
+                    gmp_init('0x5d19cce58a491386eed7d08b7fcc784f65f776c60c1abdd8af1a6677d45455ae01367b0165c0563d3ac63ae537049a6f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x462fc9719f20bc555f9cd6c3303179ab7ac8367ac3dcbc6fc1438d024ccff02f9ecfd6c29b809eab1cc47c66777d7282', 16),
+                    gmp_init('0x184f05e821cd77e7c7f4092c9e1853b8edbee156bb3a7d6261a3201cd4e1fc29018152594c48278ed7950f60d3944a6f', 16),
+                    gmp_init('0xa854f8c99a2e6c4bac55d343ec6c23f8e6dc886d42983673e1eebaff35565d839cb8ad09b99c6d15456acb69989b86ec', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf3401014f1b4ab81efb0929e02c99cd07f24ffa05027f9cc6733b53a0ee45e600a3ab25e42a2e46cf7f929fd554951b9', 16),
+                    gmp_init('0xa7429e8cf6cffe555e40e51af7a9c4497521e1dc34cd798fab93772c28c30cabe39c3b9471baee7b7809cbc6a993682', 16),
+                    gmp_init('0x66028830c9b15ba129b07c7b0ec523c23380b7ae57b0c43a7f8d6759c3cff2608dd84368b8e79db1b73118caa67aa467', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xdf1c9fc29f8fde383682a01022b12b7a10ee909de54513b2323d19e6a56e24d349f5942f85ec700e968b3fbeae3f77d5', 16),
+                    gmp_init('0x484e01010eabc63af3fbba3522a2dd35ddf5611b52d43fb21415cdd6b2309e31a110a2c7da43cbf0a7708e130a229bdf', 16),
+                    gmp_init('0x11e34ee6daae85cf53d9e75830d5da420e5523ac5f3e57dc3d554e1f87f4d018ee62963aea0adf893d0e0bfc96db5a2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x824b2ad3d22f6b52384dd5976374ddc42677d82407a2d7aacec3448451cf35c454ca4cda018483cff2c96a752425bfd1', 16),
+                    gmp_init('0x40095af0c63e1ea653e90fd608ed48d5d82b5017bfa634e9dd2c3366376b5b3440d2998149b3648425b3393c1051bf1b', 16),
+                    gmp_init('0x586ab6b5428b1720ed7bbab283cb49ec538618a9d52f932b71e4456afb4682b534183e4b3176025d48449c7fbf780c89', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbdb667c0262b8554cf1946376ab4f6a3cbb5eac01cd2142c75affa818ce4b4f3be47b3851e19f7400e717715b4ebe359', 16),
+                    gmp_init('0x37eb8ef972b9bac09eabeb4253e47e5e3ea8339d757b54232d7fd0a415c9407fab98eaf1c8c396a8a046865abe7db848', 16),
+                    gmp_init('0xb4a3329fa399e307f390ca10f7be59282f0fc46d3faa04c7b31c5418e80b20b09759e5f078774c05f0e7698085048160', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x287faaf30406cc10c2f61370bf4e660b9a23d32a6aba65a7ed481189c236917c8cacbbf220713d84aa297c7cbc99ecb2', 16),
+                    gmp_init('0x4e7b4d40034357c3914336c21b27c9ce94a7051a1ea56a4565a9d8e6d43fd360e68afa13998abbcf28bd22c52dfa9007', 16),
+                    gmp_init('0x5506fb2e493a1a9eb37fd2c4a9c29c43f239097f99b22e50856c5caee105031cb6cf598b282aa0a7fa69c0512e04c4eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8aff07c8ab57254fc4c76e48da029b38c2dcd7c7b79d0d56ab457eb3e2b9e8a64250cd3221fc9ac691e5f32136352426', 16),
+                    gmp_init('0xb544b117a7d8704c1cdcc2ec3f57db2ab7539c97c98a8eac2dae69cd8586e40dae6cf55af2a79a32e4c840655cbd738a', 16),
+                    gmp_init('0x411cc3c32734c4cc59665c8e353b852d0c85582b2e976f9afeb594377e98e3aea78b2cb198dbe383dc826b01566b29b6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4d08b5dfd57028dc8381fbb2b5dca8b4c065d245f452f83bda725ba77f99d01e03506a8cd42a73989d88e19f0b960e09', 16),
+                    gmp_init('0x5db6c6fcf4ecca106a6d4b0d8170bc6378b8a4a0acb523b1c0080bb91ec10092bd563ade21c0c7abbfb088bf61310f36', 16),
+                    gmp_init('0x5f1c3f469cf64448c18dfab3d04ada58c811e52cada2ca7e91536c8b0dbadc4ec72e44d0ff4897cfccb3c40a7a5559b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x87c514f69532fff089aee9a27d6fdb2a7e7fd8ba2255fcb70aba22b274b281509fc2325b7fedda0f38433ac12b2a33c', 16),
+                    gmp_init('0xcc747ff7fc6b616e545a97e5fc034e6255f691c99695907fb32ecf286b0db529112e4b5f8e0c07d2bc39f37dcba44ddf', 16),
+                    gmp_init('0x651614a4a9eaa9e9c74306dfc930202f5bfd8a392f40784709d4080de4673ae7aa25a1d516a95a6717ea6f47050d81c8', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8205b2d8ac72d217a39155b06104301e5741c501a8e4f66d09a9b9a9ee3ffafb4a119df4f506f97f5b1e9d9b9392cef', 16),
+                    gmp_init('0x50b6f61cd9c142586c562fd0876fe99f07cab8efc4aca039ae1e40b138219049e63526feb56d7a42ad7d4a65d174e438', 16),
+                    gmp_init('0x44e0246deef3fb0f94f04d6933570fd8a703b3a4a28b10c7d5a08da94f8e067ce2fc6e9fa0896ad2bf5ef60e2cca5228', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d53fd88364b3684087d3897cd05d918a3fe1992e46a9cf36c34c298709b3c6f3ae8935435c442d969decb35ad196df6', 16),
+                    gmp_init('0xac4944b115c031af00e0ca3b3db50169a0b9cc92395e205e2e9e0b59659ed8c6635da49a23c228ea1c73eec413bb4a1f', 16),
+                    gmp_init('0x8c52c2ffd89ca5d826f73e2f1f3998751fbaefffde2001d56cceeb8c2ea587eb46d0372ffc012692367282451c3e0f54', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9644d97da8e4b7a42136a736bc06f76de4354cb453cfc67641d1127cf4adde3fb278923edfe6eeffe3d70f0922135213', 16),
+                    gmp_init('0xe5406325608d579be5dcb098827cfb6849fb8e8ec86f65515c582611a2979a15fe4771a90c449f825462cb9ba9deb9e7', 16),
+                    gmp_init('0xb1e0c02f8f62ebb7eec56d4d7ef44af2c9902f36ea164d8addd3eff8f7267e5c1739924a03170a547ad4c8f85cb59bb3', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x82c1d8f1471e9fea4309ad189403c75fb552a142d1e6245db16ed06fdd08c1f7461bac29e4ea81f6528c0a5de3cb78e0', 16),
+                    gmp_init('0xd5272518720d3d6a7bfc3d99e7e16be0357ca04b4c530bc46b925284c4d8de8a1e874f8591eb7d0c546a50b7c700491a', 16),
+                    gmp_init('0x9fda1f091eded1de03ee1f9e992de096687fb3ffce126c4b5e3dcd4468bbc29859a88d4f0cb4c5f43a359716dfe44746', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57d7b3ab35f7cefcee4a79a9bf4fcd0f8b08eb5960e630513e79ab99d57d21faf2599d80305eaed428c5941312bdf5e8', 16),
+                    gmp_init('0x42973802855d08ef8d82cb7ca3dfd4f06f4ca728c295de6105ad54d4d3ba674611dfba72f9e593ca2b06dbf65e7683aa', 16),
+                    gmp_init('0xbd8496ee99874fbe6ca999add91f2cac08907a27cad830f3c1bf50a9cf25be2d7a741ec78394d1685e47db79fa7bb04c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x354041ff7d26721db44cdd1873329ad65feed78410f2b3a9e099f811fbce0284ad25f2985fb422e4ca6e38332c61e658', 16),
+                    gmp_init('0xacf42270949e364682bc9d168dec2f7e0b18356949ccfba95f712e3a75ddab1b25abd6127a3fde08b294e8aa9d912419', 16),
+                    gmp_init('0x99eb020ab85c5981de4997994b1adef58e8fd91dd5ab49acedf73ed3d2a0e6f5e43ed91e1f931e91e9318d64eed6709b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8c1b88a7a6b7f803f87983854937fcb12d7bde32302a41e8c326cad641f1c3fc1a8be78e5d31166eb4b4f5a38ca0694b', 16),
+                    gmp_init('0xefe3da8624f4cb3a32cdadeeb965d6492ef1bc10496b197d7edb7a73b130b7db121c2f8975cc18a8667ac03593e4734d', 16),
+                    gmp_init('0x8930d0b39e463491e7973e243510d9045a872248221972a5e68a1a6a31ad2969e4cbd513bd881ee1c5ba9201a421a0f1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf67dfa1e13d70561277863b34cbd443dd6ff5bf9c5b74326cf6ab09fa3da8a71656d9ff0493aef703f3e66e053152663', 16),
+                    gmp_init('0xdaf7aad7e83892450bcaaf8a37ed321b0f5f9d1f6f18880acb36b582676d75224823c9b2a057a85713f989d957949349', 16),
+                    gmp_init('0xa58d7e63e82c8a3c45a4203974a1561bd331b520053309fcd7ad20b1baeb3b4c5736b45fbadbc4fe03c88ae091f65541', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x82d9a64b13b8e7d55e7fcb0bb0ea064f1caa8f68884db4427c9a0a1800b05c35e0d0f99b2acf9b6a7512305f031cdfb1', 16),
+                    gmp_init('0xd592407a5a44e8fbdb38a08b221a18abdd1b75050505c4a5a6341d72e8700e809589821d6516f7211e5d532af2ca6ba7', 16),
+                    gmp_init('0x58dcee4a2553788d1d0ee3787ffd6d53a1ca4a4e271c673fdcfbbff6cabc2a8ab795b021160a21c354e43dad1582e5c0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xeaad76f7875573c83921ce5591288d4a0d4cbac93fbefd85beebdbbf59fde04edbb395447fb33a625a5648b189e75eff', 16),
+                    gmp_init('0xaadf19d866f9e60edd095395cd379c79280ddbc9fa936dc2f1e621985165be4d58dbabec64e53c657db0c05e8a4cc4e6', 16),
+                    gmp_init('0x11cabdbbee627e6a4c2bead9d29b388a41096321f498ac47cb5465d68165c7d1401fa8b5db6a0d9b80c787a7d25313c6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x24ea28410d491b4c9b09e610b41b9a66f208849dd6659e170642b24cd247c3e5b95c625c3a8ac2551aab768adab5684d', 16),
+                    gmp_init('0x77a043e50c3ee667439f30640c7d56b7b4770487dbc3d6c32bb97599401519f690cf5ad569f9fc45d213b6afd63e3013', 16),
+                    gmp_init('0x90924e25dcf401441837f693baaa9d5614f987fc32f494b72aa5bac5fe58deb9b891410c515fc523b0b6ae60d1ee734c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5a703226c8cb34cd9c72539f9e8a5f03f6ace6e4fcf4f2f9f420f709c222d234c9d02d131001aaa1a0c41628606f8dd6', 16),
+                    gmp_init('0x8576c6a0b06b0e0f0722f7dbe2f94c74a31d3d4cee31bf480b86f0fdf696aaccc107f88472c3320238c58c8180279f87', 16),
+                    gmp_init('0xbb48e500e4044ee7ed05c3ac158aae8f4bf5d416990cb905304c89166f96b3148046e533b86e649b97229562dbb225cc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa11c395544cffb6146c98bea3e418056263aafa8439b8124a23bc3d7efe14a4426b499b2567b47c14a05eab68ccf89c7', 16),
+                    gmp_init('0x7b2f47a757f652cc7d984b033fb0ff18fa87bb327502cb273a5f517b9d755116cbc470cf399ecd6157d1d9c4a181b684', 16),
+                    gmp_init('0xc686be39a4b6ccb99db5f170104712f791705ebd31d246b7233580c1c015862e2b5266a70ab6cfd8ff3058644017825c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8d2659d85ea7800dfdd8b32b39470fa2d9847a36426b3c3199d44d7fda720bff3938e132ad3b424f1caeb34e7256f11e', 16),
+                    gmp_init('0xb379d47c1f2883f04272131cc42ae089642d1f23c2549717e24c1b6de16cd12f380c9112973722aeb146a71283638441', 16),
+                    gmp_init('0x42a17a3ac4c08c4e0de1b419854bb19cd2346ad8fdace95c304e8c4ab411597b2873df2c6fda4662241d268b89e754ab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2c2db9f4a27923b3ecc3e0e90c12ba48a8de8f85866c67f6a9147e0956a9e2b33cdeb4205362c4e9c649f99878ddf575', 16),
+                    gmp_init('0x1e37b576ffd0eb0dbdda15a1c19ddf502d109809b26103dd2c95b12a2893aa6216c7174955bd03e88eec3d49650972c8', 16),
+                    gmp_init('0xcd4755f5a03d74dc0dd17b1abd4f42e612991ac88dc78a8d0814432e81706388e0bd4a2fd4bfb97bc49a26808da47485', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9ca782a9d4b12870e9905ff204dcd372b8c99dafa77d5f3702627321bcdba02d490cae557ebc72f5f46e932286357fd5', 16),
+                    gmp_init('0x6d899b1e578c8f40e35defa2635a1829a1d12f8d44fe2a0fde3ac0c2e3d969336d947374287e8b1593682e79ccf96fdc', 16),
+                    gmp_init('0x50753dc54e92a9f2b7958176c1919ed13955703b11c0cd9aa29879cd8028c48300a3cc8999b768a93d191f02ce261e4c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1753fe166c83b2a49bf270f9d1c9665e137c603c0f1e10188eb0acd947f73ca0daf966c505049d36adb8574a78196231', 16),
+                    gmp_init('0xfed5cf970f5c196ce881823beb17262a98cadde96af9c4b188683d123c5413432e82e4962605343ec004c18bbece003a', 16),
+                    gmp_init('0xa3b497855bb7a24b5cf0576b2eddbe3e69f02c71ad955d4581cd77b5daf805e609c86fbd61b9ee080ebc9bcc9c2e6817', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x79f2d1451c2117831ae138754a044e9a25247fa40cd1b54abb3bd37bb8a974ee3d8db7fbdfddeb5784dd66b9fccac6bc', 16),
+                    gmp_init('0x798dc21bfada7e235689e378534766a3650b95fa623294e57df75768f10ebff0cf220b3541aadf1a2b4c40d58138778', 16),
+                    gmp_init('0x70e20895bd4276b3e84e8109bcbfa21546a796a91b4f06485352d6c52bc395ff8e18d254aa5bbee09e6e495bf2b26e7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x49dc3435645d397985c188e72208c1179db636465799fdace76ac2783734e4e4ad275831f7c03e53cf9e01ce4e605996', 16),
+                    gmp_init('0x3c5304565aa0970b8d9e87d5a4e084d17c948ae989ee1a27191f2feb26cee3476d1e8649f70199fe2bdd3fa5c0146110', 16),
+                    gmp_init('0x9ff2c024e3df267c6b7d1acac554c546defb1c842b70b3b3942d5aebc0538799982ae89507a135515d23ced06a364456', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x829e4956d32aa90044e97f3298bf5c23ea31d37018c406e292e90045920b3f2d3b5d23b6f62d76db0de6e0267e77030c', 16),
+                    gmp_init('0x430360c2d6fb9b94e3a5cb2c50000e2d9721028548cf0c5f4a963d39896d019d11438296a39d955e7e26309f7483ad7b', 16),
+                    gmp_init('0x2ddad5cbc05b6d0a15d1d6ed33d4e3abbe0bf1800c9d8addff35a01d50a053639dbcef02f74b61cdfe64b2f57fdf4d6e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcefd3dbbdc7bfc41591d3d97f6edf98138d1e8bb03ce3871956ba4770e416aa4b9b12319c27a153c046611ff5dc9e879', 16),
+                    gmp_init('0x42a0b27a9e8bbcb7baa273e31f1b7c3ca2fd58948ab978cdaaf889e748b2f314e2fd7112bec5a8e4d1565812ca0e0a70', 16),
+                    gmp_init('0xdf4b6dea92601e3ba8e05194aa1a2382a517669344be2fbfd28796baeffc9db36fdfcd848d5db92cac7479150af2fe53', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf7a9de12def5ef6984d8e15ca9dcc2e16a7f7b90d42bbc4b74ebaba1d1cf83e8543cc6fca5302abd59d848b4fe6b9150', 16),
+                    gmp_init('0x337e58797babfe35aed07e38b0a328461e6f909f6048b5d5f1880bf972f45ef156920b0121fca665b4880af98e46a52b', 16),
+                    gmp_init('0x441cd95f2d126b75703a8370fef80a4736a93293db2a3a0963887dd44c26b8e84bfd466783a4710959ee1684f3c0972d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x680fd9aed0cefc66530c1ba20225e8d792fd7838cc0a016ecd49fba09550c513683af39decf5be787ab7b48117d1ba44', 16),
+                    gmp_init('0x631b11fc57b3230ba4e14ffaa99440873b2d7ad481408bf0cf5032dfa756cd644aedac0ee4926cad30783f9a0b813bc6', 16),
+                    gmp_init('0xd05d4b25799973c9da5e90bea744592623c78367b5fc43367d49297dec6a4d843a844ce9452845012d408d0d6a05dc1a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb504eac9be0c85e9beed386a34e029eecb52acce106f6eab0f89dc3185f1fe25340a57c1358e70f0aaadea90a30b493', 16),
+                    gmp_init('0xb60799a758325090ba8c3a07fd9b1055fc531ce0de502da8613090340ea63b209496bafb137fa3b7b8fb8190eb190e64', 16),
+                    gmp_init('0xbe12b326f2d3167a5a5850169cc3060401a71f194854e7bd41c2da9ee8885ec3125c83d74aa9a0e05270e68920410102', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbcda6d7f9e683b9cf0dea4a86ffdc816b8227bc6125677930c07555a3c249e789c173fcde1bd4264ba0ed54c93306888', 16),
+                    gmp_init('0x3d743ff36c93d4a546b6c6683b2e2fcacb9a2df8d4fea4b2adc8cdcbd8cd888d27599152201e96bd77f8fbe44311e52f', 16),
+                    gmp_init('0xcd3adcff482464797c5be2755ab5c07fdae9326c03f34888ca86db469b7b3c5fd4a3a7db12f527e05d1da7b5f7dbc8e7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x93ef29f3a3162cebf5061fdca54dc3c0c9462b10f154ce06393c33b7cda45f549760f9a17c33dab1bda332c362cbab09', 16),
+                    gmp_init('0x1fef7ba5c4ffd6d683cace3064d4ba8c9d43d17fa57c47de7c7ae4bc07a12e8ae3f5ddd6c0f40092393cb1c312b22dc6', 16),
+                    gmp_init('0x270c2b907bdab201cd589a111ac68affb93e68449c91ca512d829050657b30e6e6ec8b1ccad68ffb425ffde3c5e02362', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x350a36ae766119d7a865143a9ea5527f3adcd49624221b2aac028172d7430e85bb5be69d65619136f5f9cb9626c5053c', 16),
+                    gmp_init('0xf1c5e00972b28f8d3fb63842ccfb7db4d21d04c4f99c4e715ce142132c94583229e4f8a80369dc1000eb75e51a935439', 16),
+                    gmp_init('0xf2ebf9445f640c9dc255c926db2e30d7ca772f9e3644d7fcf74cb283762e6a253130a35f6e89ff6b9c05fb9eb3c8a4b3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x182bf6fa44b05b4046519607025eacee69360d8b06216021b349d030fe74aeb2683b4d79d2df75e80d2167fc5acd75f2', 16),
+                    gmp_init('0x7a6c8ace006ba7b445150b30b343050ca02066dc62bd16f02673387f4a194444968e050cb12ae3c194cf9760b6338519', 16),
+                    gmp_init('0xadc5c1a44d18b8377cd794fa89799419bb013c85d619f4c0a28a92c384fbb580a963265df00145113636e85782a59a6d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x599564954f1b075c87af2507ae4cee7ea065f6e1e14ebe1ebc3d532aa245108cef9f739cdb2759c6eaea16c13ecf8211', 16),
+                    gmp_init('0x2d2d06d2052b7ab76c63ad2536aa41a1c016f32334bf49536f0988408d38354a6a120e9f644e438e34572b99c0ec71e3', 16),
+                    gmp_init('0x52fcf7cee896b4fa0f46f98790203d87508cdaf0cb5eaebf4bb7989c340f6ee59b06a689fed30f25afd73994d39c851b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x40828863eaaa8ba4a59dbd1cef2aea469086c6f4fadc58f9038369c35b14107d1d794c9b5eb54e0c8fd8d038903dc1bb', 16),
+                    gmp_init('0x252a97ea4166630ca4f5f78c37823c6feeb2b7bff55c9aed38b5ec35ae45158a166e3805c98a4fa2e692559bba0f9e46', 16),
+                    gmp_init('0x33e18414c0453e8931ba02dbf37597a6ff5b8036356b6e99087533f7d3d393c86d001c22dc883353531890c761cd6d8e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb1ceb9399297f30e28b91afee153b48706b772a540e40ac9e590c7593de3bd0db8236b8df8abb5e9febbe9b48dea2fef', 16),
+                    gmp_init('0x9fde62d686dae8f5b5b8a4a30010009b64c83a53bdb0ce7d3920a53c1fd727db31de28ea2c18a9e1866d61a5af914e75', 16),
+                    gmp_init('0xcf2a0ae5eca6aacdf74df61ad4083de8684849094d6ee5ce0c46e59f71da4a684f6ba347e7a3cecb0658a256436b5e24', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7d870160533be167d61a47bcfdf087310f989530d115deb33b2019d9d387e09a7d664a8cc94105d9f029ad7868f57ef0', 16),
+                    gmp_init('0x39ed62cc522d7741600efdfc1f6bfa1ebcf00c9bfbc00ef29cb86c6ba2faf0bbbf1a3d61f36e9fff104339ad51ef2cf6', 16),
+                    gmp_init('0x3089ff325d9d3ae8428200538e8e44ba236a45026f7e5ac4a30ac3c0fd675cce53f7edfb6b8eae921265e865ab54ef8a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x974031fe4472eba3bbf03b7fa4feb4d87a3f533d7f905614ffa5540ca9d9f5367906ed275a314093dcbb74db1822ae75', 16),
+                    gmp_init('0xad55e76cc688d83ec20175129d64ccaeb92200303b0671f19374f957ff3647d0347850a01d1f2cdc143f00997248cf0', 16),
+                    gmp_init('0xf81d6ac96419608cc27cec2e1c209a7f16f4ad36e8aa117a61b3aa342bbf051008bb0ba925760a14d2390ab6a3bacea9', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x741abae3023bc105f5ae6d449a1ee8a71887ea9ebd47549862f9a26a17bbd8ce347c29beac06f777329b639d4045c5fc', 16),
+                    gmp_init('0x6cb05a0df56a494524d1da9a5626a2f56a5c1c1397bcba5c6b063c4e5c5175ba6dc40d03f032e7ae4a4a18ffabbabec5', 16),
+                    gmp_init('0xc7bb286155e84db16c91df37c396d294613ae62c60083ec5811eec1c18f52f5931007c4cd1a4344460c13958e836022e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8c8a55cc37347b3dffefd934a4ae42687cc40775542dd8a3c2ed9f9475c6045774eeca228c6d17c234865426d6ec930c', 16),
+                    gmp_init('0xf97c89d2e9169fe5762bb314ad8cdee1f94365e27a60a710fb4599f3a86f450663f86c71f09c937ec6875b318b930feb', 16),
+                    gmp_init('0xeca905188b2aaa495574117cd7fbd61d8f39d7af82d8562d2950138363d100bce2d309dc158c226fb02be10ee4ad8a79', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf25c63383b14aca3778e9563a1555145c79cb07755089e2ba85ac5ed4362613c20512a312aeb15a224f2d20a6848f2be', 16),
+                    gmp_init('0xea6db0cf67ed82d2d1f9b3b7244a82fbaeff85259209ed421878a8280e65eed57f9c2a55eee14036e58833258efdbf0e', 16),
+                    gmp_init('0x408f2c1ae87dd0eb3916064d9265d25012dd258a97e0007316eb7acfc0565b20c62df633683ef0b6f35f3481947c7d26', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6f5379b88d4ebc99f458da9fd996e83659468959b26e450c4e96e8a0e45f4715111b20bc6d00396aedd4b99398d27ec1', 16),
+                    gmp_init('0x5514cc01aad0d1ecd834c3cd53503c268d962f53c7b6f5f64a92393ddecff954eff792ebe613ce264b06b952631ecde7', 16),
+                    gmp_init('0x8d2b24aaf1c9432e865222dbb6cd3293004c3071ea0ccafeefb108a16b8d9ec322a5236b12ea3bf655df3c9e805599dc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x44dea57d94ed9e8ea3c33d564b413e141bce7bd35d3114afeaf51f1d881c59bb5a56e5dc4054fd3a2be3b46ef75b2d42', 16),
+                    gmp_init('0xe6865c09e229cd4b717cd35102b0501902d9c8f97283b4791d72f353e741243172680b74bcc3cbe7ee36fff5a73496fc', 16),
+                    gmp_init('0xdff62c053aea9fecfe84826e2c8573a73e3339eee559cb80f95ede40f361f77f7ee2b73be5cf063d8361abdec8caba7c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5d74f25a4965b14305ffd8c36dce287fbaff6d960b2402049479b1798eb68320d9e82718cdb650f5deb43af286241760', 16),
+                    gmp_init('0xc8aa34733304daaeab507ff2969852e161a8c80f3b2916c342d66a57dd77ac2dfacef43104cf36c89affc3ff84e2db92', 16),
+                    gmp_init('0xfcf3621c5f67e78bc7759f2a196f74dd25d61200090d1f761872ed3b0101f691cf5b7c7f071304fe3d10645a55dc44ab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcee112295fd340653d7a5da197052f5a7345adfa5ed923ccbd8f53f54964b4a171899280d51be3b88632f015d26918df', 16),
+                    gmp_init('0x5d60cf94618767f88496071558a18559825d2abd1f326e5405b78aa2a046723419639662f7cbc6b778ca348581eb3c3c', 16),
+                    gmp_init('0x912286feb993fb9fcfd1c6745f3c976576fadc0e539c973ea182f7eba85f30f7ea964ad854f7df3ba1aea8c375191723', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7028b47e34c14f1fb4315f6e186ac4f088f534cdf0a9bca048c058b368938d8fa8109b140f84dc6b79fbe290d963464f', 16),
+                    gmp_init('0x19f701b14a83f25fa2310e6a5b77c4201109f1d85c32588c264cd8c23145ab0beb9f56281a28efb0177965ba4a532c9', 16),
+                    gmp_init('0xa5665d6379261ea052d719c58a53c9702b5b2303c3227e5e201ef68a4265674e12d03e9b95e8c35d5ec8641dff4ca88a', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1757693e19382e624e796777359b3f405de53ea0c351c907b96ae06645f90a34fe47711c3292a65b0b47d2c7aa94aaee', 16),
+                    gmp_init('0x4d656941b95793c01e98db530730c2d95932795633c4bdf10958e0e3d85366ae5aec3b81b706188d8adc3c109687198d', 16),
+                    gmp_init('0x50abbb5dddd3ae16450cd5a8c889f11c496298b0cccb924fd77e53a8aa19b63e6a8a3525990455e82104ba7891125592', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7b032c71087be950812a3d0fd75a627a280d7f8c641b70a96a3e7207064f6dd2fbfd065841f770bee2bed0ffd5359dee', 16),
+                    gmp_init('0xeea530bc8ac70cb804435de87eb4bb446a667d3c0e3c04c988634f21066b7f1289cc1ef42ca193277f0db302575a6b76', 16),
+                    gmp_init('0xd140d0e28ed65a699f18ebdb6495d461c5e479357f1ba69d15d536916ea2cfdb787cbcbd93852eff3dccbe65940a08ee', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3e53e13a63dd44338a9ee9d75ab55b1e8bf2fc0c93246d399bbadc34a3866d91910437b6bf819ff1a667f6f53167eb38', 16),
+                    gmp_init('0x3f24f262ca4e6ce4cec2e3f019c0bfdd4343c85ee7710a8941cdcdd8e6dc1c6e8609982320db62621691d71470a9de4', 16),
+                    gmp_init('0x8d4c9145792c1fed0863274e2ca1e167325fa2636ded780bb583394d26eba78df8f09f99163dfaed9f189231166654a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x117eb0015c271b6a4f2db0cb3af9e4b30bc9683e76246148ff400143ce3d8b5d3590637526d30c09f11a4737f7c3ba7a', 16),
+                    gmp_init('0xfc3607b1386b82dcb98801392747595e07e8f629c9c872747fb6eda5dae2c306b5733f05f5550f6e735125159e424dfa', 16),
+                    gmp_init('0xd9da6badf68d5043c83f999d042bbebacfd7ad461a0281279eba66c996e3a41bdb6654da2d1372caf50f69939b3a8352', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2f5aedfc49dfb9d2fbcf8ac54db6b35ee2daf26203e29dd9d769e6d3cc2527bc572a2802a857a4cf89bbdead2417b668', 16),
+                    gmp_init('0x802cee8849225755d6ec563a84902d88c519e889639d2a52a940ca7c51ed6b5feba301f01781c214e56cc86422517473', 16),
+                    gmp_init('0x86fa283a1735a1bf1f54cc0cdeb9a468e4d6de9c40c8f1d3f67880a2183010b3fc053f3c17d4b96a1aaea37488ebe2a9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4c7e500bf824a2c80e683eb3882f7060ef435ced1d0282917cfc5e4fdfbb6396ae96f3f2402830db330e90e38352bd3', 16),
+                    gmp_init('0x28293f824a0c1459773283dcc3b929e3feb06b24d28d81e89beab61fcac8d19ed24fac0297f68fceb7b50cef5db01ac7', 16),
+                    gmp_init('0xa658b2b34cf25a2a4a24ba99b62aa7459ee30f63cd2a1a0f45f07aa8d82d11a326747a1d3b05e48721d8d9e504b7eec0', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc264196a26c9394d73eb68becc36367761c9ee0e69bc2cc3e9482abdd3a7bc3239ba23d553bcf0001077633fa856d01e', 16),
+                    gmp_init('0x8052ca0226b33cca5f72d0a6f1eb61bfbc017936ff64a1b63a40c7bc6bc3bc8a2316cef2d8a1723dc0e23a6d03d4a23', 16),
+                    gmp_init('0x7a5f2f01e1597e9f93ff2d016653dccf18ccde986ded431842687ca5d0ee1cb91f9034f2ada4679b834bfd7cea98872e', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xdc7ccb28994098a55638b5402356dc6c8493fde9d32ebfb72c5e1d1376acb175de6c157576f01ffe685d1c94a4134be2', 16),
+                    gmp_init('0xf6901274f32fa6875df9cf5180c2263281da146b9ff0e1f48e422dc6fa77726d213c08b3f6622743cb0d4faf36e6a55', 16),
+                    gmp_init('0x10a1b19c2bb23ac76a1776722fd2cbf0b37cf1842ef51d19853d47529e1f0311ac60af09346cb972d5d732a59235e329', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5c53f57486c3b49d5ab1a8161167a1fb4fafccf7e1578c4c81a1aa24c596bea72945bc8554ae1b458f8017f26b343353', 16),
+                    gmp_init('0x30565aa11852fb05af352d86793a348f51abd22929e523d7ad41a1ea42805064b3064ae1c870b4679094b03e117dee1d', 16),
+                    gmp_init('0xc6ccbf8f467411d87a00f9b1849833e8a175623d96b517490d024e45b725b1afac26d376945b65d9cfb337fb5762b3ac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9449282191fcd9ceeb5e8d723968ad35b4374df1525324fb0bcf6f62fdf111520a244678f6b24a8b3662ee8a5ceffcb1', 16),
+                    gmp_init('0x7645b8adda46286282d7ec8a7efd55666322496de550a546a58691e93a6301afa2c9d0db8a7ead90a85a0d77e406f244', 16),
+                    gmp_init('0x7eff6e5d8c39c83e7ece95dc63470c73b999328da05d2c9f40fbb9e36dc9836329dd2984ac39df9a4ee10ce0af675dd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xed9a98c0f0a3feee17a5025cbe1ccc27955af6dd673b069244628f64161c9b608f2b55a8a9f520e3761c09474a40654d', 16),
+                    gmp_init('0xd2dd6c10822eb73b4485740ebda80cc395ead60d84176383daa0d978f8ceaf0e3320bf954fdf505d230bca1363f16131', 16),
+                    gmp_init('0x991c3acd9e40af18dcf1d99efaa1bec6078b6f7a494075fde10f9eef198ff7b655bd214e26bf88cb53d2b0fa68f6e236', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x811d75af0ee984d2d9c1a227cd55ed28f4497d7157e763c575de055932a6c50d3e29fda0ff073cd657a826ffc45925bd', 16),
+                    gmp_init('0x83ecf4e56dcef25342abc5df05f171cbd724ef62f21491dda9eac9d64fafc4050bfc30abed79765551c99b863b8412d0', 16),
+                    gmp_init('0x6eda4910dd46bf7fef5ac14dbc688d945e682c2a2a061b89f6a88d003af85f9b7531f5cae5496428ebb5994706a9fbbc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd512133f3ae9f7897266475e1437fc0ea71867f31e40d7ff3e6efd7c7fb25c053e69ed9fb4e2c803420072726811bd17', 16),
+                    gmp_init('0xc6e18bd256ab0be1c250904cdec6559325863a85de4a4f485649816deaa042b43c0a277562e2c84cd95e698187e483bb', 16),
+                    gmp_init('0x4e3358d59d504d40613e35d09acbcef7bf58381593748e84f4555549fbcc9247818eea8e0377e8e445f068ff627413e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3d5e5b07536c406a36ee7c12833b5376dad082ef272f5a6510f2cfc90c1a1b15ea738e17315735bb0bec58b88af3d3bd', 16),
+                    gmp_init('0x6dd6b8aaf36eff46110b43c9e3e2484886dfc993db80fffcaa57743863bd2508d4d96837aa04f642e862bd3045feabce', 16),
+                    gmp_init('0x9e4b4fb1967159b77dca86f06d0ac7f94f0811b58d708eb0df329c06136cf87a74a1556a2aa2697bd34e5c77f40320fe', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xf7662cdc63e04397900c26ad9d1b0b133544ff12a1db522e2e88be8ab20e2de51603aa0ef02169243ac399a003257446', 16),
+                    gmp_init('0x99f4d95f5cfbf280d02538b49c62271a6d5da554db359469c355cfb4b716578994d8e12d7ae0486b1807d847699e8911', 16),
+                    gmp_init('0xbc939365e7d9a6d6e5efa59f744b40784482f0d0879713594f0bfcb7dead076936351bab63a22f7f655ddbf95d771e10', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb2cbf9670245bac98f716a1073ed348d5eb8163e5001af63b39737845aa9059b93bf48ae3f27c89e0d67ae923058d9f', 16),
+                    gmp_init('0x968b77b379fd9fc66e17c5018ddd123a6be09aae9753423352a12185ce5b3aee950aa9e67db5c90253f1fdb90cea36ee', 16),
+                    gmp_init('0x2f984a4dab1d8eb8a8cd0d9671459d26390e1f1c126739651dbf64bfe85cafa56e5da916a19348badc1d55e4dba332c7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e4b3565a5c2a1376838c62a9ddc565f6fc2e11f071cd9bd51fbf64db5a0e8807f414e9fea166ab5c403f5d5ff756369', 16),
+                    gmp_init('0x6b1aa664874aad5796b094dff8cfb138eca55e866d6d9f6cab2695426600ecf36c53a3a6bbb4476e96ea8339cdbd2979', 16),
+                    gmp_init('0xd21436249d089f629340fc405fc53f15796e22b0ec0ee3991aef91615525ac7e918c0c549a641ce61a0f192d1040298d', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7d34ab567d7709844ccf2e2e49cfc5dc6fe59cd6209735053d7a96905a2200bc83d028a954c24e20b1ec9e0c4096173a', 16),
+                    gmp_init('0xc31e523cd19067b00ad617d50fbc417b93cbb4f1f58ad8d9666ddf1fc757afb2f0bdded75ce0afe33e095c47bf25c094', 16),
+                    gmp_init('0x5cc9b19ea5a001349ddcf90af6beb5ae0ff2d0d1e6de4f5dc034814770278e9b268f21873780d85d29702958c2f269f2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5e356fbdfff3319afa74dcdb2035fc3947a19fdc336d958fb503d416849c4ab891122a05d21ef2a11df7dde81e03ee3a', 16),
+                    gmp_init('0x262f54db9f3cd1c2fbf7dd524cd3bcf9acb94ff08b62f956822533585a99614e4e13ce5c739dfd03dad1d3bf1bff313f', 16),
+                    gmp_init('0x265e212e5c2f6ea1a92a2eacace4f2a88e475fa8fef0489a524465327d0fd691578d35cbfb27c129fe07a3e9d0ed0bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbb114df90b0803d9def949948654a7351db84bd9ce7b48e74ed298bfc3f1b491fff965f93d0346d047c6dceee56a94e8', 16),
+                    gmp_init('0x1f4defc64a0db15e09ca4f1dd327f2931f605614b1a63c218fe75fdccab55c0545210d8e008dcc5e48f3e1887fb4ed13', 16),
+                    gmp_init('0x7bb2b7714a8e4bbab4333a02b9d99438cfc30049c8ffd6356f092e1384c4cea6bda92bcf2bac457b3357cc3d3d81c6ff', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa3f712a44ae6f68f9030ab28c8224a6e1eccf134f364a5456be79abe693571ae42e45a4b65a70fa8542c3df96b26035d', 16),
+                    gmp_init('0xca1a957863fa44ff08675283f94d6474def74eb644c25399a418339ce9e90a86571e251ae41b13f1dfb2c81d1004b59e', 16),
+                    gmp_init('0xa4057eb026dee0aa5b8632b5a3c41f05860f5fd7462ba351cf30c2b1a79b9aed08c90f6b086877159e71b028650aacbc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec34fc5138ea7dd63f018b7082842e5cd7fb786af7f830218c86c9dfcf85956ce7d060ca7159c2865094903cd318a93b', 16),
+                    gmp_init('0xf743ed86e701f476da5c013ec68b884357965bfb7381d51def701d5d7d3581feaee9492303b5704c6da3555b4399960', 16),
+                    gmp_init('0xb4829cd60729f564bff6a8682dcb55af5cfbd92f35bf3bd0cd86eb3e78957bb12c483ec03151a741c9adae42ea5e778f', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x8c740aa8e1e1e59b528a32430612ecf2ff3db15eadc68aea3fe932b4f002899415b8488dd6b412b61c313678757dc7bc', 16),
+                    gmp_init('0xb7869fe6ba22f6a680266975e8d10d10edbbb78742d168d5a976e4fa7069a3e4e2549e6c5700bfa16bc8e7eec69bdde3', 16),
+                    gmp_init('0x3ee9860512f04769b9fc2a144bed4aeee6fe50536b374967c43327eaf0effa4559195464819998691246905705c8be29', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcd25c02af8d5718585c790a8ae077a2085c4da973acc4e1f731b482c6f5b3174a418009e9f9e5d7da641629f6eeea3e7', 16),
+                    gmp_init('0xda7b49b0256f2748737fbf4e7327137b5b59eda1025175a7f33e34a0b3fb9f6c23ec838dcb2de894b2a667292787c3c8', 16),
+                    gmp_init('0x52b52bc654b5f0b5bc94f4332fa269a845ab73761c95106a6278f2d2c3b12c65d5a8a048f3b6f895d5bd540ef26a62f7', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x87a0ff0ab5aa6c2d795cd13fe0bb8c6ffb05bc018f70cc367ccb146af88e417c2d8db8de60a547946859158e3644a8fd', 16),
+                    gmp_init('0x1a34bede849a0ad00ba8dcdb8db21d9dea7563c2e7abae40f2efb4a65cea0f0c33fae70a3102474e736221ec708f1c64', 16),
+                    gmp_init('0xced5d95a56acd6fe3e7c391c3b370b346e7369375dec5477e06643efa8a7698d4e72ceb9f0f033c9492de4aaa2479431', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6860d5ac723dd91634fdcc4121f3102c21fd757e281210b966b8cf1c50e0c94517a0b4525f06feb7dc4320ec6108dfda', 16),
+                    gmp_init('0x5d6ac99bcf8c35b2e18e28bf09a7fcd09aeb471003f0e001f1b79165ebb33f92424be4fcf140725396870eed63bbc00b', 16),
+                    gmp_init('0x9ef901a8a26773c139e26c5bc1179f9eb9eb56b2d31c42020c453b7c61d9897c6a7d2c27107be9c8ac333f4d885b5088', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x183828532f33d1cd44c01395de6a6c85242a04a922e0bdad2812d2721bd2ba393b4dea86a4e2b1cb0adafbf1002da017', 16),
+                    gmp_init('0xdbeb9a638c4dc2961dc23a25895b70358c45fcd32826b1e8e93820cd84313e246a47dab32663784bf19ed61620515773', 16),
+                    gmp_init('0x77184b9621cc481e5d44d577f0e6b1d4859a474e1f787ddad41efb54886e0cfb65c03a6c4cd13c4a97e1487c428813e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcb08789244874fa024255d6c5ed3dd902629f94e552121522e7dbb5563e13b86303d4342a80948ffb1b92ca353657ebc', 16),
+                    gmp_init('0x9c617b28a9c62ac5ba22de2b1c7de6de834f1714a4f09f7310acb3701322ac19fef379f9292a57cc15471278940a339b', 16),
+                    gmp_init('0x3e382ffc53e29f6d66adb2c26c258b58d2403ed0fe622634feafcfb473867a822f30f143296aed08e476b4f145d7843c', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4c30b70965b5ca9bab038b70f38c437a320021d849416dae39fedc785115e50b3e957de8084fcecae1a015324dd1fc48', 16),
+                    gmp_init('0xad27c8ed5c90a2f3780ab64f84322e34286a7ac96ea463197b1fa0686adfc6e163e9cf28b8449ccb900b67de646b31bb', 16),
+                    gmp_init('0xfb6ba80de917f0095724ac33f5e0c5aa419aff12ac87d84a607b852fe47251e772a7274505b92efd882a293611a15ffa', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7fdfc6c72d7de6589d389207847f629e54422aa7f5926730f7a51dc68a6e65088f34e3de18e529e7baf91de33f2c48aa', 16),
+                    gmp_init('0x482b7eafb4c164c3c2e162e660f43caa6199f3f8812c7fb44f533230c3a8aab87c6ee6883325f8eb04cff8f6af228067', 16),
+                    gmp_init('0x81b2d09cb1f0efbe186b03f4d1dfa37ee8cb4310cad3f167dc52d5b3a272d5248cca5631a4969b3286d0bcdfdefa6dac', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xcd28145911b5fe33b00e585134ee675d9e9bbd59110dd7fa952711bf5110d12863407b6c7ba6157031fa96ccafc59fe', 16),
+                    gmp_init('0x88571bae0c06d41b950404246433190998a7b63c3c953e78fc6d03af2dad262d2382f4bfedd0b127584a5b5034252f1d', 16),
+                    gmp_init('0x46481a728bf1fe57e3df28ca7ed38ce23f9d1b21a9a8e82b876c1f58077865c650ae1e74c9ab9272876e400b8316a742', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb502058796f77b0f20551ce851c2732a422e15fe38044359b21dc71eea3bae6c5cff526f3120c75b21642de84c01c16f', 16),
+                    gmp_init('0xf43ffa1f3f1d6c8d887a77afe676312af52b65ba2c1f6efb55010f2692192252a458200f75df66df476e81ebef58288a', 16),
+                    gmp_init('0x2b4a8045de3c9e1892cad5b449ed8bf4a3ed18cef77ca81df73c5d1cb9ab3b3808ebf3bc281db74ccbf134c304687725', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd8589859208f0970090f6fef422e86ce8fd78e4344c2c9f0cd21a254b0db0bc56c72bddc415aa2df6276f628302f7dc5', 16),
+                    gmp_init('0xc5bf7bb80731ce7a6019d0feca0ad98836af3433029330814602eb2e58c6b242d25093217693fd079cf34db627dba533', 16),
+                    gmp_init('0x501de4c44ee2504915ee3628c7deb23826dcf3f142a1d8401f57f7656eb76c8325c02fef861c6754b2e2eeae21afdcc2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x4a92b8553643b79decb49f41938de1539a55948280a223bff04ef4dd26bfc3507f06e54136966c99f86d87e3e3db35fe', 16),
+                    gmp_init('0xa364803f79fefe09315431fd2a4218087f57ab1669ea7a3f015cb58cef073e082902973b672bfca26e899c39acd243', 16),
+                    gmp_init('0x86256d9fb84b88dd756bdc5b3c5eed2d11abe806563090d9bba55c042a175905751cb00840c94d9662ce9e9117577d43', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd753ff205d12a084a9339b56485131c05dc561f774a68234e5e20d676b5b4914bc803bbbe1b79df50326d9d35dab6ba', 16),
+                    gmp_init('0x31b1074eac7e922f007cff3ccbb16dff4612072f1a8c52940c9499bf659f0d5b603eca817c644868235f461eddaff4e1', 16),
+                    gmp_init('0xe826cc4986cf59f7d6be15e1569127fda18c22b9c101839629ca70e5adbb844c10550df949dcb7921dde1f0dc60b2b2', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x859e269a59d100d6d2396ab9fb951de0a872d42f16af82e79248ed369d879f5783c2c28319aa5955c732f4f06069b54', 16),
+                    gmp_init('0xaf6f8e7dbc8aa9e312d69e2c43a3345b6ba6bc206fea18b8fec1d4cbcc855fb583e7e7e7d62a246ce4bdfc56a0811815', 16),
+                    gmp_init('0xcd484adc8e51a8aefc18290b7951c08b0c6f3a4cd75b64fe1e4ba4ca3ec917e8752e346ec78827b3c93ead388737e300', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec1769fd2ec14fc0e231530b7e19b4066cccbbb8881da53f862149177d4832da0ca76324e22540674f7ae817c3eb6d9b', 16),
+                    gmp_init('0x171be8a5ecc225cfc76f179085232c913b074d3dbaaf84bae9716cfabb7ba59f45a6427da0d8f1f9051bfa19d337033f', 16),
+                    gmp_init('0xcde3cd940a92ead899d43222840505e53679ac43213ca0f73eecdfdc3a60219e809ef538dded61db55ef8de06aff1258', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0xce5f6afec86b5b87ab27202964e7bfeec1d201efb63c3219033b7d1a2b693d5810b72f9b65541931c334e0e3cd04957f', 16),
+                    gmp_init('0x8a61daa34f15f5d8b4979fe03ea57414f39ec38af9a30c0acde34921132cae9494e64e3630144c957bf642eaf082d9ce', 16),
+                    gmp_init('0x2bd0f2801d1be9d1a895838b6585f22c9a7af8ebb10388af0c9ac0cad817110b2e3b8651939294d24a9ebed16022cf67', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc487bffbf54451f4f53875b6227012f24f1a80775feb6d5a9762f049e257bd6b602d4f6df2c688cbede2fb187dd2295f', 16),
+                    gmp_init('0x1a7cd5e942d7f79e217547927f42f3306b2d2babd8a13a3599d0084b1eb86c9a387649bdd7b60992fa88697938feda7c', 16),
+                    gmp_init('0x515ddeebabe5dde17253a9957878884eb1fb7f89e19665cb9aa349dd3e0dfe9a39433d074b307ba90eeb443927f565b9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd7a29c4a447b36c71e0db03b5110d105941122f03a8424268aad65bcf14bc197c6f479c26a38668bb8192ee2411a7ff', 16),
+                    gmp_init('0xf3f1e00a07b1df0730f66367eef60317b665fae15440c3c20285973a3cfa860321b9592d61675125307ee5b8dd5f174d', 16),
+                    gmp_init('0x86bfcb43afc01f8f3678dba8dfa3b481f0c7330594d9828ce7b61bca428fba19d55c33221fe203e57c94e337da926692', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x496556690cf06c790abff7015f2a18c9cc117f55a1f5f9c8f395cbc679fd354282a3282a33a551344d4fc1c533a64d00', 16),
+                    gmp_init('0xbac37f0dda6a86259e1ba122df067fe937a25d405559adac3cbe730c0a343b2b79968e2890c7794600a84b81f08358d6', 16),
+                    gmp_init('0x872ea9294883c2d1f76e51c15102e4d10b55d5e6ecf9807b834c027aec610c15bb32fabdddc93943c22eb0e8bbe86e69', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe2b0e31b76840d04eeb99aa1256b57ab0cb2ea5d27e5a387d4b420652f1ea842005909ad3fa85578cc84e5272ed38249', 16),
+                    gmp_init('0x10b89634c1333bf81bceca24778aadbcd322f204f0f51584ddef6ea6d195e313283f7840e2061cf19bd7fdfb1ce099b6', 16),
+                    gmp_init('0x15950ccd1c8ffde9eae671fee5f677772809cf3c77649c9a4a75dcb7e996bda8f8945d91ebb617c422c7f5419e721353', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x7bb45b0d0c2766c7b1006cc3ed1e962de1157de171baaafc5eb0791533d0351677418245336e1b63001e6481fffc1b5', 16),
+                    gmp_init('0x7747410a5d8e2b6bd25e22344ede5373653ccc9005da91dcf0a36d05a83c4b58cdcf0bda7a750861495a31214ebfdbea', 16),
+                    gmp_init('0x5d7ddac136400ec71e9996719b68b4d47f4a2a668452ee4adc0ddd1b3d0ee2bc780e9f77a0120975ec69d8de828351f5', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe5727fc5c7094eac295a1e3871e9a62e65189835a4abcae9086a7005d01184c3c528d1cac5b8e50f3dfd5c341d0fda43', 16),
+                    gmp_init('0xa33220afcd2bf577caa3a8271e72c33d9253cef3a7cd69f3141375826f756e0cf1087086a7f293ec62f485cfb6d2decf', 16),
+                    gmp_init('0x3083d69f6107c529744f81de5b3cf0b7ecf45ae10c5eb34d119660fed59a0971d166028d7a3be47d126a8f2e455d0d11', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2065d95997cb828cd402426629d7a9e2b5c8e008bacdcbe9e3d3b513fa7fa747479de2bf1291b463614f76f76e1e21bd', 16),
+                    gmp_init('0xfd076f6f8d3a600150f7fa9f43f9896a5670b3116e4a91a675755177ebf168f01af5b0b998d6fdc7f6968719310b2140', 16),
+                    gmp_init('0xb74772108450d4addb8c21cc75429cbcd3e59ac0cd70a32ffd8d52123fd22c9de90d29f827697f41682a4b2a00e262b1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xec21d043a6148245e7326bc1bb733e5e9e8fc2acd9c845e07d828d199b6371d20e2fe9cd69518a7cf3c63a9f7e8b9a04', 16),
+                    gmp_init('0x3a2535d82d7f2dd30b63a88bb951374bc6445242949f3c5084495f541294533ff4ffade9e6bbc9c6484a506980f186e4', 16),
+                    gmp_init('0x3933a30c2715508395a4ee895ae294204d87f01c1c89f4fa11f4b7a3b78ec0da7462b772bef6ad745354112c61bc665f', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xbf5d2c9f800bb741c25740f6dbbe9e9231fa7f03e886df96e00f1b8b762086bb6961c104e7aa68809b64ead65f9a1655', 16),
+                    gmp_init('0x1be1d18ebaa2008372d5beb7c4f0467fdb37e8c564e66ddc31531eae0a7939aa53556ec46d9b7e4959329b4cd68bfd99', 16),
+                    gmp_init('0x43e3c7ec293acc051295a7e2c8f07b6f98ee322ded78c726e788840d6695ef0f376f4e00091311ed549a9140c30540e', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xa13cea61bcf18a7f488e91546eb72cff0678dc889d8ab0ee3c9978d5963716cf57b7d2ecd4082b02c1a90f635d6feac5', 16),
+                    gmp_init('0x667e1cc64ffeabede48771a9f968fd4f5f9f6f7035e52d9b8c34dc7ceae4e3d3214e05175eb42df6ed822445adf36fa4', 16),
+                    gmp_init('0x482141c662348750b187587631ee00102d67aa876c1567ec43664f11d6a2fad8f787d2d1d507b385133520bae97b2652', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9517216e933988b688c1f8073627c9f6c74dce3f13a7bebdbb16a552aaf495d08b6bc29a0f9416fe8a0e6117a40c5b86', 16),
+                    gmp_init('0xf70b8b9ea61f12490bb587325472ba0552571e5734e99b0e46929a81563b4a27adad605f6b0b4df2e91ceea8a15f463', 16),
+                    gmp_init('0x78682a1e57d0695460a057132d63dd6da2311b8b00ed90a5c212ee6100d5928a4f299b415ba2b4d7ae2b966763ee95bd', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xadba857835f7213de454167bf30da3b64eb05e077617dde56792ad0352602010ba735d3741ec9abf87fa438f469430d4', 16),
+                    gmp_init('0x6968bbdfe4f7262aae1fbd492106f32dcc259d4b06eecbb8afae00528207d3b0fa1158ffae07787fd4a24b63ca5644a5', 16),
+                    gmp_init('0x2cd93fa076e525ddf4311be506be43aca40ac03e57c1338b959a0828f5c6488eab8e32648919a58bae74712b85e85380', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1cffeef0d5d948c801a905b2e28002747a88293197686b0a8030fc449ea225c8fbaadcfc550707352640e00a4bef6a1a', 16),
+                    gmp_init('0x4016a2044239b75897e443cc592153c0fe7167eca603adc94671f69e79cfa2e9390d1aa402c80fc1d98dc5e73b417c2', 16),
+                    gmp_init('0x862e0e9908b3ceb135bf596323ea6c7ef2508e3f217509fc88616a79698bab2e09348d5440a0635177dfe2ca8e83c749', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9fec43385b7618809ffcad3c986558da54d5cb8cb98607cbb31febca32930483c92ab5c276dfa3832b89ea883389724', 16),
+                    gmp_init('0xbf85453ca5cf3c780d2b4da05d5f2b6b2238b6bf4fe86c534a90156f20306ff93832e123175c834378f2fd4b9015fdef', 16),
+                    gmp_init('0x8cba6c9bbe36078170fe16f25e5ee47ab7bf82ccde8f0c257d9e6d8ab33d8d3a566caa23b9007b309efd26637880eed7', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x81793581a513b51df56d5d379ba1ee9a5105359ded4fa363952c0b2545f7e398527be6aa0122af0f5165a928baf87050', 16),
+                    gmp_init('0x1ac008540edb9fa13de89188ce381adb76f26d2d60df5dae63497d67a2355934441e3d330cebbe35e664625cc31a2034', 16),
+                    gmp_init('0xaf9ec5b2ec2ea7faa48e1e98170addfa11df0e43f95cf2f3cf0310a640db867d977952c34c235caf24278da7b77f4fe1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2b7bf9fc780ad7b71db5048e2f444f9e7998c7ba9744d480e1bb1c3e731a663e567eb62045b0ac1934ee9fb59cb5776', 16),
+                    gmp_init('0x42f37dd77231b122df442875c89f70a33dc4232f30d4088720856d53f0a99f885aa32d1e00257635b097498a1ab65a2', 16),
+                    gmp_init('0xe13211973bc29b0227bd205e7a83074b76e1a321709f023d484e02c0baa52e8263a2db3310fcff20d0178580a8aac694', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x57fad0168ae5b3b199e9e6e947005a1ed65a1ae3685bd25a8d9bec5714dc89d5f1b7e832f1290b2b172e105195af4df0', 16),
+                    gmp_init('0xb2db990aac25a2aacd0edaad4cdf53e27ad729d6946991cacb0ea65fc127f943338455f481da1d0849fda555c3191d7d', 16),
+                    gmp_init('0x2127e6040371e2782116b4c7c92dbdf4765b70bdb3ec7b831479d5308d8896f1f40c857d300c264894c92a0596f4c0e3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe5e5008ddba7af7a012fd51f5ad36eddde87717546c8824f1c717424ad91a4cb5b35ba487e2fa8bbcb9a1f5058706e9c', 16),
+                    gmp_init('0x858b639d07a3f4bd3ae69738321eac23a44e949775273e2e6a6c6f110380c7ecb26aca39cd6bf92047a0a6b69390ca73', 16),
+                    gmp_init('0xd88312af49d6ccc8d0cdbd9ad91f7371551c7905218d207e59f805f8e70af21c6bb074303f5d3fcc40c27a7b093439f3', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd3d7cdb3c7621788ea2743298829552e66614c09a80ec664ba09abb8a3dd05cd0184e2a8cb69bec1b58f91caf51ae782', 16),
+                    gmp_init('0x40fb6c1dc46dbf484bb603eca2c94cdd678e09284465eb191448e0d9eec8e04f2197b08c8ca1992ca49bfa234799fba8', 16),
+                    gmp_init('0x3347ce9dbe5ac0da4a26d974ee1ade29d1c7753995f458109ee9fb3dac0331126408a55da9218d9cdeee9ab07a829f87', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6da1a88bb84ee9d9f669f5def5d03eb53eee3535b4bd14d3478eb8383469a5a5e6535281e59ead7d38787d9b64c5a54d', 16),
+                    gmp_init('0xa8e18320a8fd32a70b18d5e288c58c9204c8d5b39d81ea24e16c665d40b393aae8a13fdee848f0efa9484cd04e13a762', 16),
+                    gmp_init('0xaff39bbb77483fd729be306b638e5a24d7e1a394dd05ab066ca3d8b817c61b1331511dadd0d50de74f4dc539ae60f616', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x15d0add3cccbad8ba144921daacee70e0392c474cf83b8f027a9f0351b3e9a45ccac4b9f1d57b2964e3b5f2d425c6c95', 16),
+                    gmp_init('0xc2b739e5855d8be9624006d8b0cc8970c87075e959db88b7b5d915dbf4b0c47839e527878d34b5ee914c755e7009064c', 16),
+                    gmp_init('0x605b3861d29bf2967b5bc88fa8ecbf77455cc8121172b5677e2faece04e5d4ccca5a6a06713e76e1c22e7bcf4c3f3a05', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x42d61a74295bfc2cc01795714eba3910b1fdb93dba52e3e9cf3f9ae324239e3d5c90b5ea7742b0672544221051b262d5', 16),
+                    gmp_init('0x27673c79c3ceeb061dd602ea758fd4748eb2851152ccd572675342b7ab05530bc111aa0a02be37871f6ca27a711168a0', 16),
+                    gmp_init('0x3e951d5ff7a5905901371bf0f182a556bcddd74e1884fe3ec09a8dc59a0ae87a0e4f01206e5722c6d53ef53985960ddc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x9d1bf1a4431d082155f1fdb15bf3746bcec1e9b41f3bd4d40af7a36d286d7e8a04551d743293564c4fca664574e4890', 16),
+                    gmp_init('0xcd6afaa2518b4cee7b6cad7ab3f8a5421966a0310d04b5a59975196f0950088a74284371f8f3d02b0adc25c0ac031176', 16),
+                    gmp_init('0x12c02ce40449b2820165ca2c67e94d6e21acfeaa90dd71c25e9ac26af987fc0a311a389d8bd9b3d4275cf0119069e203', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x3fc304cf2b603e680c6def68895f9b41d9df1896b806f29aa3dd3dc21717f92874ce836b0d929d7f062c8e86bc1dc67d', 16),
+                    gmp_init('0x7b94e1b057e25e573767f2b0b5a9f080626da145a9901a83ac20b1be7e1f127007497e47f12d9077a9c4a74898b71ab3', 16),
+                    gmp_init('0x1e6598fe562e0c0e19fe46a6c460448f5882345ef5ccdf53c540d2e2925171407dffaf43426d91b6f402911b0a4c3dc1', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x713aef9205197d80bae496f5af803b1bb8ead033036799b756fdf6687de77ce646409e7afc0a93fb37e6f8c1e381bdd2', 16),
+                    gmp_init('0xe4771401527daf6cce3e5a86aa9ea5bbe3349fd2aa7e2fc5e2729faf94cc8674a3d49fe1119a3d1c7020b83dc3f5a517', 16),
+                    gmp_init('0xf26bdcb03237da4676c11df3b5a67fa2d3434bc75b380d8cdf0c96155dcf36814de962c9b444445a9ea37536e2aa3c65', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x719a6d842298b99a1800dfda3e9117701900c14f93bd200b8b48b580aabc2276b347953c6b50240cb2483d1519b8bb56', 16),
+                    gmp_init('0x8461f59d3f0fe8228676770ffb5d531173ceef22b5cfd0408f53d76ab38a467a2070ed925a24fc5e767563c76c2ca5f6', 16),
+                    gmp_init('0xb45b2a6c87eb2b1c0356a520a57fc3f206f1eeded4ffab1383b09e7ff8b94217dba1e5e5ae99c84928a65c017cb40365', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xd66c1f50063a672e934f0cfa5b41bab95bc2afb34059ad94e8fcd529f991e656ce10e99d39715317aa1b4e7af47d22d6', 16),
+                    gmp_init('0x59702f2f8b0fbc8deea713321db72b945db794933818f1cf60130e7b6fe8a51e34eb4ccefa463c90baeafba7561b36c6', 16),
+                    gmp_init('0x1c9869678e760750e73cca52c388296cc8bc52b06ff971238362415e11c91f30092be22d8fbba31d3842976ee0039fb6', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6d33b0dbfdc1707ccab9e49450ad03b52e97f8741b8b265db4860b45a84781a047ca9a54952a244f5d5d00ba523f5b92', 16),
+                    gmp_init('0xb3427d43ea9500ab12aad67e7e964d5b94a47316fe65c0db4b8b2249b849b4011a1cb34a4352c8eb2b37e04b70b276ba', 16),
+                    gmp_init('0x9539a788062a100aa9ea1941976a1b6fddb86f70b0521dffbb26e5c527761dba706a811df14689a78e7ec4a8ec0164eb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8ec0d224eaa4f72143c448d869ed2a40420c8ae8f852b1d651e597196de0ea1dfc93fc84bd8f11105aea9363da032590', 16),
+                    gmp_init('0xdf42b4374a30ca0e3eb32b4cc0886837dad0d8a4f15b6b0777c076dca5d95e63df2d3c410c6256bc2d0e45c439de61fe', 16),
+                    gmp_init('0x1ebd1e2bc6c8279c2ccb2f10f6e82f76278e9a8a66281c588844e94ee14485172b94d9b46f0cbca85fb21e8dc8aa60d0', 16)
+                ),
+            ],
+            [
+                JacobiPoint::init(
+                    gmp_init('0x543b3e4d85d719a9abed68985911fa8fda7e8dfc1fff910dba419467b9a97e8f4d2da590aec202d99f44c6f15cc11fde', 16),
+                    gmp_init('0x554ed4a230f7c575d3fb062e681289e782e926a1316271bf8d416b3eacb07790512c76acc8f7e8b73a644b70aae04fc3', 16),
+                    gmp_init('0x488c701fc3f2cbb58203663c2c20c54a58ad26399bae2783f33c499a22092b25e6749f9a4dcd178db4091ea41c785389', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb040a081fe77e33752ff4674bbc1b83c5e6ce86f8ca056aeb333ae0067bdbc74c4db2601b01b1804e75e9b36c75f9d3e', 16),
+                    gmp_init('0x440cbfd0568647d5047bb00e2adf089ebe7900f2168b18c972d0ebb23825c952fe55e0efb6efddc14b3a922c569a8', 16),
+                    gmp_init('0x2cebd4ce1b81dfea8f75b28bcb465123c614c2a0cd41ffc35d826be895d546b450e90b30ca42816d5455f0e5ea7a5323', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x6eb904766b0d6161469ee3e951423f191b42984f5327d2494d4973d80d7fc9aacc67ec9e5ac538068ae79ca8083856dc', 16),
+                    gmp_init('0xc8763a1f2ed4a778d7e21ef86efbc09b1d1c8fbc2b36b2300e63ffc01e9196cea6e421e40a9b473f91461c07be1e8a14', 16),
+                    gmp_init('0xafdedae6da1cfa83b450e17e21af0ee5475ddbd0546cfb1fcb1557b789e4a476aeebad07d8966cc10dae43b04a7b0887', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe0817ce702a4507a2dfc9b602748a6fbbbddb1c6fb88b4881ae78b645b204b93602ea65680611e0ded708a1b1e3c2f94', 16),
+                    gmp_init('0x15ed8114f5805398364eda0e306e835b8a2085c3c0cc7a6f1c294c2407c4b81b22b1dea68b163a96e9acdc3e553530bb', 16),
+                    gmp_init('0xb4d03df08c0abb338e64528196bcc23bf39c8d953f99c4f467e6fe212757620b8be37db5c3cf54cf8692f2250f318d27', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x16da3e0ac9727ec6979505b8fe6c85394683c8a8ec3a0c1b63c947be777e90c756ba40c11c8ca8a6c63cb9574cc7830a', 16),
+                    gmp_init('0xd6a77ff879b95877d64ac6843849f6a26ebe535e13335e1991d22cab742490a25d646e6a0f07211d6c48abed6e1683b1', 16),
+                    gmp_init('0x33f5785db778f649b5cf3c934645f6563f9f6ea605e8aa186fdfb79954989a5400faac193a0bde5c2b5defc328441bcb', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xb4babba96805bbcda8ddd8f811c201e45ceddaffbb4fa698746508924f25feda423d603cff0cb7f7a7cc5f2f1212a9d', 16),
+                    gmp_init('0x7d736d1ff6f4cabcf6edcd302f5bdc72d4f25877f672bca42de450cc767aeade0979e624ec7142d20caff1aa1f06842e', 16),
+                    gmp_init('0x958cca22edb5a6da76d594036c0f8d443acccc3a62365822278b708d7e26302cc87ea52cd3d74d23bfb15f2faaa4ee1b', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xe8de544dbed11ccef0f2a1010ba57bacf24283c9179dfe86e3d0506a38572d75466d0acd43db41cab979b235b3ec901a', 16),
+                    gmp_init('0x2f59f3a1b70135f4da6d2b996d0ecf11255f5fad629786c1d93b2b0ff28e5ba1f940f09b02f05ac5f830fc5c26260dd8', 16),
+                    gmp_init('0xeac057935d520d378078a972ea466b1081b001e9f3105c783a72570e59f364d3af09c06fe0637277e47fbdf949035cbc', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x872a02b1228b387d5a279cc651d2a00e0d0120e7ec3287fe110a247ec27060d65a96839d2103d0428df54dac4455b965', 16),
+                    gmp_init('0xb43ce717c52ea6c1b5e9b3609ed0952792479dbefc285164f950391d04d79f15abb31b504d740bff3b1aa6d03a61e990', 16),
+                    gmp_init('0xec17e1c32e70807e8598e13df6402ebb1cb1c99b4b5fdcf78327d61e7df85237e0cff5bbd55edc3c1b5039cd4e14ad87', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x49efb2114e355187d1536241c62d6e68b4602820e9c3aa1e51910a453d1d5fd31b76086a01feda2aecd67d11f5f6f039', 16),
+                    gmp_init('0x1c825d895cc0f6d4b09187817331b69976f0ba79543e86eb0b152612a788ad1a8e52cb54a3f7f95d7a37ba612c24bbb', 16),
+                    gmp_init('0xb1a25e206c79dc1591d2acaa394a8e9188575ce6a0a1cfe6dc7f6b48fbb4f536aa725c4b8be765d8a4d98d0dc8ff66b4', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x1e7f3e1752013821ddbbe9bd501f315c05b3cb031dbb30d7e86214df627c2508c32a77bf79737d1e147aaba6c95b24e0', 16),
+                    gmp_init('0x4f9c75e721522c42ccb769cb592f6c4f3d939de7cf402272e25fb8205a0386f59583f7595f86717331936abbb584720f', 16),
+                    gmp_init('0x5ac17e0031dfee639e30cab2bbee4e09fcfee16b0b88832f49da4c51723ada5b9688478fbb73be28e1f3deec62a2dab', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xc726075973b40effc763d2243505c02a0e80e1c914424b4a2455beaa219fb30f7cd051cab69ec13926abe905c28f647e', 16),
+                    gmp_init('0x5c1cafec3941511e6cdc776ae481481be9630b4aca598db60414e2a608604b580f0fdd1c8bf2f335eb84f87c84636962', 16),
+                    gmp_init('0xddabedf5948cc1e5db03b0886141e1ed6a2d6f7dc016a96f3de9f0ea17325c42307a8612b657e45228148764a8e3db63', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x2157ef327c248653abe79299677660e24d25e33586378b59337827c931688c38ea5c54e9ff51a9d7946a1d5afab94ec5', 16),
+                    gmp_init('0x15a91ff79c41bfe2ff817cd881a2e99fd7e2bdfadaf74711dff08c5e5bac1745c77828c1c8cf0b6b1f89f45efb06b975', 16),
+                    gmp_init('0x2edc166e7c26371f2b59918250998b851d41c007e0ea3ebff917140a214c1b50288dd08852d8873d49fee8aa3cd0f902', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0xda8a7f4e87d5f90d1af089e841d5fcbb33befb58a239dbc4b909a2dd3aad3446f17b046ce1df5b0035bb6c26d234f680', 16),
+                    gmp_init('0x930a4763416ff927cddaf5e09c1537b47b7f49cec6b6ca2b22ebd43863d779b9bb4c15fd47417f1b1fe010a1c587bcbb', 16),
+                    gmp_init('0x9cf9971e8a380d02ca6ef1d172eea5abd7e11255bd7cbcc7f88ee24a0821dd9f9226709185e2c03aa7b4d28e91883b03', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x8011210ed492c154c14f6429cc07f9b2758d13e1324fff37389d298c878f6927bcf5d8d08f457eb0530a8330f29ba7de', 16),
+                    gmp_init('0xad2cf1230f16b30b6115e0654d64f2a0b1cf2dcc107ec09e5962a09418766bfa5a15cd18c2470a988d2915887e0829ed', 16),
+                    gmp_init('0x14adde05e853141cb99be0f772c543606098f03ca77be673c37f480ca617ea0da10919381d73972b94215fa7e5fcc9e9', 16)
+                ),
+                JacobiPoint::init(
+                    gmp_init('0x5906e38976552f64951356764f5dec1bcb8b38944f256de8014af5e129e55157b297cd782fc6f5aa6bf62c8a335e5fcb', 16),
+                    gmp_init('0x61f5ba55c0cd2d8aaa957a2b3bc997b0f532e26764d609df9aa31df7bad79ba538457137a7368f817276b1320c2cea2f', 16),
+                    gmp_init('0x9c8cbb075e2d0f186384e8cb2020d3d715d55176b56ad7466289b22dd2f733da4c996c44cbee2975895a835e494c85bd', 16)
+                ),
+            ],
+        ];
+    }
+}

--- a/src/Primitives/OptimizedCurveInterface.php
+++ b/src/Primitives/OptimizedCurveInterface.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Primitives;
+
+use Mdanter\Ecc\Optimized\OptimizedCurveOpsInterface;
+
+/**
+ * This refers to an elliptic curve for which we provide an optimized,
+ * constant-time optimization for its operations.
+ *
+ */
+interface OptimizedCurveInterface
+{
+    public function setOptimizedCurveOps(OptimizedCurveOpsInterface $ops): self;
+    public function getOptimizedCurveOps(): OptimizedCurveOpsInterface;
+}

--- a/src/Primitives/Point.php
+++ b/src/Primitives/Point.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Mdanter\Ecc\Primitives;
 
 use GMP;
+use Mdanter\Ecc\Curves\OptimizedCurveFp;
 use Mdanter\Ecc\Exception\PointException;
 use Mdanter\Ecc\Exception\PointNotOnCurveException;
 use Mdanter\Ecc\Math\ConstantTimeMath;
@@ -188,6 +189,10 @@ class Point implements PointInterface
     {
         if (! $this->curve->equals($addend->getCurve())) {
             throw new \RuntimeException("The Elliptic Curves do not match.");
+        }
+        if ($this->curve instanceof OptimizedCurveFp) {
+            $ops = $this->curve->getOptimizedCurveOps();
+            return $ops->addPoints($this, $addend);
         }
 
         if ($addend->isInfinity()) {
@@ -384,6 +389,10 @@ class Point implements PointInterface
      */
     public function getDouble(): PointInterface
     {
+        if ($this->curve instanceof OptimizedCurveFp) {
+            $ops = $this->curve->getOptimizedCurveOps();
+            return $ops->doublePoint($this);
+        }
         if ($this->isInfinity()) {
             return $this->curve->getInfinity();
         }

--- a/src/Primitives/Point.php
+++ b/src/Primitives/Point.php
@@ -190,10 +190,6 @@ class Point implements PointInterface
         if (! $this->curve->equals($addend->getCurve())) {
             throw new \RuntimeException("The Elliptic Curves do not match.");
         }
-        if ($this->curve instanceof OptimizedCurveFp) {
-            $ops = $this->curve->getOptimizedCurveOps();
-            return $ops->addPoints($this, $addend);
-        }
 
         if ($addend->isInfinity()) {
             return clone $this;
@@ -389,10 +385,6 @@ class Point implements PointInterface
      */
     public function getDouble(): PointInterface
     {
-        if ($this->curve instanceof OptimizedCurveFp) {
-            $ops = $this->curve->getOptimizedCurveOps();
-            return $ops->doublePoint($this);
-        }
         if ($this->isInfinity()) {
             return $this->curve->getInfinity();
         }

--- a/tests/unit/AbstractTestCase.php
+++ b/tests/unit/AbstractTestCase.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace Mdanter\Ecc\Tests;
 
+use GMP;
 use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Math\GmpMath;
 use Mdanter\Ecc\Math\GmpMathInterface;
@@ -11,11 +12,25 @@ use PHPUnit\Framework\TestCase;
 
 abstract class AbstractTestCase extends TestCase
 {
+    public function assertGMPSame(GMP $a, GMP $b, string $comment = ''): void
+    {
+        $str_a = gmp_strval($a, 16);
+        $str_b = gmp_strval($b, 16);
+        $this->assertSame($str_a, $str_b, $comment);
+    }
+
+    public function assertGMPNotSame(GMP $a, GMP $b, string $comment = ''): void
+    {
+        $str_a = gmp_strval($a, 16);
+        $str_b = gmp_strval($b, 16);
+        $this->assertNotSame($str_a, $str_b, $comment);
+    }
+
     /**
-     * @param array $extra
+     * @param ?array $extra
      * @return array
      */
-    protected function _getAdapters(array $extra = null)
+    protected function _getAdapters(?array $extra = null): array
     {
         if (! defined('PHPUNIT_DEBUG')) {
             define('PHPUNIT_DEBUG', false);

--- a/tests/unit/Optimized/InteropTest.php
+++ b/tests/unit/Optimized/InteropTest.php
@@ -1,0 +1,101 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Tests\Optimized;
+
+use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Curves\OptimizedCurveFp;
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Math\GmpMath;
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Random\RandomGeneratorFactory;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+
+class InteropTest extends AbstractTestCase
+{
+
+    /**
+     * @dataProvider getAdapters
+     *
+     * @param GmpMathInterface $adapter
+     * @return void
+     * @throws \Exception
+     */
+    public function testP256Interop(GmpMathInterface $adapter)
+    {
+        $nistFactory = EccFactory::getNistCurves($adapter);
+        $signer = new Signer($adapter);
+
+        $p256Old = $nistFactory->generator256(null, false);
+        $p256New = $nistFactory->generator256(null, true);
+        $this->assertNotInstanceOf(OptimizedCurveFp::class, $p256Old->getCurve());
+        $this->assertInstanceOf(OptimizedCurveFp::class, $p256New->getCurve());
+
+        $secret = gmp_init(bin2hex(random_bytes(32)), 16);
+
+        $oldSK = $p256Old->getPrivateKeyFrom($secret);
+        $newSK = $p256New->getPrivateKeyFrom($secret);
+
+
+        $pk1 = $oldSK->getPublicKey();
+        $pk2 = $newSK->getPublicKey();
+        $this->assertGMPSame($pk1->getPoint()->getX(), $pk2->getPoint()->getX(), 'X');
+        $this->assertGMPSame($pk1->getPoint()->getY(), $pk2->getPoint()->getY(), 'Y');
+
+        $randomK = RandomGeneratorFactory::getRandomGenerator()->generate($oldSK->getPoint()->getOrder());
+        $message = RandomGeneratorFactory::getRandomGenerator()->generate($oldSK->getPoint()->getOrder());
+
+        $sig1 = $signer->sign($oldSK, $message, $randomK);
+        $sig2 = $signer->sign($newSK, $message, $randomK);
+
+        $this->assertGMPSame($sig1->getR(), $sig2->getR(), 'R');
+        $this->assertGMPSame($sig1->getS(), $sig2->getS(), 'S');
+
+        $this->assertTrue($signer->verify($pk1, $sig1, $message));
+        $this->assertTrue($signer->verify($pk2, $sig1, $message));
+        $this->assertTrue($signer->verify($pk1, $sig2, $message));
+        $this->assertTrue($signer->verify($pk2, $sig2, $message));
+    }
+
+    /**
+     * @dataProvider getAdapters
+     *
+     * @param GmpMathInterface $adapter
+     * @return void
+     * @throws \Exception
+     */
+    public function testP384Interop(GmpMathInterface $adapter)
+    {
+        $nistFactory = EccFactory::getNistCurves($adapter);
+        $signer = new Signer($adapter);
+
+        $p384Old = $nistFactory->generator384(null, false);
+        $p384New = $nistFactory->generator384(null, true);
+        $this->assertNotInstanceOf(OptimizedCurveFp::class, $p384Old->getCurve());
+        $this->assertInstanceOf(OptimizedCurveFp::class, $p384New->getCurve());
+
+        $secret = gmp_init(bin2hex(random_bytes(32)), 16);
+
+        $oldSK = $p384Old->getPrivateKeyFrom($secret);
+        $newSK = $p384New->getPrivateKeyFrom($secret);
+
+
+        $pk1 = $oldSK->getPublicKey();
+        $pk2 = $newSK->getPublicKey();
+        $this->assertGMPSame($pk1->getPoint()->getX(), $pk2->getPoint()->getX(), 'X');
+        $this->assertGMPSame($pk1->getPoint()->getY(), $pk2->getPoint()->getY(), 'Y');
+
+        $randomK = RandomGeneratorFactory::getRandomGenerator()->generate($oldSK->getPoint()->getOrder());
+        $message = RandomGeneratorFactory::getRandomGenerator()->generate($oldSK->getPoint()->getOrder());
+
+        $sig1 = $signer->sign($oldSK, $message, $randomK);
+        $sig2 = $signer->sign($newSK, $message, $randomK);
+
+        $this->assertGMPSame($sig1->getR(), $sig2->getR(), 'R');
+        $this->assertGMPSame($sig1->getS(), $sig2->getS(), 'S');
+
+        $this->assertTrue($signer->verify($pk1, $sig1, $message));
+        $this->assertTrue($signer->verify($pk2, $sig1, $message));
+        $this->assertTrue($signer->verify($pk1, $sig2, $message));
+        $this->assertTrue($signer->verify($pk2, $sig2, $message));
+    }
+}

--- a/tests/unit/Optimized/P256Test.php
+++ b/tests/unit/Optimized/P256Test.php
@@ -77,14 +77,6 @@ class P256Test extends AbstractTestCase
         $this->assertGMPSame($g2->x, $dbl->x, 'x differs (g+g vs 2g)');
         $this->assertGMPSame($g2->y, $dbl->y, 'y differs (g+g vs 2g)');
 
-        /*
-        $expectX = gmp_init('0x2e266b2f20e364762d87ade1cf5657d3f10d2d48a235a9aa74b00bf91aeb7e16', 16);
-        $expectY = gmp_init('0x881f89d798da41a6abbcea4c3023a314225f973c2c9672a3e874649cf6a67d8e', 16);
-
-        $this->assertGMPSame($expectX, $dbl->x, 'x differs');
-        $this->assertGMPSame($expectY, $dbl->y, 'y differs');
-        */
-
         $affine = $dbl;
 
         $expectX = gmp_init('0x7cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978', 16);

--- a/tests/unit/Optimized/P256Test.php
+++ b/tests/unit/Optimized/P256Test.php
@@ -1,0 +1,344 @@
+<?php
+declare(strict_types=1);
+
+namespace Mdanter\Ecc\Tests\Optimized;
+
+use GMP;
+use Mdanter\Ecc\Curves\CurveFactory;
+use Mdanter\Ecc\Curves\NistCurve;
+use Mdanter\Ecc\Math\ConstantTimeMath;
+use Mdanter\Ecc\Optimized\Common\JacobiPoint;
+use Mdanter\Ecc\Optimized\P256;
+use Mdanter\Ecc\Primitives\Point;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+
+class P256Test extends AbstractTestCase
+{
+    /** @var P256 $p256 */
+    private $p256;
+
+    /** @var GMP $prime */
+    private $prime;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->p256 = new P256();
+        $this->prime = gmp_init('0xffffffff00000001000000000000000000000000ffffffffffffffffffffffff', 16);
+        $this->order = gmp_init('0xffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551', 16);
+    }
+
+    public function testAddPoint(): void
+    {
+        $p1 = $this->getGenerator();
+        $p2 = new JacobiPoint();
+        $p2->x = gmp_init('0x7cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978', 16);
+        $p2->y = gmp_init('0x7775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d1', 16);;
+        $p2->z = gmp_init(1);
+        $added = $this->p256->addInternal($p1, $p2);
+        $affine = $this->p256->jacobiToAffine($added);
+
+        $expectX = gmp_init('0x5ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c', 16);
+        $expectY = gmp_init('0x8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d5032', 16);
+
+        $this->assertGMPSame($expectX, $affine->x, 'x differs');
+        $this->assertGMPSame($expectY, $affine->y, 'y differs');
+    }
+
+    private function getGenerator(): JacobiPoint
+    {
+        $p = new JacobiPoint();
+        /** @var GMP $x */
+        $x = gmp_init('0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296', 16);
+        /** @var GMP $y */
+        $y = gmp_init('0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5', 16);
+        /** @var GMP $z */
+        $z = gmp_init(1);
+
+        $p->x = $x;
+        $p->y = $y;
+        $p->z = $z;
+        return $p;
+    }
+
+    public function testDoublePoint(): void
+    {
+        $g = $this->getGenerator();
+        $g2 = $this->p256->addInternal(clone $g, clone $g);
+        $dbl = $this->p256->doubleInternal($g);
+
+        $this->assertGMPSame($g2->x, $dbl->x, 'x differs (g+g vs 2g)');
+        $this->assertGMPSame($g2->y, $dbl->y, 'y differs (g+g vs 2g)');
+        $this->assertGMPSame($g2->z, $dbl->z, 'z differs (g+g vs 2g)');
+
+        $g2 = $this->p256->jacobiToAffine($g2);
+        $dbl = $this->p256->jacobiToAffine($dbl);
+
+        $this->assertGMPSame($g2->x, $dbl->x, 'x differs (g+g vs 2g)');
+        $this->assertGMPSame($g2->y, $dbl->y, 'y differs (g+g vs 2g)');
+
+        /*
+        $expectX = gmp_init('0x2e266b2f20e364762d87ade1cf5657d3f10d2d48a235a9aa74b00bf91aeb7e16', 16);
+        $expectY = gmp_init('0x881f89d798da41a6abbcea4c3023a314225f973c2c9672a3e874649cf6a67d8e', 16);
+
+        $this->assertGMPSame($expectX, $dbl->x, 'x differs');
+        $this->assertGMPSame($expectY, $dbl->y, 'y differs');
+        */
+
+        $affine = $dbl;
+
+        $expectX = gmp_init('0x7cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978', 16);
+        $expectY = gmp_init('0x07775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d1', 16);
+
+        $this->assertGMPSame($expectX, $affine->x, 'x differs');
+        $this->assertGMPSame($expectY, $affine->y, 'y differs');
+    }
+
+
+    /**
+     * @dataProvider jacobiToAffineProvider
+     * @return void
+     */
+    public function testJacobiToAffine(
+        GMP $inX,
+        GMP $inY,
+        GMP $inZ,
+        GMP $expectX,
+        GMP $expectY
+    ): void {
+        $in = new JacobiPoint();
+        $in->x = clone $inX;
+        $in->y = clone $inY;
+        $in->z = clone $inZ;
+
+        $affine = $this->p256->jacobiToAffine($in);
+        $this->assertGMPSame($expectX, $affine->x, 'x differs');
+        $this->assertGMPSame($expectY, $affine->y, 'y differs');
+    }
+
+    /**
+     * @dataProvider scalarMultBaseProvider
+     */
+    public function testScalarMultBase(GMP $scalar, GMP $expectX, GMP $expectY): void
+    {
+        $point = $this->p256->scalarMultBase($scalar);
+
+        $this->assertGMPSame($expectX, $point->getX());
+        $this->assertGMPSame($expectY, $point->getY());
+    }
+
+    /**
+     * @dataProvider scalarMultProvider
+     */
+    public function testScalarMult(GMP $k, GMP $xIn, GMP $yIn, GMP $xOut, GMP $yOut): void
+    {
+        $curve = CurveFactory::getCurveByName(NistCurve::NAME_P256);
+        $point = new Point(
+            new ConstantTimeMath(),
+            $curve,
+            $xIn,
+            $yIn,
+            clone $this->order
+        );
+
+        $out = $this->p256->scalarMult($k, $point);
+        $this->assertGMPSame($xOut, $out->getX());
+        $this->assertGMPSame($yOut, $out->getY());
+    }
+
+    /**
+     * @dataProvider addProvider
+     */
+    public function testAddElements(GMP $e, GMP $f): void
+    {
+        $x1 = gmp_mod(gmp_add($e, $f), $this->prime);
+        $x2 = $this->p256->addElements($e, $f, true);
+
+        // Ensure we get what we expect:
+        $this->assertGMPSame($x1, $x2);
+    }
+
+    /**
+     * @dataProvider mulProvider
+     */
+    public function testMulElements(GMP $a, GMP $b): void
+    {
+        $c = gmp_mod($a * $b, $this->prime);
+        $d = $this->p256->mulElements($a, $b);
+        $this->assertGMPSame($c, $d);
+    }
+
+    /**
+     * @dataProvider subProvider
+     */
+    public function testSubElements(GMP $e, GMP $f): void
+    {
+        $x1 = gmp_mod(gmp_sub($e, $f), $this->prime);
+        $y1 = gmp_mod(gmp_sub($f, $e), $this->prime);
+        $x2 = $this->p256->subElements($e, $f);
+        $y2 = $this->p256->subElements($f, $e);
+
+        // Ensure we get what we expect:
+        $this->assertGMPSame($x1, $x2);
+        $this->assertGMPSame($y1, $y2);
+
+        // Catch false positives and arithmetic errors:
+        $this->assertGMPNotSame($x1, $y1);
+        $this->assertGMPNotSame($x2, $y2);
+        $this->assertGMPNotSame($x1, $y2);
+        $this->assertGMPNotSame($x2, $y1);
+    }
+
+    public function addProvider(): array
+    {
+        if (!isset($this->prime)) $this->setUp();
+        return [
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_sub($this->prime, gmp_init(1, 10))
+            ],
+            [
+                gmp_sub($this->prime, gmp_init(1, 10)),
+                gmp_sub($this->prime, gmp_init(1, 10)),
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_init(bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                gmp_init(bin2hex(random_bytes(16)), 16),
+                gmp_init(bin2hex(random_bytes(16)), 16)
+            ],
+        ];
+    }
+
+    public function mulProvider(): array
+    {
+        if (!isset($this->prime)) $this->setUp();
+        return [
+            [
+                gmp_init(333, 10),
+                gmp_init(2024, 10),
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_init(bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                $this->prime - gmp_init(3, 10),
+                gmp_init(5, 10)
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                $this->prime - gmp_init(random_int(1, 100000))
+            ],
+            [
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                $this->prime - gmp_init(random_int(100, 100000)),
+                $this->prime - gmp_init(random_int(100, 100000))
+            ],
+            [
+                gmp_init(bin2hex(random_bytes(16)), 16),
+                gmp_init(bin2hex(random_bytes(16)), 16)
+            ],
+        ];
+    }
+
+    public function subProvider(): array
+    {
+        if (!isset($this->prime)) $this->setUp();
+        return [
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_sub($this->prime, gmp_init(1, 10))
+            ],
+            [
+                gmp_sub($this->prime, gmp_init(1, 10)),
+                gmp_sub($this->prime, gmp_init(2, 10)),
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_init(bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                gmp_init(bin2hex(random_bytes(16)), 16),
+                gmp_init(bin2hex(random_bytes(16)), 16)
+            ],
+        ];
+    }
+
+    public function scalarMultBaseProvider(): array
+    {
+        return [
+            [
+                gmp_init(1),
+                gmp_init('0x6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296', 16),
+                gmp_init('0x4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5', 16)
+            ],
+            [
+                gmp_init(2),
+                gmp_init('0x7cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978', 16),
+                gmp_init('0x07775510db8ed040293d9ac69f7430dbba7dade63ce982299e04b79d227873d1', 16)
+            ],
+            [
+                gmp_init(3),
+                gmp_init('0x5ecbe4d1a6330a44c8f7ef951d4bf165e6c6b721efada985fb41661bc6e7fd6c', 16),
+                gmp_init('0x8734640c4998ff7e374b06ce1a64a2ecd82ab036384fb83d9a79b127a27d5032', 16)
+            ],
+            [
+                gmp_init(4),
+                gmp_init('0xe2534a3532d08fbba02dde659ee62bd0031fe2db785596ef509302446b030852', 16),
+                gmp_init('0xe0f1575a4c633cc719dfee5fda862d764efc96c3f30ee0055c42c23f184ed8c6', 16)
+            ],
+            [
+                gmp_init(1000000),
+                gmp_init('0xc5b222271bc42f0bcfadfe338b7f38062022f3ee82f2d0aa3726cbbd30aedc6c', 16),
+                gmp_init('0x942aef454829994b6c5ee673f19803d289d898107edbce02b65886dd1094dc47', 16)
+            ]
+        ];
+    }
+
+    public function scalarMultProvider(): array
+    {
+        return [
+            [
+                gmp_init("2a265f8bcbdcaf94d58519141e578124cb40d64a501fba9c11847b28965bc737", 16),
+                gmp_init("023819813ac969847059028ea88a1f30dfbcde03fc791d3a252c6b41211882ea", 16),
+                gmp_init("f93e4ae433cc12cf2a43fc0ef26400c0e125508224cdb649380f25479148a4ad", 16),
+                gmp_init("4d4de80f1534850d261075997e3049321a0864082d24a917863366c0724f5ae3", 16),
+                gmp_init("a22d2b7f7818a3563e0f7a76c9bf0921ac55e06e2e4d11795b233824b1db8cc0", 16)
+            ],
+            [
+                gmp_init("313f72ff9fe811bf573176231b286a3bdb6f1b14e05c40146590727a71c3bccd", 16),
+                gmp_init("cc11887b2d66cbae8f4d306627192522932146b42f01d3c6f92bd5c8ba739b06", 16),
+                gmp_init("a2f08a029cd06b46183085bae9248b0ed15b70280c7ef13a457f5af382426031", 16),
+                gmp_init("831c3f6b5f762d2f461901577af41354ac5f228c2591f84f8a6e51e2e3f17991", 16),
+                gmp_init("93f90934cd0ef2c698cc471c60a93524e87ab31ca2412252337f364513e43684", 16)
+            ]
+        ];
+    }
+
+    public function jacobiToAffineProvider(): array
+    {
+        return [
+            [
+                gmp_init("69923961955967387994258645329874512676251231789611885617885350872868369909519"),
+                gmp_init("29468416531536242154810423193772930342200868632530199947817229236472112149969"),
+                gmp_init("72268501913499591597170255839175763913222213345970030143754396507136828810218"),
+                gmp_init('f90eae1c994bded3dc74b5d97fab8ea4784259406f318145f226e3f8db256494', 16),
+                gmp_init('cec9c0d93c1e33ab310781e25dc7d7a53cdc3091a4ee524b901a857be8eba80f', 16)
+            ]
+        ];
+    }
+}

--- a/tests/unit/Optimized/P256Test.php
+++ b/tests/unit/Optimized/P256Test.php
@@ -203,15 +203,15 @@ class P256Test extends AbstractTestCase
             ],
             [
                 gmp_init(random_int(1, 100000), 10),
-                gmp_init(bin2hex(random_bytes(15)), 16)
+                gmp_init(bin2hex(random_bytes(31)), 16)
             ],
             [
-                gmp_init('fe' . bin2hex(random_bytes(15)), 16),
-                gmp_init('fe' . bin2hex(random_bytes(15)), 16)
+                gmp_init('fe' . bin2hex(random_bytes(31)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(31)), 16)
             ],
             [
-                gmp_init(bin2hex(random_bytes(16)), 16),
-                gmp_init(bin2hex(random_bytes(16)), 16)
+                gmp_init(bin2hex(random_bytes(32)), 16),
+                gmp_init(bin2hex(random_bytes(32)), 16)
             ],
         ];
     }
@@ -226,7 +226,7 @@ class P256Test extends AbstractTestCase
             ],
             [
                 gmp_init(random_int(1, 100000), 10),
-                gmp_init(bin2hex(random_bytes(15)), 16)
+                gmp_init(bin2hex(random_bytes(31)), 16)
             ],
             [
                 $this->prime - gmp_init(3, 10),
@@ -237,16 +237,16 @@ class P256Test extends AbstractTestCase
                 $this->prime - gmp_init(random_int(1, 100000))
             ],
             [
-                gmp_init('fe' . bin2hex(random_bytes(15)), 16),
-                gmp_init('fe' . bin2hex(random_bytes(15)), 16)
+                gmp_init('fe' . bin2hex(random_bytes(31)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(31)), 16)
             ],
             [
                 $this->prime - gmp_init(random_int(100, 100000)),
                 $this->prime - gmp_init(random_int(100, 100000))
             ],
             [
-                gmp_init(bin2hex(random_bytes(16)), 16),
-                gmp_init(bin2hex(random_bytes(16)), 16)
+                gmp_init(bin2hex(random_bytes(32)), 16),
+                gmp_init(bin2hex(random_bytes(32)), 16)
             ],
         ];
     }

--- a/tests/unit/Optimized/P384Test.php
+++ b/tests/unit/Optimized/P384Test.php
@@ -1,0 +1,261 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Tests\Optimized;
+
+use GMP;
+use Mdanter\Ecc\Optimized\Common\JacobiPoint;
+use Mdanter\Ecc\Optimized\P384;
+use Mdanter\Ecc\Tests\AbstractTestCase;
+
+class P384Test extends AbstractTestCase
+{
+    /** @var P384 $p384 */
+    private $p384;
+
+    /** @var GMP $prime */
+    private $prime;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->p384 = new P384();
+        $this->prime = gmp_init('0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff', 16);
+        $this->order = gmp_init('0xffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973', 16);
+    }
+
+    /**
+     * @dataProvider addProvider
+     */
+    public function testAddElements(GMP $e, GMP $f): void
+    {
+        $x1 = gmp_mod(gmp_add($e, $f), $this->prime);
+        $x2 = $this->p384->addElements($e, $f, true);
+
+        // Ensure we get what we expect:
+        $this->assertGMPSame($x1, $x2);
+    }
+
+    public function testDoublePoint(): void
+    {
+        $g = $this->getGenerator();
+        $g2 = $this->p384->addInternal(clone $g, clone $g);
+        $dbl = $this->p384->doubleInternal($g);
+
+        $this->assertGMPSame($g2->x, $dbl->x, 'x differs (g+g vs 2g)');
+        $this->assertGMPSame($g2->y, $dbl->y, 'y differs (g+g vs 2g)');
+        $this->assertGMPSame($g2->z, $dbl->z, 'z differs (g+g vs 2g)');
+
+        $g2 = $this->p384->jacobiToAffine($g2);
+        $dbl = $this->p384->jacobiToAffine($dbl);
+
+        $this->assertGMPSame($g2->x, $dbl->x, 'x differs (g+g vs 2g)');
+        $this->assertGMPSame($g2->y, $dbl->y, 'y differs (g+g vs 2g)');
+
+        $affine = $dbl;
+
+        $expectX = gmp_init('0x08D999057BA3D2D969260045C55B97F089025959A6F434D651D207D19FB96E9E4FE0E86EBE0E64F85B96A9C75295DF61', 16);
+        $expectY = gmp_init('0x8E80F1FA5B1B3CEDB7BFE8DFFD6DBA74B275D875BC6CC43E904E505F256AB4255FFD43E94D39E22D61501E700A940E80', 16);
+
+        $this->assertGMPSame($expectX, $affine->x, 'x differs');
+        $this->assertGMPSame($expectY, $affine->y, 'y differs');
+    }
+
+    /**
+     * @dataProvider scalarMultBaseProvider
+     */
+    public function testScalarMultBase(GMP $scalar, GMP $expectX, GMP $expectY): void
+    {
+        $point = $this->p384->scalarMultBase($scalar);
+
+        $this->assertGMPSame($expectX, $point->getX());
+        $this->assertGMPSame($expectY, $point->getY());
+    }
+
+    /**
+     * @dataProvider mulProvider
+     */
+    public function testMulElements(GMP $a, GMP $b): void
+    {
+        $c = gmp_mod($a * $b, $this->prime);
+        $d = $this->p384->mulElements($a, $b);
+        $this->assertGMPSame($c, $d);
+    }
+
+    /**
+     * @dataProvider subProvider
+     */
+    public function testSubElements(GMP $e, GMP $f): void
+    {
+        $x1 = gmp_mod(gmp_sub($e, $f), $this->prime);
+        $y1 = gmp_mod(gmp_sub($f, $e), $this->prime);
+        $x2 = $this->p384->subElements($e, $f);
+        $y2 = $this->p384->subElements($f, $e);
+
+        // Ensure we get what we expect:
+        $this->assertGMPSame($x1, $x2);
+        $this->assertGMPSame($y1, $y2);
+
+        // Catch false positives and arithmetic errors:
+        $this->assertGMPNotSame($x1, $y1);
+        $this->assertGMPNotSame($x2, $y2);
+        $this->assertGMPNotSame($x1, $y2);
+        $this->assertGMPNotSame($x2, $y1);
+    }
+
+    public function addProvider(): array
+    {
+        if (!isset($this->prime)) $this->setUp();
+        return [
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_sub($this->prime, gmp_init(1, 10))
+            ],
+            [
+                gmp_sub($this->prime, gmp_init(1, 10)),
+                gmp_sub($this->prime, gmp_init(1, 10)),
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_init(bin2hex(random_bytes(47)), 16)
+            ],
+            [
+                gmp_init('fe' . bin2hex(random_bytes(47)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(47)), 16)
+            ],
+            [
+                gmp_init(bin2hex(random_bytes(48)), 16),
+                gmp_init(bin2hex(random_bytes(48)), 16)
+            ],
+        ];
+    }
+
+
+    public function mulProvider(): array
+    {
+        if (!isset($this->prime)) $this->setUp();
+        return [
+            [
+                gmp_init(333, 10),
+                gmp_init(2024, 10),
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_init(bin2hex(random_bytes(31)), 16)
+            ],
+            [
+                $this->prime - gmp_init(3, 10),
+                gmp_init(5, 10)
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                $this->prime - gmp_init(random_int(1, 100000))
+            ],
+            [
+                gmp_init('fe' . bin2hex(random_bytes(31)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(31)), 16)
+            ],
+            [
+                $this->prime - gmp_init(random_int(100, 100000)),
+                $this->prime - gmp_init(random_int(100, 100000))
+            ],
+            [
+                gmp_init(bin2hex(random_bytes(32)), 16),
+                gmp_init(bin2hex(random_bytes(32)), 16)
+            ],
+        ];
+    }
+
+    public function subProvider(): array
+    {
+        if (!isset($this->prime)) $this->setUp();
+        return [
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_sub($this->prime, gmp_init(1, 10))
+            ],
+            [
+                gmp_sub($this->prime, gmp_init(1, 10)),
+                gmp_sub($this->prime, gmp_init(2, 10)),
+            ],
+            [
+                gmp_init(random_int(1, 100000), 10),
+                gmp_init(bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16),
+                gmp_init('fe' . bin2hex(random_bytes(15)), 16)
+            ],
+            [
+                gmp_init(bin2hex(random_bytes(16)), 16),
+                gmp_init(bin2hex(random_bytes(16)), 16)
+            ],
+        ];
+    }
+
+    public function scalarMultBaseProvider(): array
+    {
+        return [
+            [
+                gmp_init(1),
+                gmp_init('0xAA87CA22BE8B05378EB1C71EF320AD746E1D3B628BA79B9859F741E082542A385502F25DBF55296C3A545E3872760AB7', 16),
+                gmp_init('0x3617DE4A96262C6F5D9E98BF9292DC29F8F41DBD289A147CE9DA3113B5F0B8C00A60B1CE1D7E819D7A431D7C90EA0E5F', 16)
+            ],
+            [
+                gmp_init(2),
+                gmp_init('0x08D999057BA3D2D969260045C55B97F089025959A6F434D651D207D19FB96E9E4FE0E86EBE0E64F85B96A9C75295DF61', 16),
+                gmp_init('0x8E80F1FA5B1B3CEDB7BFE8DFFD6DBA74B275D875BC6CC43E904E505F256AB4255FFD43E94D39E22D61501E700A940E80', 16)
+            ],
+            [
+                gmp_init(3),
+                gmp_init('0x077A41D4606FFA1464793C7E5FDC7D98CB9D3910202DCD06BEA4F240D3566DA6B408BBAE5026580D02D7E5C70500C831', 16),
+                gmp_init('0xC995F7CA0B0C42837D0BBE9602A9FC998520B41C85115AA5F7684C0EDC111EACC24ABD6BE4B5D298B65F28600A2F1DF1', 16)
+            ],
+            [
+                gmp_init(4),
+                gmp_init('0x138251CD52AC9298C1C8AAD977321DEB97E709BD0B4CA0ACA55DC8AD51DCFC9D1589A1597E3A5120E1EFD631C63E1835', 16),
+                gmp_init('0xCACAE29869A62E1631E8A28181AB56616DC45D918ABC09F3AB0E63CF792AA4DCED7387BE37BBA569549F1C02B270ED67', 16)
+            ],
+            [
+                gmp_init('112233445566778899'),
+                gmp_init('0xA499EFE48839BC3ABCD1C5CEDBDD51904F9514DB44F4686DB918983B0C9DC3AEE05A88B72433E9515F91A329F5F4FA60', 16),
+                gmp_init('0x3B7CA28EF31F809C2F1BA24AAED847D0F8B406A4B8968542DE139DB5828CA410E615D1182E25B91B1131E230B727D36A', 16)
+            ]
+        ];
+    }
+
+    public function scalarMultProvider(): array
+    {
+        return [
+            [
+                gmp_init("2a265f8bcbdcaf94d58519141e578124cb40d64a501fba9c11847b28965bc737", 16),
+                gmp_init("023819813ac969847059028ea88a1f30dfbcde03fc791d3a252c6b41211882ea", 16),
+                gmp_init("f93e4ae433cc12cf2a43fc0ef26400c0e125508224cdb649380f25479148a4ad", 16),
+                gmp_init("4d4de80f1534850d261075997e3049321a0864082d24a917863366c0724f5ae3", 16),
+                gmp_init("a22d2b7f7818a3563e0f7a76c9bf0921ac55e06e2e4d11795b233824b1db8cc0", 16)
+            ],
+            [
+                gmp_init("313f72ff9fe811bf573176231b286a3bdb6f1b14e05c40146590727a71c3bccd", 16),
+                gmp_init("cc11887b2d66cbae8f4d306627192522932146b42f01d3c6f92bd5c8ba739b06", 16),
+                gmp_init("a2f08a029cd06b46183085bae9248b0ed15b70280c7ef13a457f5af382426031", 16),
+                gmp_init("831c3f6b5f762d2f461901577af41354ac5f228c2591f84f8a6e51e2e3f17991", 16),
+                gmp_init("93f90934cd0ef2c698cc471c60a93524e87ab31ca2412252337f364513e43684", 16)
+            ]
+        ];
+    }
+
+    private function getGenerator(): JacobiPoint
+    {
+        $p = new JacobiPoint();
+        /** @var GMP $x */
+        $x = gmp_init('0xaa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7', 16);
+        /** @var GMP $y */
+        $y = gmp_init('0x3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f', 16);
+        /** @var GMP $z */
+        $z = gmp_init(1);
+
+        $p->x = $x;
+        $p->y = $y;
+        $p->z = $z;
+        return $p;
+    }
+}


### PR DESCRIPTION
Closes #11 and #12.

This pull request does a few things:

1. Provides [**Complete Addition Formulas** for a=-3 Weierstrass curves](https://eprint.iacr.org/2015/1060). This ensures that point addition and point doubling are exception-free and avoid timing leaks.
2. Uses windowed scalar multiplication with constant-time conditional swaps to maximize performance without a security loss.
3. Hard-codes the pre-calculated tables needed for scalar multiplication of the base point, which speeds up keypair generation.
4. Implements Barrett reduction (with a pre-calculated R factor for each curve) to avoid division for reduction modulo a prime. Division and modulo reduction are generally not constant-time.

This implementations assumes that bigint multiplication is constant-time. On most hardware, this is a good assumption. [BearSSL has good documentation on the hardware where this assumption is false](https://www.bearssl.org/ctmul.html). The odds are good that you're running PHP on hardware that uses constant-time multiplication.

Despite being PHP implementations of constant-time code, the performance hit for using these curves is minimal. There is probably some opportunity for further optimizations.

We do not force the use of our implementation by default, due to the minor performance hit it does have. To use the new code:

```diff
  $nistFactory = EccFactory::getNistCurves($adapter);

- $p256 = $nistFactory->generator256($rng);
+ $p256 = $nistFactory->generator256($rng, true);

- $p384 = $nistFactory->generator384$rng);
+ $p384 = $nistFactory->generator384($rng, true);
```

We will update [EasyECC](https://github.com/paragonie/easy-ecc) to use this API in the next release.