### PR TITLE
Better Factories

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -16,6 +16,7 @@
     </projectFiles>
     <issueHandlers>
         <InvalidAttribute errorLevel="info" />
+        <UndefinedAttributeClass errorLevel="info" />
         <UnnecessaryVarAnnotation errorLevel="info" />
         <UnusedClass errorLevel="info" />
         <UnusedProperty errorLevel="info" />

--- a/src/Curves/SecgCurve.php
+++ b/src/Curves/SecgCurve.php
@@ -165,11 +165,11 @@ class SecgCurve
 
     /**
      * @param ?RandomNumberGeneratorInterface $randomGenerator
+     * @param bool $optimized
      * @return GeneratorPoint
      */
     public function generator256k1(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = false): GeneratorPoint
     {
-
         if ($optimized) {
             $curve = $this->optimizedCurve256k1();
         } else {
@@ -205,10 +205,14 @@ class SecgCurve
 
     /**
      * @param ?RandomNumberGeneratorInterface $randomGenerator
+     * @param bool $optimized
      * @return GeneratorPoint
      */
-    public function generator256r1(?RandomNumberGeneratorInterface $randomGenerator = null): GeneratorPoint
+    public function generator256r1(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = false): GeneratorPoint
     {
+        if ($optimized) {
+           return (new NistCurve($this->adapter))->generator256($randomGenerator, true);
+        }
         $curve = $this->curve256r1();
 
         /** @var GMP $order */
@@ -240,10 +244,14 @@ class SecgCurve
 
     /**
      * @param ?RandomNumberGeneratorInterface $randomGenerator
+     * @param bool $optimized
      * @return GeneratorPoint
      */
-    public function generator384r1(?RandomNumberGeneratorInterface $randomGenerator = null): GeneratorPoint
+    public function generator384r1(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = false): GeneratorPoint
     {
+        if ($optimized) {
+            return (new NistCurve($this->adapter))->generator256($randomGenerator, true);
+        }
         $curve = $this->curve384r1();
 
         /** @var GMP $order */

--- a/src/Curves/SecureBrainpoolCurve.php
+++ b/src/Curves/SecureBrainpoolCurve.php
@@ -1,0 +1,61 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Exception\InsecureCurveException;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+class SecureBrainpoolCurve extends BrainpoolCurve
+{
+    public function curve256r1(): NamedCurveFp
+    {
+        $curve = parent::curve256r1();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized brainpoolP256r1 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    public function curve384r1(): NamedCurveFp
+    {
+        $curve = parent::curve384r1();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized brainpoolP384r1 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    public function curve512r1(): NamedCurveFp
+    {
+        $curve = parent::curve512r1();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized brainpoolP512r1 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generator256r1(RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator256r1($randomGenerator, $optimized);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generator384r1(RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator384r1($randomGenerator, $optimized);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generator512r1(RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator512r1($randomGenerator, $optimized);
+    }
+}

--- a/src/Curves/SecureCurveFactory.php
+++ b/src/Curves/SecureCurveFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Math\GmpMathInterface;
+use Mdanter\Ecc\Math\MathAdapterFactory;
+
+/**
+ * Similar to CurveFactory, but only returns secure implementations
+ */
+class SecureCurveFactory extends CurveFactory
+{
+    /**
+     * @param GmpMathInterface $math
+     * @return NistCurve
+     */
+    private static function getNistFactory(GmpMathInterface $math): NistCurve
+    {
+        return new SecureNistCurve($math);
+    }
+
+    /**
+     * @param GmpMathInterface $math
+     * @return BrainpoolCurve
+     */
+    private static function getBrainpoolFactory(GmpMathInterface $math): BrainpoolCurve
+    {
+        return new SecureBrainpoolCurve($math);
+    }
+
+    /**
+     * @param GmpMathInterface $math
+     * @return SecgCurve
+     */
+    private static function getSecpFactory(GmpMathInterface $math): SecgCurve
+    {
+        return new SecureSecgCurve($math);
+    }
+}

--- a/src/Curves/SecureNistCurve.php
+++ b/src/Curves/SecureNistCurve.php
@@ -1,0 +1,116 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Exception\InsecureCurveException;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+/**
+ * Selects secure NIST curves
+ */
+class SecureNistCurve extends NistCurve
+{
+    public function curve192(): NamedCurveFp
+    {
+        throw new InsecureCurveException('P-192 is not a secure elliptic curve');
+    }
+
+    public function curve224(): NamedCurveFp
+    {
+        throw new InsecureCurveException('P-224 is not a secure elliptic curve');
+    }
+
+    /**
+     * @return NamedCurveFp
+     * @throws InsecureCurveException
+     */
+    public function curve256(): NamedCurveFp
+    {
+        $curve = parent::curve256();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized P-256 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    /**
+     * @return NamedCurveFp
+     * @throws InsecureCurveException
+     */
+    public function curve384(): NamedCurveFp
+    {
+        $curve = parent::curve384();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized P-384 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    /**
+     * @return NamedCurveFp
+     * @throws InsecureCurveException
+     */
+    public function curve521(): NamedCurveFp
+    {
+        $curve = parent::curve521();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized P-521 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    /**
+     * @param RandomNumberGeneratorInterface|null $randomGenerator
+     * @throws InsecureCurveException
+     */
+    public function generator192(?RandomNumberGeneratorInterface $randomGenerator = null): GeneratorPoint
+    {
+        throw new InsecureCurveException('P-192 is not a secure elliptic curve');
+    }
+
+    /**
+     * @param RandomNumberGeneratorInterface|null $randomGenerator
+     * @throws InsecureCurveException
+     */
+    public function generator224(?RandomNumberGeneratorInterface $randomGenerator = null): GeneratorPoint
+    {
+        throw new InsecureCurveException('P-224 is not a secure elliptic curve');
+    }
+
+    /**
+     * Returns an NIST P-256 generator.
+     *
+     * @param  ?RandomNumberGeneratorInterface $randomGenerator
+     * @param bool $optimized
+     * @return GeneratorPoint
+     */
+    public function generator256(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator256($randomGenerator, $optimized);
+    }
+
+    /**
+     * Returns an NIST P-384 generator.
+     *
+     * @param  ?RandomNumberGeneratorInterface $randomGenerator
+     * @param bool $optimized
+     * @return GeneratorPoint
+     */
+    public function generator384(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator384($randomGenerator, $optimized);
+    }
+
+    /**
+     * Returns an NIST P-521 generator.
+     *
+     * @param  ?RandomNumberGeneratorInterface $randomGenerator
+     * @param bool $optimized
+     * @return GeneratorPoint
+     */
+    public function generator521(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator521($randomGenerator, $optimized);
+    }
+}

--- a/src/Curves/SecureSecgCurve.php
+++ b/src/Curves/SecureSecgCurve.php
@@ -1,0 +1,81 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Curves;
+
+use Mdanter\Ecc\Exception\InsecureCurveException;
+use Mdanter\Ecc\Primitives\GeneratorPoint;
+use Mdanter\Ecc\Random\RandomNumberGeneratorInterface;
+
+class SecureSecgCurve extends SecgCurve
+{
+
+    public function curve112r1(): NamedCurveFp
+    {
+        throw new InsecureCurveException('secp112r1 is not a secure elliptic curve');
+    }
+
+    public function curve192k1(): NamedCurveFp
+    {
+        throw new InsecureCurveException('secp192r1 is not a secure elliptic curve');
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function curve256k1(): NamedCurveFp
+    {
+        $curve = parent::curve256k1();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized secp256k1 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function curve256r1(): NamedCurveFp
+    {
+        $curve = parent::curve256r1();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized secp256k1 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function curve384r1(): NamedCurveFp
+    {
+        $curve = parent::curve384r1();
+        if (!$curve->isOpensslAvailable()) {
+            throw new InsecureCurveException('Cannot securely use non-optimized secp256k1 without OpenSSL support');
+        }
+        return $curve;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generator256k1(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator256k1($randomGenerator, $optimized);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generator256r1(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator256r1($randomGenerator, $optimized);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function generator384r1(?RandomNumberGeneratorInterface $randomGenerator = null, bool $optimized = true): GeneratorPoint
+    {
+        return parent::generator384r1($randomGenerator, $optimized);
+    }
+}

--- a/src/EccFactory.php
+++ b/src/EccFactory.php
@@ -6,6 +6,8 @@ namespace Mdanter\Ecc;
 use Mdanter\Ecc\Crypto\Signature\Signer;
 use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Curves\SecgCurve;
+use Mdanter\Ecc\Curves\SecureNistCurve;
+use Mdanter\Ecc\Curves\SecureSecgCurve;
 use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Math\MathAdapterFactory;
 use Mdanter\Ecc\Primitives\CurveFp;
@@ -36,20 +38,27 @@ class EccFactory
      * @param  ?GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
      * @return NistCurve
      */
-    public static function getNistCurves(?GmpMathInterface $adapter = null): NistCurve
+    public static function getNistCurves(?GmpMathInterface $adapter = null, bool $allowInsecure = false): NistCurve
     {
-        return new NistCurve($adapter ?: self::getAdapter());
+        if ($allowInsecure) {
+            return new NistCurve($adapter ?: self::getAdapter());
+        }
+        return new SecureNistCurve($adapter ?: self::getAdapter());
     }
 
     /**
      * Returns a factory to return SECG Recommended curves and generators.
      *
      * @param  ?GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
+     * @param  bool $allowInsecure [optional] Allow insecure curves? (default: false)
      * @return SecgCurve
      */
-    public static function getSecgCurves(?GmpMathInterface $adapter = null): SecgCurve
+    public static function getSecgCurves(?GmpMathInterface $adapter = null, bool $allowInsecure = false): SecgCurve
     {
-        return new SecgCurve($adapter ?: self::getAdapter());
+        if ($allowInsecure) {
+            return new SecgCurve($adapter ?: self::getAdapter());
+        }
+        return new SecureSecgCurve($adapter ?: self::getAdapter());
     }
 
     /**

--- a/src/EccFactory.php
+++ b/src/EccFactory.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 namespace Mdanter\Ecc;
 
 use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Curves\BrainpoolCurve;
 use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Curves\SecgCurve;
+use Mdanter\Ecc\Curves\SecureBrainpoolCurve;
 use Mdanter\Ecc\Curves\SecureNistCurve;
 use Mdanter\Ecc\Curves\SecureSecgCurve;
 use Mdanter\Ecc\Math\GmpMathInterface;
@@ -33,9 +35,25 @@ class EccFactory
     }
 
     /**
+     * Returns a factory to return Brainpool curves and generators.
+     *
+     * @param  ?GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
+     * @param  bool $allowInsecure [optional] Allow insecure curves? (default: false)
+     * @return BrainpoolCurve
+     */
+    public static function getBrainpoolCurves(?GmpMathInterface $adapter = null, bool $allowInsecure = false): BrainpoolCurve
+    {
+        if ($allowInsecure) {
+            return new BrainpoolCurve($adapter ?: self::getAdapter());
+        }
+        return new SecureBrainpoolCurve($adapter ?: self::getAdapter());
+    }
+
+    /**
      * Returns a factory to create NIST Recommended curves and generators.
      *
      * @param  ?GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
+     * @param bool $allowInsecure [optional] Allow insecure curves? (default: false)
      * @return NistCurve
      */
     public static function getNistCurves(?GmpMathInterface $adapter = null, bool $allowInsecure = false): NistCurve
@@ -50,7 +68,7 @@ class EccFactory
      * Returns a factory to return SECG Recommended curves and generators.
      *
      * @param  ?GmpMathInterface $adapter [optional] Defaults to the return value of EccFactory::getAdapter().
-     * @param  bool $allowInsecure [optional] Allow insecure curves? (default: false)
+     * @param bool $allowInsecure [optional] Allow insecure curves? (default: false)
      * @return SecgCurve
      */
     public static function getSecgCurves(?GmpMathInterface $adapter = null, bool $allowInsecure = false): SecgCurve

--- a/src/Exception/InsecureCurveException.php
+++ b/src/Exception/InsecureCurveException.php
@@ -1,0 +1,8 @@
+<?php
+declare(strict_types=1);
+namespace Mdanter\Ecc\Exception;
+
+class InsecureCurveException extends \Exception
+{
+
+}

--- a/tests/unit/Crypto/EcDH/EcDHTest.php
+++ b/tests/unit/Crypto/EcDH/EcDHTest.php
@@ -72,7 +72,7 @@ class EcDHTest extends AbstractTestCase
         $p1 = EccFactory::getNistCurves()->generator521()->getPrivateKeyFrom($g521Priv);
 
         $g192Pub = "0468e3642493c4e433a741c78ab67ee607d94925c506e9554d43de2d1c71493334c681cf4683aee863d90e9732745d5bc7";
-        $g192 = EccFactory::getNistCurves()->generator192();
+        $g192 = EccFactory::getNistCurves(null, true)->generator192();
 
         $p2 = (new UncompressedPointSerializer())->unserialize($g192->getCurve(), $g192Pub);
         $pubkey = $g192->getPublicKeyFrom($p2->getX(), $p2->getY());

--- a/tests/unit/Crypto/Key/PublicKeyTest.php
+++ b/tests/unit/Crypto/Key/PublicKeyTest.php
@@ -19,7 +19,7 @@ class PublicKeyTest extends AbstractTestCase
         $this->expectExceptionMessage('Point has x and y out of range');
 
         $adapter = EccFactory::getAdapter();
-        $generator192 = EccFactory::getNistCurves($adapter)->generator192();
+        $generator192 = EccFactory::getNistCurves($adapter, true)->generator192();
         $generator384 = EccFactory::getNistCurves($adapter)->generator384();
 
         $tooLarge = $generator384->createPrivateKey()->getPublicKey()->getPoint();
@@ -40,7 +40,7 @@ class PublicKeyTest extends AbstractTestCase
         $adapter = EccFactory::getAdapter();
         $generator384 = EccFactory::getNistCurves($adapter)->generator384();
 
-        $generator192 = EccFactory::getNistCurves($adapter)->generator192();
+        $generator192 = EccFactory::getNistCurves($adapter, true)->generator192();
         $mismatchPoint = $generator192->createPrivateKey()->getPublicKey()->getPoint();
 
         try {
@@ -55,7 +55,7 @@ class PublicKeyTest extends AbstractTestCase
     public function testInstance()
     {
         $adapter = EccFactory::getAdapter();
-        $generator = EccFactory::getNistCurves($adapter)->generator192();
+        $generator = EccFactory::getNistCurves($adapter, true)->generator192();
         $curve = $generator->getCurve();
         $point = $generator->createPrivateKey()->getPublicKey()->getPoint();
         $key = new PublicKey($adapter, $generator, $point);

--- a/tests/unit/Curves/NamedCurveFpTest.php
+++ b/tests/unit/Curves/NamedCurveFpTest.php
@@ -12,7 +12,7 @@ class NamedCurveFpTest extends AbstractTestCase
 {
     public function testInstance()
     {
-        $curve = EccFactory::getNistCurves()->curve384();
+        $curve = EccFactory::getNistCurves(null, true)->curve384();
         $this->assertInstanceOf(NamedCurveFp::class, $curve);
         ;
         $this->assertEquals(NistCurve::NAME_P384, $curve->getName());

--- a/tests/unit/Curves/NistCurveTest.php
+++ b/tests/unit/Curves/NistCurveTest.php
@@ -18,7 +18,7 @@ class NistCurveTest extends AbstractTestCase
      */
     public function testP192CurveAnsiX962ValidityTest(GmpMathInterface $math)
     {
-        $generator = EccFactory::getNistCurves($math)->generator192();
+        $generator = EccFactory::getNistCurves($math, true)->generator192();
 
         $d = gmp_init('651056770906015076056810763456358567190100156695615665659', 10);
         $Q = $generator->mul($d);
@@ -27,7 +27,7 @@ class NistCurveTest extends AbstractTestCase
 
         $k = gmp_init('6140507067065001063065065565667405560006161556565665656654', 10);
         $R = $generator->mul($k);
-        $expected = EccFactory::getNistCurves($math)->curve192()->getPoint(
+        $expected = EccFactory::getNistCurves($math, true)->curve192()->getPoint(
             gmp_init('0x885052380FF147B734C330C43D39B2C4A89F29B0F749FEAD', 16),
             gmp_init('0x9CF9FA1CBEFEFB917747A3BB29C072B9289C2547884FD835', 16)
         );
@@ -86,7 +86,7 @@ class NistCurveTest extends AbstractTestCase
         $x = gmp_init($x, 16);
         $y = gmp_init($y, 16);
 
-        $generator = EccFactory::getNistCurves($math)->generator192();
+        $generator = EccFactory::getNistCurves($math, true)->generator192();
 
         $this->assertEquals($expected, $generator->isValid($x, $y));
     }
@@ -201,7 +201,7 @@ class NistCurveTest extends AbstractTestCase
         $R = gmp_init($R, 16);
         $S = gmp_init($S, 16);
 
-        $generator = EccFactory::getNistCurves($math)->generator192();
+        $generator = EccFactory::getNistCurves($math, true)->generator192();
 
         $publicKey = $generator->getPublicKeyFrom($Qx, $Qy);
         $signer = new Signer($math);
@@ -231,7 +231,7 @@ class NistCurveTest extends AbstractTestCase
      */
     public function testSignatureValidityWithCorrectHash(GmpMathInterface $math, array $values)
     {
-        $generator = EccFactory::getNistCurves($math)->generator192();
+        $generator = EccFactory::getNistCurves($math, true)->generator192();
 
         $privateKey = $generator->getPrivateKeyFrom(gmp_init($values['d'], 10));
         $publicKey = $privateKey->getPublicKey();
@@ -251,7 +251,7 @@ class NistCurveTest extends AbstractTestCase
      */
     public function testSignatureValidityWithForgedHash(GmpMathInterface $math, array $values)
     {
-        $generator = EccFactory::getNistCurves($math)->generator192();
+        $generator = EccFactory::getNistCurves($math, true)->generator192();
 
         $privateKey = $generator->getPrivateKeyFrom(gmp_init($values['d'], 10));
         $publicKey = $privateKey->getPublicKey();
@@ -279,7 +279,7 @@ class NistCurveTest extends AbstractTestCase
      */
     public function testSignatureValidityWithGeneratedKeys(GmpMathInterface $math, RandomNumberGeneratorInterface $rng)
     {
-        $generator = EccFactory::getNistCurves($math)->generator192();
+        $generator = EccFactory::getNistCurves($math, true)->generator192();
 
         $signer = new Signer($math);
 
@@ -300,7 +300,7 @@ class NistCurveTest extends AbstractTestCase
      */
     public function testDiffieHellman(GmpMathInterface $math, RandomNumberGeneratorInterface $rng)
     {
-        $generator = EccFactory::getNistCurves($math)->generator192($rng);
+        $generator = EccFactory::getNistCurves($math, true)->generator192($rng);
         $alicePrivKey = $generator->createPrivateKey();
         $bobPrivKey = $generator->createPrivateKey();
 

--- a/tests/unit/Curves/SecCurveTest.php
+++ b/tests/unit/Curves/SecCurveTest.php
@@ -35,7 +35,7 @@ class SecCurveTest extends AbstractTestCase
      */
     public function testCurveGeneration(GmpMathInterface $math, string $function, string $a, string $b, string $prime)
     {
-        $factory = EccFactory::getSecgCurves($math);
+        $factory = EccFactory::getSecgCurves($math, true);
         /** @var CurveFpInterface $curve */
         $curve = $factory->{$function}();
 
@@ -64,7 +64,7 @@ class SecCurveTest extends AbstractTestCase
      */
     public function testGeneratorGeneration(GmpMathInterface $math, string $function, string $order, string $prime)
     {
-        $factory = EccFactory::getSecgCurves($math);
+        $factory = EccFactory::getSecgCurves($math, true);
         /** @var GeneratorPoint $generator */
         $generator = $factory->{$function}();
 
@@ -79,8 +79,8 @@ class SecCurveTest extends AbstractTestCase
      */
     public function testSecp256r1EquivalenceToNistP256(GmpMathInterface $adapter)
     {
-        $secpFactory = EccFactory::getSecgCurves($adapter);
-        $nistFactory = EccFactory::getNistCurves($adapter);
+        $secpFactory = EccFactory::getSecgCurves($adapter, true);
+        $nistFactory = EccFactory::getNistCurves($adapter, true);
 
         $signer = new Signer($adapter);
 
@@ -108,8 +108,8 @@ class SecCurveTest extends AbstractTestCase
      */
     public function testSecp384r1EquivalenceToNistP384(GmpMathInterface $adapter)
     {
-        $secpFactory = EccFactory::getSecgCurves($adapter);
-        $nistFactory = EccFactory::getNistCurves($adapter);
+        $secpFactory = EccFactory::getSecgCurves($adapter, true);
+        $nistFactory = EccFactory::getNistCurves($adapter, true);
 
         $signer = new Signer($adapter);
 

--- a/tests/unit/Curves/Secp112r1EcdsaTest.php
+++ b/tests/unit/Curves/Secp112r1EcdsaTest.php
@@ -15,7 +15,7 @@ class Secp112r1EcdsaTest extends AbstractTestCase
         $expectedS = '1960761230049936699759766101723490';
 
         $adapter = \Mdanter\Ecc\EccFactory::getAdapter();
-        $g = \Mdanter\Ecc\EccFactory::getSecgCurves()->generator112r1();
+        $g = \Mdanter\Ecc\EccFactory::getSecgCurves($adapter, true)->generator112r1();
 
         $key = gmp_init('deadbeef', 16);
         $priv = $g->getPrivateKeyFrom($key);

--- a/tests/unit/EccFactoryTest.php
+++ b/tests/unit/EccFactoryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 namespace Mdanter\Ecc\Tests;
 
 use Mdanter\Ecc\Crypto\Signature\Signer;
+use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Exception\InsecureCurveException;
 use Mdanter\Ecc\Primitives\CurveFp;
 use Mdanter\Ecc\Tests\AbstractTestCase;
 
@@ -19,6 +21,19 @@ class EccFactoryTest extends AbstractTestCase
         $b = gmp_init(hash('sha512', 'testing'), 16);
         $created = EccFactory::createCurve(512, $p, $a, $b);
         $this->assertInstanceOf(CurveFp::class, $created);
+    }
+
+    public function testsNoInscureCurvesByDefaultNIST(): void
+    {
+        $this->expectExceptionMessage('P-192 is not a secure elliptic curve');
+        $this->expectException(InsecureCurveException::class);
+        EccFactory::getNistCurves()->curve192();
+    }
+    public function testsNoInscureCurvesByDefaultSecg(): void
+    {
+        $this->expectExceptionMessage('secp112r1 is not a secure elliptic curve');
+        $this->expectException(InsecureCurveException::class);
+        EccFactory::getSecgCurves()->curve112r1();
     }
 
     public function testGetSigner(): void

--- a/tests/unit/EccFactoryTest.php
+++ b/tests/unit/EccFactoryTest.php
@@ -23,15 +23,23 @@ class EccFactoryTest extends AbstractTestCase
         $this->assertInstanceOf(CurveFp::class, $created);
     }
 
+    public function testsNoInscureCurvesByDefaultBrainpool(): void
+    {
+        $this->expectException(InsecureCurveException::class);
+        $curve = EccFactory::getBrainpoolCurves()->curve256r1();
+        if ($curve->isOpensslAvailable()) {
+            $this->markTestSkipped('We can actually use this curve securely');
+        }
+    }
+
     public function testsNoInscureCurvesByDefaultNIST(): void
     {
-        $this->expectExceptionMessage('P-192 is not a secure elliptic curve');
         $this->expectException(InsecureCurveException::class);
         EccFactory::getNistCurves()->curve192();
     }
+
     public function testsNoInscureCurvesByDefaultSecg(): void
     {
-        $this->expectExceptionMessage('secp112r1 is not a secure elliptic curve');
         $this->expectException(InsecureCurveException::class);
         EccFactory::getSecgCurves()->curve112r1();
     }

--- a/tests/unit/Math/NumberTheoryTestPhpunit6.php
+++ b/tests/unit/Math/NumberTheoryTestPhpunit6.php
@@ -23,7 +23,7 @@ abstract class NumberTheoryTestPhpunit6 extends AbstractTestCase
         if (! file_exists($file_sqrt)) {
             $this->fail('Square root input data not found');
         }
-        $this->generator = EccFactory::getSecgCurves()->generator256k1();
+        $this->generator = EccFactory::getSecgCurves(null, true)->generator256k1();
         $this->compression_data = json_decode(file_get_contents($file_comp));
 
         $this->sqrt_data = json_decode(file_get_contents($file_sqrt));

--- a/tests/unit/Math/NumberTheoryTestPhpunit7.php
+++ b/tests/unit/Math/NumberTheoryTestPhpunit7.php
@@ -23,7 +23,7 @@ abstract class NumberTheoryTestPhpunit7 extends AbstractTestCase
         if (! file_exists($file_sqrt)) {
             $this->fail('Square root input data not found');
         }
-        $this->generator = EccFactory::getSecgCurves()->generator256k1();
+        $this->generator = EccFactory::getSecgCurves(null, true)->generator256k1();
         $this->compression_data = json_decode(file_get_contents($file_comp));
 
         $this->sqrt_data = json_decode(file_get_contents($file_sqrt));

--- a/tests/unit/Optimized/InteropTest.php
+++ b/tests/unit/Optimized/InteropTest.php
@@ -22,7 +22,7 @@ class InteropTest extends AbstractTestCase
      */
     public function testP256Interop(GmpMathInterface $adapter)
     {
-        $nistFactory = EccFactory::getNistCurves($adapter);
+        $nistFactory = EccFactory::getNistCurves($adapter, true);
         $signer = new Signer($adapter);
 
         $p256Old = $nistFactory->generator256(null, false);
@@ -65,7 +65,7 @@ class InteropTest extends AbstractTestCase
      */
     public function testP384Interop(GmpMathInterface $adapter)
     {
-        $nistFactory = EccFactory::getNistCurves($adapter);
+        $nistFactory = EccFactory::getNistCurves($adapter, true);
         $signer = new Signer($adapter);
 
         $p384Old = $nistFactory->generator384(null, false);

--- a/tests/unit/Primitives/CurveFpTest.php
+++ b/tests/unit/Primitives/CurveFpTest.php
@@ -32,7 +32,7 @@ class CurveFpTest extends AbstractTestCase
         $this->assertTrue($infinityPoint->isInfinity());
 
         // Check equality tests
-        $differentCurve = EccFactory::getNistCurves()->curve192();
+        $differentCurve = EccFactory::getNistCurves($adapter, true)->curve192();
         $this->assertEquals(1, $curve->cmp($differentCurve));
         $this->assertEquals(0, $curve->cmp($curve));
         $this->assertFalse($curve->equals($differentCurve));

--- a/tests/unit/Random/HmacRandomNumberGeneratorTest.php
+++ b/tests/unit/Random/HmacRandomNumberGeneratorTest.php
@@ -16,7 +16,7 @@ class HmacRandomNumberGeneratorTest extends AbstractTestCase
         $this->expectExceptionMessage('Unsupported hashing algorithm');
 
         $math = EccFactory::getAdapter();
-        $g = EccFactory::getNistCurves()->generator192();
+        $g = EccFactory::getNistCurves($math, true)->generator192();
         $privateKey  = new PrivateKey($math, $g, gmp_init(1, 10));
         $hash = gmp_init(hash('sha256', 'message', false), 16);
 

--- a/tests/unit/Serializer/Point/CompressedPointSerializerTest.php
+++ b/tests/unit/Serializer/Point/CompressedPointSerializerTest.php
@@ -17,7 +17,7 @@ class CompressedPointSerializerTest extends AbstractTestCase
         $this->expectExceptionMessage('Invalid data: only compressed keys are supported.');
         $data = '01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
         $serializer = new CompressedPointSerializer(EccFactory::getAdapter());
-        $serializer->unserialize(EccFactory::getNistCurves()->curve192(), $data);
+        $serializer->unserialize(EccFactory::getNistCurves(null, true)->curve192(), $data);
         $this->assertInstanceOf(NumberTheory::class, $serializer->getNumberTheory());
     }
 
@@ -34,7 +34,7 @@ class CompressedPointSerializerTest extends AbstractTestCase
 
         // Uncompress the point
         $recovered = $serializer->unserialize(
-            EccFactory::getNistCurves()->curve384(),
+            EccFactory::getNistCurves($adapter, true)->curve384(),
             $compressed
         );
 

--- a/tests/unit/Serializer/Point/UncompressedPointSerializerTest.php
+++ b/tests/unit/Serializer/Point/UncompressedPointSerializerTest.php
@@ -15,6 +15,6 @@ class UncompressedPointSerializerTest extends AbstractTestCase
         $this->expectExceptionMessage('Invalid data: only uncompressed keys are supported.');
         $data = '01aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
         $serializer = new UncompressedPointSerializer();
-        $serializer->unserialize(EccFactory::getNistCurves()->curve192(), $data);
+        $serializer->unserialize(EccFactory::getNistCurves(null, true)->curve192(), $data);
     }
 }

--- a/tests/unit/Serializer/PrivateKey/DerPrivateKeySerializerTest.php
+++ b/tests/unit/Serializer/PrivateKey/DerPrivateKeySerializerTest.php
@@ -29,7 +29,7 @@ class DerPrivateKeySerializerTest extends AbstractTestCase
     public function testConsistent()
     {
         $adapter = EccFactory::getAdapter();
-        $G = EccFactory::getNistCurves($adapter)->generator192();
+        $G = EccFactory::getNistCurves($adapter, true)->generator192();
         $key = $G->createPrivateKey();
 
         $derPrivSerializer = new DerPrivateKeySerializer($adapter, new DerPublicKeySerializer());
@@ -44,7 +44,7 @@ class DerPrivateKeySerializerTest extends AbstractTestCase
         $this->expectExceptionMessage('Invalid data: only version 1 (RFC5915) keys are supported.');
 
         $adapter = EccFactory::getAdapter();
-        $G = EccFactory::getNistCurves($adapter)->generator192();
+        $G = EccFactory::getNistCurves($adapter, true)->generator192();
         $key = $G->createPrivateKey();
 
         $derPubSerializer = new DerPublicKeySerializer();

--- a/tests/unit/Serializer/PrivateKey/PemPrivateKeySerializerTest.php
+++ b/tests/unit/Serializer/PrivateKey/PemPrivateKeySerializerTest.php
@@ -24,7 +24,7 @@ class PemPrivateKeySerializerTest extends AbstractTestCase
     public function testConsistent()
     {
         $adapter = EccFactory::getAdapter();
-        $G = EccFactory::getNistCurves($adapter)->generator192();
+        $G = EccFactory::getNistCurves($adapter, true)->generator192();
         $key = $G->createPrivateKey();
 
         $derPrivSerializer = new DerPrivateKeySerializer($adapter);

--- a/tests/unit/Serializer/PublicKey/PemPublicKeySerializerTest.php
+++ b/tests/unit/Serializer/PublicKey/PemPublicKeySerializerTest.php
@@ -24,7 +24,7 @@ class PemPublicKeySerializerTest extends AbstractTestCase
     public function testConsistent()
     {
         $adapter = EccFactory::getAdapter();
-        $G = EccFactory::getNistCurves($adapter)->generator192();
+        $G = EccFactory::getNistCurves($adapter, true)->generator192();
         $pubkey = $G->createPrivateKey()->getPublicKey();
 
         $serializer = new PemPublicKeySerializer(new DerPublicKeySerializer($adapter));

--- a/tests/unit/Serializer/Util/CurveOidMapperTest.php
+++ b/tests/unit/Serializer/Util/CurveOidMapperTest.php
@@ -23,8 +23,8 @@ class CurveOidMapperTest extends AbstractTestCase
 
     public function testValidValues()
     {
-        $nistCurve = EccFactory::getNistCurves()->curve521();
-        $G = EccFactory::getNistCurves()->generator521();
+        $nistCurve = EccFactory::getNistCurves(null, true)->curve521();
+        $G = EccFactory::getNistCurves(null, true)->generator521();
         $nistp521oid = CurveOidMapper::getCurveOid($nistCurve);
         $this->assertEquals(66, CurveOidMapper::getByteSize($nistCurve));
         $this->assertInstanceOf(ObjectIdentifier::class, $nistp521oid);


### PR DESCRIPTION
- `EccFactory` now only returns secure curves by default
   - To get access to insecure curves, pass `true` as the optional second argument to `getNistCurves()` and `getSecgCurves()`.
- Created `SecureCurveFactory` which only returns Curves and Generators if it's possible to impleemnt securely