### PR TITLE
fix: Use gmp_pow overload to avoid php bug GH-16870

### DIFF
--- a/src/Math/GmpMath.php
+++ b/src/Math/GmpMath.php
@@ -27,7 +27,7 @@ class GmpMath implements GmpMathInterface
     {
         return gmp_cmp($first, $other) === 0;
     }
-    
+
     /**
      * {@inheritDoc}
      * @see GmpMathInterface::mod()
@@ -90,7 +90,7 @@ class GmpMath implements GmpMathInterface
     public function pow(GMP $base, int $exponent): GMP
     {
         /** @var GMP $out */
-        $out = gmp_pow($base, $exponent);
+        $out = $base ** $exponent;
         return $out;
     }
 
@@ -115,7 +115,7 @@ class GmpMath implements GmpMathInterface
         /** @var GMP $two */
         $two = gmp_init(2, 10);
         /** @var GMP $exp */
-        $exp = gmp_pow($two, $positions);
+        $exp = $two ** $positions;
         /** @var GMP $out */
         $out = gmp_div($number, $exp);
         return $out;
@@ -141,7 +141,7 @@ class GmpMath implements GmpMathInterface
         /** @var GMP $two */
         $two = gmp_init(2, 10);
         /** @var GMP $exp */
-        $exp = gmp_pow($two, $positions);
+        $exp = $two ** $positions;
         // Shift 1 left = mul by 2
         /** @var GMP $out */
         $out = gmp_mul($number, $exp);
@@ -268,18 +268,18 @@ class GmpMath implements GmpMathInterface
         /** @var GMP $two */
         $two = gmp_init(2);
         /** @var GMP $range */
-        $range = gmp_pow($two, $byteSize * 8);
+        $range = $two ** ($byteSize * 8);
         if (NumberSize::bnNumBits($this, $x) >= NumberSize::bnNumBits($this, $range)) {
             throw new \RuntimeException("Number overflows byte size");
         }
 
-        $maskShift = gmp_pow($two, 8);
+        $maskShift = $two ** 8;
         $mask = gmp_mul(gmp_init(255), $range);
 
         $binary = '';
         for ($i = $byteSize - 1; $i >= 0; $i--) {
             $mask = gmp_div($mask, $maskShift);
-            $binary .= pack('C', gmp_strval(gmp_div(gmp_and($x, $mask), gmp_pow($two, $i * 8)), 10));
+            $binary .= pack('C', gmp_strval(gmp_div(gmp_and($x, $mask), $two ** ($i * 8)), 10));
         }
 
         return $binary;

--- a/src/Random/RandomNumberGenerator.php
+++ b/src/Random/RandomNumberGenerator.php
@@ -38,7 +38,7 @@ class RandomNumberGenerator implements RandomNumberGeneratorInterface
         $value = $this->adapter->stringToInt($bytes);
 
         /** @var GMP $mask */
-        $mask = gmp_sub(gmp_pow(2, $numBits), 1);
+        $mask = gmp_sub(gmp_init(2) ** $numBits, 1);
         /** @var GMP $integer */
         $integer = gmp_and($value, $mask);
 


### PR DESCRIPTION
In the newest php minor releases there is an issue with `gmp_pow` that only accepts very small values: https://github.com/php/php-src/issues/16870 Concretely, for reasonably big numbers, the execution fails with `Uncaught ValueError: base and exponent overflow ` According to the [changelog](https://www.php.net/ChangeLog-8.php), this change is in 8.3.14 and 8.2.26.

However, according to a [comment](https://github.com/php/php-src/issues/16870#issuecomment-2499293925) in the bug thread, it is sufficient to replace `gmp_pow` with `**` to avoid triggering the bug.

I've applied this patch to this project, and indeed the tests pass.