### PR TITLE
Prevent Signature swapping within our APIs

### DIFF
--- a/src/Crypto/Signature/SchnorrSigner.php
+++ b/src/Crypto/Signature/SchnorrSigner.php
@@ -6,6 +6,7 @@ namespace Mdanter\Ecc\Crypto\Signature;
 use Exception;
 use GMP;
 use InvalidArgumentException;
+use Mdanter\Ecc\Exception\IncorrectAlgorithmException;
 use Mdanter\Ecc\Util\BinaryString;
 use Mdanter\Ecc\Crypto\Key\{
     PrivateKeyInterface,
@@ -49,7 +50,7 @@ class SchnorrSigner
         // Deconstruct as a Signature object:
         $r = gmp_init(BinaryString::substring($results['signature'], 0, $l), 16);
         $s = gmp_init(BinaryString::substring($results['signature'], $l), 16);
-        return new Signature($r, $s);
+        return new Signature($r, $s, Signature::TYPE_SCHNORR);
     }
 
     /**
@@ -63,6 +64,9 @@ class SchnorrSigner
         Signature $signature,
         string $message
     ): bool {
+        if (!(hash_equals(Signature::TYPE_SCHNORR, $signature->getSignatureType()))) {
+            throw new IncorrectAlgorithmException('This is not a Schnorr signature');
+        }
         $ptX = gmp_strval($key->getPoint()->getX(), 16);
         $x = str_pad($ptX, 64, '0', STR_PAD_LEFT);
         $serialized = $this->formatSignature($key, $signature);

--- a/src/Crypto/Signature/Signature.php
+++ b/src/Crypto/Signature/Signature.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Mdanter\Ecc\Crypto\Signature;
 
+use GMP;
+
 /**
  * *********************************************************************
  * Copyright (C) 2012 Matyas Danter
@@ -32,34 +34,45 @@ namespace Mdanter\Ecc\Crypto\Signature;
  */
 class Signature implements SignatureInterface
 {
+    const TYPE_ECDSA = 'ecdsa';
+
+    const TYPE_SCHNORR = 'schnorr';
+
     /**
-     * @var \GMP
+     * @var GMP
      */
     private $r;
 
     /**
      *
-     * @var \GMP
+     * @var GMP
      */
     private $s;
 
     /**
+     * @var string $sigType
+     */
+    private $sigType;
+
+    /**
      * Initialize a new instance with values
      *
-     * @param \GMP $r
-     * @param \GMP $s
+     * @param GMP $r
+     * @param GMP $s
+     * @param string $signatureType "ecdsa" or "schnorr"
      */
-    public function __construct(\GMP $r, \GMP $s)
+    public function __construct(GMP $r, GMP $s, string $signatureType = self::TYPE_ECDSA)
     {
         $this->r = $r;
         $this->s = $s;
+        $this->sigType = $signatureType;
     }
 
     /**
      * {@inheritDoc}
      * @see SignatureInterface::getR
      */
-    public function getR(): \GMP
+    public function getR(): GMP
     {
         return $this->r;
     }
@@ -68,8 +81,16 @@ class Signature implements SignatureInterface
      * {@inheritDoc}
      * @see SignatureInterface::getS
      */
-    public function getS(): \GMP
+    public function getS(): GMP
     {
         return $this->s;
+    }
+
+    /**
+     * @return string
+     */
+    public function getSignatureType(): string
+    {
+        return $this->sigType;
     }
 }

--- a/src/Crypto/Signature/SignatureInterface.php
+++ b/src/Crypto/Signature/SignatureInterface.php
@@ -45,4 +45,11 @@ interface SignatureInterface
      * @return \GMP
      */
     public function getS(): \GMP;
+
+    /**
+     * Returns "ecdsa" or "schnorr" depending on the signature type.
+     *
+     * @return string
+     */
+    public function getSignatureType(): string;
 }

--- a/src/Crypto/Signature/Signer.php
+++ b/src/Crypto/Signature/Signer.php
@@ -10,6 +10,7 @@ use GMP;
 use Mdanter\Ecc\Curves\NamedCurveFp;
 use Mdanter\Ecc\Curves\NistCurve;
 use Mdanter\Ecc\Curves\SecgCurve;
+use Mdanter\Ecc\Exception\IncorrectAlgorithmException;
 use Mdanter\Ecc\Math\ConstantTimeMath;
 use Mdanter\Ecc\Math\GmpMathInterface;
 use Mdanter\Ecc\Crypto\Key\PrivateKeyInterface;
@@ -210,6 +211,11 @@ class Signer
         $n = $generator->getOrder();
         $r = $signature->getR();
         $s = $signature->getS();
+
+        // Make sure this isn't a Schnorr signature:
+        if (!(hash_equals(Signature::TYPE_ECDSA, $signature->getSignatureType()))) {
+            throw new IncorrectAlgorithmException('This is not an ECDSA signature');
+        }
 
         $math = $this->adapter;
         /** @var GMP $one */

--- a/src/Exception/IncorrectAlgorithmException.php
+++ b/src/Exception/IncorrectAlgorithmException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Mdanter\Ecc\Exception;
+
+class IncorrectAlgorithmException extends \RuntimeException
+{
+
+}

--- a/tests/unit/Crypto/Signature/SignatureTest.php
+++ b/tests/unit/Crypto/Signature/SignatureTest.php
@@ -15,5 +15,6 @@ class SignatureTest extends AbstractTestCase
         $signature = new Signature($r, $s);
         $this->assertSame($r, $signature->getR());
         $this->assertSame($s, $signature->getS());
+        $this->assertSame(Signature::TYPE_ECDSA, $signature->getSignatureType());
     }
 }


### PR DESCRIPTION
Since the updated Schnorr API makes use of the same Signature class as ECDSA, we need to make sure signature swapping at our API layer is caught and rejected.

This isn't a cryptographic mitigation. It is not meant to guard against algorithm confusion attacks.

This is only intended to prevent a trivial kind of developer mistake.