### PR TITLE
Fix SchnorrSignature gmp_hexval to always return 64-character hex strings

### DIFF
--- a/src/Crypto/Signature/SchnorrSignature.php
+++ b/src/Crypto/Signature/SchnorrSignature.php
@@ -184,11 +184,8 @@ class SchnorrSignature
         // gmp_strval does not properly pad hexadecimal values
         $hex = gmp_strval($gmp, 16);
 
-        if (mb_strlen($hex) % 2 === 0) {
-            return $hex;
-        }
-
-        return '0' . $hex;
+        // Always ensure the result is exactly 64 characters, zero-padded from the left
+        return str_pad($hex, 64, '0', STR_PAD_LEFT);
     }
 
     private function finalizeSchnorrVerify(\GMP $r, PointInterface $P, \GMP $s, \GMP $e): bool

--- a/tests/unit/Crypto/Signature/SchnorrSignatureTest.php
+++ b/tests/unit/Crypto/Signature/SchnorrSignatureTest.php
@@ -94,4 +94,32 @@ final class SchnorrSignatureTest extends AbstractTestCase
         // make assertion
         static::assertSame($signature, $finalResult);
     }
+
+    /**
+     * Test that signatures are always 128 characters (64 hex chars each for r and s)
+     */
+    public function testSignatureLengthConsistency(): void
+    {
+        // Test with various private keys that might produce short hex values
+        $testCases = [
+            ['privateKey' => '0000000000000000000000000000000000000000000000000000000000000001', 'message' => 'test'],
+            ['privateKey' => '0000000000000000000000000000000000000000000000000000000000000123', 'message' => 'test'],
+            ['privateKey' => '000000000000000000000000000000000000000000000000000000000000abcd', 'message' => 'test'],
+        ];
+
+        foreach ($testCases as $case) {
+            $schnorr = new SchnorrSignature();
+            $result = $schnorr->sign($case['privateKey'], $case['message'], 'a' . str_repeat('0', 63));
+
+            // Signature should always be exactly 128 characters
+            static::assertSame(128, strlen($result['signature']),
+                sprintf('Signature length should be 128, got %d for private key %s',
+                    strlen($result['signature']), $case['privateKey']));
+
+            // Public key should always be exactly 64 characters
+            static::assertSame(64, strlen($result['publicKey']),
+                sprintf('Public key length should be 64, got %d for private key %s',
+                    strlen($result['publicKey']), $case['privateKey']));
+        }
+    }
 }


### PR DESCRIPTION
## Problem

The `gmp_hexval()` method in `SchnorrSignature.php` was not ensuring consistent 64-character hex string output, which could lead to signatures shorter than the expected 128 characters (64 hex chars each for r and s components).

The current implementation only padded hex strings to ensure even length:

```php
private function gmp_hexval(\GMP $gmp): string
{
    $hex = gmp_strval($gmp, 16);
    
    if (mb_strlen($hex) % 2 === 0) {
        return $hex;
    }
    
    return '0' . $hex;
}
```

This could produce hex strings of varying lengths (2, 4, 6, 8... characters) instead of the required 64 characters, potentially causing signature length inconsistency.

## Solution

Updated `gmp_hexval()` to always return exactly 64-character hex strings, zero-padded from the left:

```php
private function gmp_hexval(\GMP $gmp): string
{
    $hex = gmp_strval($gmp, 16);
    
    // Always ensure the result is exactly 64 characters, zero-padded from the left
    return str_pad($hex, 64, '0', STR_PAD_LEFT);
}
```

## Changes Made

- **src/Crypto/Signature/SchnorrSignature.php**: Updated `gmp_hexval()` method to use `str_pad()` with 64-character padding
- **tests/unit/Crypto/Signature/SchnorrSignatureTest.php**: Added `testSignatureLengthConsistency()` test to validate that signatures are always 128 characters and public keys are always 64 characters
